### PR TITLE
feat(release): 1.5.1 device-id driver detection + install-progress persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to DLSSync are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.1] - 2026-05-28
+
+A driver-detection accuracy release. GPU driver resolution is now keyed on the PCI device id for every
+vendor, so laptops with integrated Intel graphics alongside a discrete card get the correct driver instead
+of the Arc desktop package, and install progress no longer breaks when you switch tabs.
+
+### Fixed
+
+- Intel driver detection resolves the exact driver for the installed GPU by matching its PCI device id against the catalog's per-package hardware-id list, instead of always serving the Arc desktop driver. Integrated Intel graphics — including 6th–10th-gen parts on the 31.x branch and 11th–14th-gen parts on their own branch — no longer trigger the installer's "exit code 8" (no compatible device) and no longer open the generic Arc page when you click Release notes.
+- Driver download and install progress survives switching tabs. The state moved to a shared, app-level store, so leaving the Drivers tab mid-download no longer cancels the progress or corrupts the animation.
+- On systems with more than one GPU — an integrated plus a discrete card, or two cards from the same vendor — each adapter's installed driver version is matched by PCI hardware id rather than by name, so versions are no longer assigned to the wrong card. Duplicate adapter enumerations are collapsed.
+
+### Added
+
+- Device-id-driven resolution for all three families: Intel matches the catalog hardware-id list, AMD maps the device id to its driver branch (RDNA3+, RDNA1/2, Polaris/Vega) before falling back to the model name, and NVIDIA notebook ("Laptop GPU") and desktop products resolve to distinct drivers.
+- A clearer Drivers tab: an "Open download page" action for AMD, a "Find my driver" link when a GPU's driver cannot be resolved, an `aria-live` install-progress region, and visible keyboard focus rings.
+
+### Changed
+
+- AMD opens its official download page instead of a constructed installer URL. The direct `.exe` is gated behind a license prompt and its filename changes per release, so a fabricated link was unreliable; version and changelog detection are unchanged.
+- Vendor installer exit codes are reported with a readable message. Intel's "no compatible device" (exit code 8) now explains the GPU may be OEM-locked or need a different driver branch, pointing to the manufacturer or Windows Update.
+
+[1.5.1]: https://github.com/xt0n1-t3ch/DLSSync/releases/tag/v1.5.1
+
 ## [1.5.0] - 2026-05-27
 
 The public release of the GPU driver updater, the NVIDIA DLSS overrides and the anti-cheat work

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "anticheat-detect"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "jwalk",
  "memchr",
@@ -352,7 +352,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "backup-store"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "chrono",
  "rusqlite",
@@ -1094,7 +1094,7 @@ dependencies = [
 
 [[package]]
 name = "dll-catalog"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "bytes",
  "chrono",
@@ -1117,7 +1117,7 @@ dependencies = [
 
 [[package]]
 name = "dll-scanner"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "jwalk",
  "once_cell",
@@ -1154,7 +1154,7 @@ dependencies = [
 
 [[package]]
 name = "dlssync"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "anticheat-detect",
  "anyhow",
@@ -1235,7 +1235,7 @@ dependencies = [
 
 [[package]]
 name = "driver-catalog"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1251,7 +1251,7 @@ dependencies = [
 
 [[package]]
 name = "driver-install"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "dll-catalog",
  "futures-util",
@@ -2557,7 +2557,7 @@ dependencies = [
 
 [[package]]
 name = "launcher-scan"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -2694,7 +2694,7 @@ dependencies = [
 
 [[package]]
 name = "manifest-builder"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2879,7 +2879,7 @@ dependencies = [
 
 [[package]]
 name = "notifications-store"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "chrono",
  "rusqlite",
@@ -2971,7 +2971,7 @@ dependencies = [
 
 [[package]]
 name = "nvapi-drs"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "serde",
  "windows-sys 0.59.0",
@@ -3334,7 +3334,7 @@ checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "pe-version"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "pelite",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["src-tauri", "crates/*"]
 
 [workspace.package]
-version = "1.5.0"
+version = "1.5.1"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/xt0n1-t3ch/DLSSync"

--- a/contracts/driver-release.schema.json
+++ b/contracts/driver-release.schema.json
@@ -32,7 +32,10 @@
     "channel": { "enum": ["stable", "beta"] },
     "is_beta": { "type": "boolean" },
     "display_version": { "type": ["string", "null"] },
-    "download_url": { "type": "string", "minLength": 1 },
+    "download_url": {
+      "type": "string",
+      "description": "Direct installer URL when the vendor exposes one (NVIDIA, Intel). Empty for vendors with no safe direct link (AMD: EULA-gated, unstable filename) — the UI then routes to release_notes_url as an 'Open download page' action."
+    },
     "size_bytes": { "type": "integer", "minimum": 0 },
     "signature_subject": { "type": "string" },
     "released_at": { "type": ["string", "null"] },

--- a/crates/driver-catalog/Cargo.toml
+++ b/crates/driver-catalog/Cargo.toml
@@ -17,3 +17,4 @@ roxmltree.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+reqwest.workspace = true

--- a/crates/driver-catalog/src/consts.rs
+++ b/crates/driver-catalog/src/consts.rs
@@ -22,14 +22,12 @@ pub mod intel {
     pub const PUBLISHER_SUBJECT: &str = "Intel Corporation";
     pub const SOFTWARE_CONFIGURATIONS_FILE: &str = "software-configurations.json";
     pub const SELECTABLE_GRAPHICS_FILE: &str = "selectable-graphics.json";
-    pub const CLIENT_GRAPHICS_GROUP_ID: &str = "785597";
-    pub const GRAPHICS_VERSION_PREFIX: &str = "32.0.101.";
+    pub const PCI_VENDOR_ID: u16 = super::pci::INTEL;
 }
 
 pub mod amd {
     pub const VERSION_TABLE_URL: &str = "https://gpuopen.com/version-table/";
     pub const VERSION_TABLE_XML: &str =
         "https://raw.githubusercontent.com/GPUOpen-Drivers/amd-vulkan-versions/master/amdversions.xml";
-    pub const DRIVER_DOWNLOAD_PREFIX: &str = "https://drivers.amd.com/drivers/";
     pub const PUBLISHER_SUBJECT: &str = "Advanced Micro Devices, Inc.";
 }

--- a/crates/driver-catalog/src/sources/amd.rs
+++ b/crates/driver-catalog/src/sources/amd.rs
@@ -8,15 +8,6 @@ use async_trait::async_trait;
 
 pub struct AmdGpuSource;
 
-pub fn adrenalin_download_url(version: &str, os_suffix: &str) -> String {
-    format!(
-        "{prefix}whql-amd-software-adrenalin-edition-{version}-{os}-c.exe",
-        prefix = c::DRIVER_DOWNLOAD_PREFIX,
-        version = version,
-        os = os_suffix,
-    )
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AmdArch {
     Mainstream,
@@ -24,9 +15,45 @@ pub enum AmdArch {
     PolarisVega,
 }
 
+/// Known PCI device ids on the RDNA1/RDNA2 legacy driver branch (Navi 10/12/14
+/// = RX 5000, Navi 21/22/23/24 = RX 6000). Used to pick the right branch even
+/// when an OEM renames the card so the model string is unreliable.
+const RDNA12_DEVICE_IDS: &[u16] = &[
+    0x7310, 0x7312, 0x7318, 0x7319, 0x731A, 0x731B, 0x731E, 0x731F, 0x7340, 0x7341, 0x7347, 0x734F,
+    0x7360, 0x7362, 0x73A0, 0x73A1, 0x73A2, 0x73A3, 0x73A5, 0x73AB, 0x73AE, 0x73AF, 0x73BF, 0x73D0,
+    0x73DF, 0x73E0, 0x73E1, 0x73E3, 0x73E8, 0x73E9, 0x73EF, 0x73FF, 0x7420, 0x7421, 0x7422, 0x7423,
+    0x743F,
+];
+
+/// Known PCI device ids on the Polaris/Vega legacy driver branch (Polaris 10/11/
+/// 12/20/21/22 = RX 400/500, Vega 10/12/20 = Vega 56/64, Radeon VII).
+const POLARIS_VEGA_DEVICE_IDS: &[u16] = &[
+    0x67C0, 0x67C2, 0x67C4, 0x67C7, 0x67CA, 0x67CC, 0x67CF, 0x67D0, 0x67D4, 0x67D7, 0x67DF, 0x6FDF,
+    0x67E0, 0x67E1, 0x67E3, 0x67E8, 0x67EB, 0x67EF, 0x67FF, 0x6980, 0x6981, 0x6985, 0x6986, 0x6987,
+    0x698F, 0x699F, 0x6860, 0x6861, 0x6862, 0x6863, 0x6864, 0x6867, 0x6868, 0x686C, 0x687F, 0x69A0,
+    0x69A1, 0x69A2, 0x69A3, 0x69AF, 0x66A0, 0x66A1, 0x66A2, 0x66A3, 0x66A7, 0x66AF,
+];
+
+/// Classify by PCI device id — the authoritative key. Returns `None` for ids not
+/// on a legacy branch (RDNA3+ / APUs / unknown) so the caller falls back to the
+/// model-name classifier (which defaults such cards to the mainstream branch).
+pub fn amd_arch_from_device_id(device_id: u16) -> Option<AmdArch> {
+    if device_id == 0 {
+        return None;
+    }
+    if RDNA12_DEVICE_IDS.contains(&device_id) {
+        return Some(AmdArch::Rdna12);
+    }
+    if POLARIS_VEGA_DEVICE_IDS.contains(&device_id) {
+        return Some(AmdArch::PolarisVega);
+    }
+    None
+}
+
 /// Classify an AMD GPU model into the driver branch AMD publishes for it.
 /// RDNA3+ (RX 7000/9000) take the mainstream branch; RX 5000/6000 take the
-/// RDNA1/2 legacy branch; Polaris/Vega take their own.
+/// RDNA1/2 legacy branch; Polaris/Vega take their own. Used as a fallback when
+/// the PCI device id is unknown.
 pub fn amd_arch(model: &str) -> AmdArch {
     let m = model.to_lowercase();
     let has = |needles: &[&str]| needles.iter().any(|n| m.contains(n));
@@ -41,6 +68,12 @@ pub fn amd_arch(model: &str) -> AmdArch {
         return AmdArch::PolarisVega;
     }
     AmdArch::Mainstream
+}
+
+/// Resolve the driver branch for a device: PCI device id first, model name as a
+/// fallback. This is the single place the two classifiers are combined.
+fn arch_for(device: &DeviceId) -> AmdArch {
+    amd_arch_from_device_id(device.pci_device_id).unwrap_or_else(|| amd_arch(&device.model))
 }
 
 fn version_branch(version_attr: &str) -> AmdArch {
@@ -159,7 +192,7 @@ impl DriverSource for AmdGpuSource {
         _os: &OsTarget,
     ) -> Result<Option<DriverRelease>, DriverError> {
         let xml = fetch_version_table(client).await?;
-        parse_version_table(&xml, amd_arch(&device.model))
+        parse_version_table(&xml, arch_for(device))
     }
 
     async fn history(
@@ -170,7 +203,7 @@ impl DriverSource for AmdGpuSource {
         limit: usize,
     ) -> Result<Vec<DriverRelease>, DriverError> {
         let xml = fetch_version_table(client).await?;
-        let mut releases = parse_version_table_history(&xml, amd_arch(&device.model))?;
+        let mut releases = parse_version_table_history(&xml, arch_for(device))?;
         releases.truncate(limit);
         Ok(releases)
     }
@@ -190,11 +223,44 @@ async fn fetch_version_table(client: &reqwest::Client) -> Result<String, DriverE
 mod tests {
     use super::*;
 
+    fn amd_device(device_id: u16, model: &str) -> DeviceId {
+        DeviceId {
+            class: DeviceClass::Gpu,
+            vendor: DriverVendor::Amd,
+            pci_vendor_id: 0x1002,
+            pci_device_id: device_id,
+            model: model.into(),
+        }
+    }
+
     #[test]
-    fn adrenalin_download_url_matches_known_pattern() {
+    fn amd_arch_from_device_id_classifies_legacy_branches() {
+        assert_eq!(amd_arch_from_device_id(0x73BF), Some(AmdArch::Rdna12));
+        assert_eq!(amd_arch_from_device_id(0x731F), Some(AmdArch::Rdna12));
+        assert_eq!(amd_arch_from_device_id(0x67DF), Some(AmdArch::PolarisVega));
+        assert_eq!(amd_arch_from_device_id(0x687F), Some(AmdArch::PolarisVega));
+        assert_eq!(amd_arch_from_device_id(0x66AF), Some(AmdArch::PolarisVega));
+    }
+
+    #[test]
+    fn amd_arch_from_device_id_returns_none_for_rdna3_plus_and_zero() {
+        assert_eq!(amd_arch_from_device_id(0x744C), None);
+        assert_eq!(amd_arch_from_device_id(0), None);
+    }
+
+    #[test]
+    fn arch_for_prefers_device_id_over_name_then_falls_back() {
         assert_eq!(
-            adrenalin_download_url("26.5.1", "win11"),
-            "https://drivers.amd.com/drivers/whql-amd-software-adrenalin-edition-26.5.1-win11-c.exe"
+            arch_for(&amd_device(0x67DF, "AMD Radeon Graphics")),
+            AmdArch::PolarisVega
+        );
+        assert_eq!(
+            arch_for(&amd_device(0, "AMD Radeon RX 6800 XT")),
+            AmdArch::Rdna12
+        );
+        assert_eq!(
+            arch_for(&amd_device(0x744C, "AMD Radeon RX 7900 XTX")),
+            AmdArch::Mainstream
         );
     }
 

--- a/crates/driver-catalog/src/sources/intel.rs
+++ b/crates/driver-catalog/src/sources/intel.rs
@@ -13,46 +13,47 @@ fn version_token(version: &str) -> &str {
     version.split_whitespace().next().unwrap_or_default()
 }
 
-fn group_id_str(entry: &serde_json::Value) -> Option<String> {
-    let gid = &entry["GroupId"];
-    gid.as_str()
-        .map(str::to_string)
-        .or_else(|| gid.as_u64().map(|n| n.to_string()))
-}
-
-fn group_matches(entry: &serde_json::Value, target: &str) -> bool {
-    group_id_str(entry).as_deref() == Some(target)
-}
-
-fn group_is_client(entry: &serde_json::Value) -> bool {
-    group_matches(entry, c::CLIENT_GRAPHICS_GROUP_ID)
-}
-
-/// Intel publishes a sibling "Historical" group next to each current driver
-/// group; including those entries gives the user a known-compatible older
-/// driver without scraping intel.com (which is Akamai-protected from server
-/// requests).
-const HISTORICAL_GROUP_IDS: &[&str] = &["857252", "857390"];
-
-fn group_is_history_capable(entry: &serde_json::Value) -> bool {
-    if group_is_client(entry) {
-        return true;
-    }
-    let Some(gid) = group_id_str(entry) else {
-        return false;
-    };
-    HISTORICAL_GROUP_IDS.iter().any(|h| gid == *h)
-}
-
 fn parse_iso_date(raw: &str) -> Option<chrono::DateTime<chrono::Utc>> {
     chrono::DateTime::parse_from_rfc3339(raw.trim())
         .ok()
         .map(|d| d.with_timezone(&chrono::Utc))
 }
 
+/// `VEN_8086&DEV_XXXX` exactly as Intel writes it in `Components[].DetectionValues`.
+fn intel_hardware_id(device_id: u16) -> String {
+    format!("VEN_{:04X}&DEV_{device_id:04X}", c::PCI_VENDOR_ID)
+}
+
+/// True when the configuration ships a graphics-class component. The DSA catalog
+/// mixes Wi-Fi, Bluetooth, BIOS, LAN and NPU entries in with the GPU drivers, so
+/// every other category must be ignored.
+fn entry_is_graphics(entry: &serde_json::Value) -> bool {
+    entry["Components"]
+        .as_array()
+        .is_some_and(|comps| comps.iter().any(|comp| comp["Category"] == "Graphics"))
+}
+
+/// True when any component's `DetectionValues` lists this exact PCI device id.
+/// Intel keys each driver package to the hardware ids it actually supports — the
+/// only correct way to tell an integrated UHD/Iris Xe driver apart from the Arc
+/// package and never serve a mismatched installer (exit code 8).
+fn entry_supports_device(entry: &serde_json::Value, device_id: u16) -> bool {
+    let needle = intel_hardware_id(device_id);
+    entry["Components"].as_array().is_some_and(|comps| {
+        comps.iter().any(|comp| {
+            comp["DetectionValues"].as_array().is_some_and(|vals| {
+                vals.iter().any(|v| {
+                    v.as_str()
+                        .is_some_and(|s| s.to_ascii_uppercase().starts_with(&needle))
+                })
+            })
+        })
+    })
+}
+
 fn entry_to_release(entry: &serde_json::Value) -> Option<DriverRelease> {
     let token = version_token(entry["Version"].as_str().unwrap_or_default());
-    if !token.starts_with(c::GRAPHICS_VERSION_PREFIX) {
+    if !token.chars().next().is_some_and(|ch| ch.is_ascii_digit()) {
         return None;
     }
     let date = parse_iso_date(entry["DisplayReleaseDate"].as_str().unwrap_or_default())?;
@@ -87,39 +88,18 @@ fn entry_to_release(entry: &serde_json::Value) -> Option<DriverRelease> {
     })
 }
 
-/// Pure parser over the `software-configurations.json` array extracted from the
-/// Intel DSA catalog. Picks the newest WHQL/optional client graphics driver.
-pub fn parse_software_configurations(json: &str) -> Result<Option<DriverRelease>, DriverError> {
-    let root: serde_json::Value =
-        serde_json::from_str(json).map_err(|e| DriverError::Parse(e.to_string()))?;
-    let entries = root
-        .as_array()
-        .ok_or_else(|| DriverError::Parse("software-configurations: expected array".into()))?;
-    let mut best: Option<DriverRelease> = None;
-    for entry in entries {
-        if !group_is_client(entry) {
-            continue;
-        }
-        let Some(release) = entry_to_release(entry) else {
-            continue;
-        };
-        if best
-            .as_ref()
-            .is_none_or(|b| release.released_at > b.released_at)
-        {
-            best = Some(release);
-        }
-    }
-    Ok(best)
-}
-
-/// Pure parser returning the current client driver plus every entry from the
-/// sibling "Historical Intel Arc/Pro Graphics" groups (Intel only ships the
-/// previous recommended driver in DSA — that yields 1-2 entries per device,
-/// limited but honest data with no fragile HTML scraping).
-pub fn parse_software_configurations_history(
+/// Every graphics driver in the catalog that lists this device id, newest-first,
+/// deduped by version. Spans the device's current group plus any sibling
+/// "Historical" group that still lists it. The first element is the recommended
+/// `latest`. An unknown/zero device id resolves to nothing rather than guessing.
+pub fn resolve_history(
     json: &str,
+    device_id: u16,
+    limit: usize,
 ) -> Result<Vec<DriverRelease>, DriverError> {
+    if device_id == 0 {
+        return Ok(Vec::new());
+    }
     let root: serde_json::Value =
         serde_json::from_str(json).map_err(|e| DriverError::Parse(e.to_string()))?;
     let entries = root
@@ -127,13 +107,23 @@ pub fn parse_software_configurations_history(
         .ok_or_else(|| DriverError::Parse("software-configurations: expected array".into()))?;
     let mut releases: Vec<DriverRelease> = entries
         .iter()
-        .filter(|e| group_is_history_capable(e))
+        .filter(|e| entry_is_graphics(e) && entry_supports_device(e, device_id))
         .filter_map(entry_to_release)
         .collect();
     releases.sort_by_key(|r| std::cmp::Reverse(r.released_at));
     let mut seen = std::collections::BTreeSet::new();
     releases.retain(|r| seen.insert(r.version.display.clone()));
+    releases.truncate(limit);
     Ok(releases)
+}
+
+/// The newest graphics driver that actually supports this exact device — the
+/// correct integrated / Arc / legacy package, carrying its real download URL and
+/// its own release-notes page (not the generic Arc landing page).
+pub fn resolve_release(json: &str, device_id: u16) -> Result<Option<DriverRelease>, DriverError> {
+    Ok(resolve_history(json, device_id, usize::MAX)?
+        .into_iter()
+        .next())
 }
 
 fn extract_configurations(zip_bytes: &[u8]) -> Result<String, DriverError> {
@@ -162,24 +152,22 @@ impl DriverSource for IntelGpuSource {
     async fn latest(
         &self,
         client: &reqwest::Client,
-        _device: &DeviceId,
+        device: &DeviceId,
         _os: &OsTarget,
     ) -> Result<Option<DriverRelease>, DriverError> {
         let json = fetch_configurations_json(client).await?;
-        parse_software_configurations(&json)
+        resolve_release(&json, device.pci_device_id)
     }
 
     async fn history(
         &self,
         client: &reqwest::Client,
-        _device: &DeviceId,
+        device: &DeviceId,
         _os: &OsTarget,
         limit: usize,
     ) -> Result<Vec<DriverRelease>, DriverError> {
         let json = fetch_configurations_json(client).await?;
-        let mut releases = parse_software_configurations_history(&json)?;
-        releases.truncate(limit);
-        Ok(releases)
+        resolve_history(&json, device.pci_device_id, limit)
     }
 }
 
@@ -198,118 +186,122 @@ async fn fetch_configurations_json(client: &reqwest::Client) -> Result<String, D
 mod tests {
     use super::*;
 
-    fn device(vendor: DriverVendor, class: DeviceClass) -> DeviceId {
+    fn device(device_id: u16) -> DeviceId {
         DeviceId {
-            class,
-            vendor,
-            pci_vendor_id: 0,
-            pci_device_id: 0,
-            model: "intel arc b580".into(),
+            class: DeviceClass::Gpu,
+            vendor: DriverVendor::Intel,
+            pci_vendor_id: 0x8086,
+            pci_device_id: device_id,
+            model: "intel graphics".into(),
         }
     }
 
     #[test]
     fn supports_only_intel_gpus() {
         let source = IntelGpuSource;
-        assert!(source.supports(&device(DriverVendor::Intel, DeviceClass::Gpu)));
-        assert!(!source.supports(&device(DriverVendor::Nvidia, DeviceClass::Gpu)));
+        assert!(source.supports(&device(0xE20B)));
+        let mut nvidia = device(0x2705);
+        nvidia.vendor = DriverVendor::Nvidia;
+        assert!(!source.supports(&nvidia));
+    }
+
+    #[test]
+    fn intel_hardware_id_is_uppercase_padded() {
+        assert_eq!(intel_hardware_id(0xE20B), "VEN_8086&DEV_E20B");
+        assert_eq!(intel_hardware_id(0x9A49), "VEN_8086&DEV_9A49");
+        assert_eq!(intel_hardware_id(0x0B), "VEN_8086&DEV_000B");
     }
 
     const FIXTURE: &str = r#"[
-        {"Version":"15.22.58.2993","DisplayReleaseDate":"2013-02-19T00:00:00Z","Name":"Old GMA","GroupId":"111","Url":"https://intel/old","Files":[{"Url":"https://dl/old.exe","Size":1}]},
-        {"Version":"32.0.101.8517 - Q1.26.R2","DisplayReleaseDate":"2026-04-24T00:00:00Z","Name":"Intel Arc Pro Graphics","GroupId":"741626","Url":"https://intel/pro","Files":[{"Url":"https://dl/pro.exe","Size":2}]},
-        {"Version":"32.0.101.7085","DisplayReleaseDate":"2026-03-18T00:00:00Z","Name":"Intel Arc Graphics","GroupId":785597,"IsBeta":false,"Url":"https://intel/old-client","Files":[{"Url":"https://dl/7085.exe","Size":700}]},
-        {"Version":"32.0.101.8801 WHQL Certified","DisplayReleaseDate":"2026-05-15T00:00:00Z","Name":"Intel Arc Graphics - Windows","GroupId":"785597","IsBeta":false,"Url":"https://www.intel.com/.../785597/.../graphics.html","Files":[{"Url":"https://downloadmirror.intel.com/919751/gfx_win_101.8801.exe","Hash":"81093879","Size":823031088,"OperatingSystems":["windows-11-24h2-64"]}]}
+        {"Id":919751,"GroupId":"785597","Version":"32.0.101.8801 WHQL Certified","DisplayReleaseDate":"2026-05-15T00:00:00Z","Name":"Intel Arc Graphics - Windows","IsBeta":false,"Url":"https://www.intel.com/.../785597/919751/intel-arc-graphics-windows.html","Files":[{"Url":"https://downloadmirror.intel.com/919751/gfx_win_101.8801.exe","Size":823031088}],"Components":[{"Category":"Graphics","DetectionValues":["VEN_8086&DEV_E20B","VEN_8086&DEV_56A0","VEN_8086&DEV_7D55&SUBSYS_00000000"]}]},
+        {"Id":919765,"GroupId":"857252","Version":"32.0.101.8626 WHQL Certified","DisplayReleaseDate":"2026-03-17T00:00:00Z","Name":"Historical Intel Arc Graphics Drivers","Url":null,"Files":[{"Url":"https://downloadmirror.intel.com/x/gfx_win_101.8626.exe","Size":1064962136}],"Components":[{"Category":"Graphics","DetectionValues":["VEN_8086&DEV_E20B","VEN_8086&DEV_56A0"]}]},
+        {"Id":915569,"GroupId":"864990","Version":"32.0.101.7085","DisplayReleaseDate":"2026-03-18T00:00:00Z","Name":"Intel 11th-14th Gen Processor Graphics - Windows","Url":"https://www.intel.com/.../864990/intel-11th-14th-gen-processor-graphics-windows.html","Files":[{"Url":"https://downloadmirror.intel.com/y/gfx_win_101.7085.exe","Size":500000000}],"Components":[{"Category":"Graphics","DetectionValues":["VEN_8086&DEV_9A49","VEN_8086&DEV_46A6"]}]},
+        {"Id":916846,"GroupId":"776137","Version":"31.0.101.2141","DisplayReleaseDate":"2026-04-06T00:00:00Z","Name":"Intel 7th-10th Gen Processor Graphics - Windows","Url":"https://www.intel.com/.../776137/intel-7th-10th-gen-processor-graphics-windows.html","Files":[{"Url":"https://downloadmirror.intel.com/z/win64_2141.exe","Size":400000000}],"Components":[{"Category":"Graphics","DetectionValues":["VEN_8086&DEV_9BC4","VEN_8086&DEV_3E92"]}]},
+        {"Id":764512,"GroupId":"762755","Version":"31.0.101.2115","DisplayReleaseDate":"2022-12-29T00:00:00Z","Name":"Intel 6th Gen Processor Graphics - Windows","Url":"https://www.intel.com/.../762755/intel-6th-gen-processor-graphics-windows.html","Files":[{"Url":"https://downloadmirror.intel.com/w/win64_2115.exe","Size":300000000}],"Components":[{"Category":"Graphics","DetectionValues":["VEN_8086&DEV_1912","VEN_8086&DEV_9BC4"]}]},
+        {"Id":30195,"GroupId":"18799","Version":"15.45.34.5174","DisplayReleaseDate":"2021-02-05T00:00:00Z","Name":"Intel Graphics Driver 15.45","Url":"https://www.intel.com/.../18799/intel-graphics-driver-for-windows-15-45.html","Files":[{"Url":"https://downloadmirror.intel.com/v/win64_15.45.exe","Size":200000000}],"Components":[{"Category":"Graphics","DetectionValues":["VEN_8086&DEV_1912"]}]},
+        {"Id":918237,"GroupId":"19351","Version":"24.40.0","DisplayReleaseDate":"2026-04-28T00:00:00Z","Name":"Intel Wireless Wi-Fi Drivers","Url":"https://www.intel.com/.../19351/wifi.html","Files":[{"Url":"https://downloadmirror.intel.com/u/wifi.exe","Size":100}],"Components":[{"Category":"Wireless","DetectionValues":["VEN_8086&DEV_ABCD","VEN_8086&DEV_E20B"]}]}
     ]"#;
 
     #[test]
-    fn parses_newest_client_graphics_driver_only() {
-        let release = parse_software_configurations(FIXTURE)
-            .unwrap()
-            .expect("release");
-        assert_eq!(release.vendor, DriverVendor::Intel);
-        assert_eq!(release.version.display, "32.0.101.8801");
+    fn arc_b_series_resolves_to_current_arc_client_driver() {
+        let r = resolve_release(FIXTURE, 0xE20B).unwrap().expect("release");
+        assert_eq!(r.version.display, "32.0.101.8801");
         assert_eq!(
-            release.download_url,
+            r.download_url,
             "https://downloadmirror.intel.com/919751/gfx_win_101.8801.exe"
         );
-        assert_eq!(release.size_bytes, 823031088);
-        assert_eq!(release.signature_subject, "Intel Corporation");
-        assert!(release
-            .release_notes_url
-            .as_deref()
-            .unwrap()
-            .contains("intel.com"));
-        assert!(release.released_at.is_some());
+        assert!(r.release_notes_url.as_deref().unwrap().contains("785597"));
+        assert_eq!(r.signature_subject, "Intel Corporation");
     }
 
     #[test]
-    fn ignores_pro_and_legacy_and_returns_none_when_no_client() {
-        let only_pro = r#"[{"Version":"32.0.101.8517","DisplayReleaseDate":"2026-04-24T00:00:00Z","GroupId":"741626","Files":[{"Url":"pro.exe","Size":2}]}]"#;
-        assert!(parse_software_configurations(only_pro).unwrap().is_none());
+    fn arc_a_series_resolves_to_arc_client_driver() {
+        let r = resolve_release(FIXTURE, 0x56A0).unwrap().expect("release");
+        assert_eq!(r.version.display, "32.0.101.8801");
     }
 
     #[test]
-    fn empty_array_and_malformed_json_handled() {
-        assert!(parse_software_configurations("[]").unwrap().is_none());
-        assert!(parse_software_configurations("not json").is_err());
+    fn tiger_lake_integrated_resolves_to_its_own_32x_group_not_arc() {
+        let r = resolve_release(FIXTURE, 0x9A49).unwrap().expect("release");
+        assert_eq!(r.version.display, "32.0.101.7085");
+        assert!(r.release_notes_url.as_deref().unwrap().contains("864990"));
+        assert!(r.download_url.contains("7085"));
     }
 
-    const HISTORY_FIXTURE: &str = r#"[
-        {"Version":"15.22.58.2993","DisplayReleaseDate":"2013-02-19T00:00:00Z","GroupId":"111","Files":[{"Url":"https://dl/old.exe","Size":1}]},
-        {"Version":"32.0.101.8801 WHQL Certified","DisplayReleaseDate":"2026-05-15T00:00:00Z","Name":"Intel Arc Graphics","GroupId":"785597","Url":"https://intel/785597","Files":[{"Url":"https://dl/8801.exe","Size":823031088}]},
-        {"Version":"32.0.101.8626 WHQL Certified","DisplayReleaseDate":"2026-03-17T00:00:00Z","Name":"Historical Intel Arc Graphics","GroupId":"857252","Url":null,"Files":[{"Url":"https://dl/8626.exe","Size":1064962136}]},
-        {"Version":"32.0.101.6637 - Q1.25","DisplayReleaseDate":"2025-03-27T00:00:00Z","Name":"Historical Intel Arc Pro Graphics","GroupId":"857390","Url":null,"Files":[{"Url":"https://dl/6637.exe","Size":658757216}]},
-        {"Version":"32.0.101.7085","DisplayReleaseDate":"2026-03-18T00:00:00Z","Name":"Intel 11-14th Gen integrated","GroupId":"864990","Files":[{"Url":"https://dl/7085.exe","Size":700}]},
-        {"Version":"32.0.101.8801 WHQL Certified","DisplayReleaseDate":"2026-05-15T00:00:00Z","GroupId":"785597","Files":[{"Url":"https://dl/dup.exe","Size":1}]}
-    ]"#;
+    #[test]
+    fn comet_lake_integrated_resolves_to_newest_legacy_31x_branch() {
+        let r = resolve_release(FIXTURE, 0x9BC4).unwrap().expect("release");
+        assert_eq!(r.version.display, "31.0.101.2141");
+        assert!(r.release_notes_url.as_deref().unwrap().contains("776137"));
+    }
 
     #[test]
-    fn history_collects_current_plus_sibling_historical_groups_newest_first() {
-        let releases = parse_software_configurations_history(HISTORY_FIXTURE).unwrap();
+    fn skylake_integrated_picks_newest_of_31x_over_legacy_15x() {
+        let r = resolve_release(FIXTURE, 0x1912).unwrap().expect("release");
+        assert_eq!(r.version.display, "31.0.101.2115");
+    }
+
+    #[test]
+    fn unknown_and_zero_device_ids_resolve_to_nothing() {
+        assert!(resolve_release(FIXTURE, 0xFFFF).unwrap().is_none());
+        assert!(resolve_release(FIXTURE, 0).unwrap().is_none());
+    }
+
+    #[test]
+    fn wifi_only_device_id_is_ignored_by_the_graphics_filter() {
+        assert!(resolve_release(FIXTURE, 0xABCD).unwrap().is_none());
+    }
+
+    #[test]
+    fn history_spans_current_plus_sibling_historical_group_newest_first() {
+        let releases = resolve_history(FIXTURE, 0xE20B, 50).unwrap();
         let versions: Vec<_> = releases
             .iter()
             .map(|r| r.version.display.as_str())
             .collect();
-        assert_eq!(
-            versions,
-            vec!["32.0.101.8801", "32.0.101.8626", "32.0.101.6637"]
-        );
+        assert_eq!(versions, vec!["32.0.101.8801", "32.0.101.8626"]);
     }
 
     #[test]
-    fn history_dedupes_repeated_versions_keeping_first_occurrence() {
-        let releases = parse_software_configurations_history(HISTORY_FIXTURE).unwrap();
-        assert_eq!(
-            releases
-                .iter()
-                .filter(|r| r.version.display == "32.0.101.8801")
-                .count(),
-            1
-        );
-        assert_eq!(releases[0].size_bytes, 823031088);
+    fn history_dedupes_repeated_versions_keeping_newest_first() {
+        let dup = r#"[
+            {"GroupId":"785597","Version":"32.0.101.8801","DisplayReleaseDate":"2026-05-15T00:00:00Z","Url":"https://intel/785597","Files":[{"Url":"https://dl/8801.exe","Size":2}],"Components":[{"Category":"Graphics","DetectionValues":["VEN_8086&DEV_E20B"]}]},
+            {"GroupId":"857252","Version":"32.0.101.8801","DisplayReleaseDate":"2026-03-01T00:00:00Z","Url":null,"Files":[{"Url":"https://dl/dup.exe","Size":1}],"Components":[{"Category":"Graphics","DetectionValues":["VEN_8086&DEV_E20B"]}]}
+        ]"#;
+        let releases = resolve_history(dup, 0xE20B, 50).unwrap();
+        assert_eq!(releases.len(), 1);
+        assert_eq!(releases[0].size_bytes, 2);
     }
 
     #[test]
-    fn history_excludes_unrelated_groups_and_pre_graphics_versions() {
-        let releases = parse_software_configurations_history(HISTORY_FIXTURE).unwrap();
-        for r in &releases {
-            assert!(
-                r.version.display.starts_with("32.0.101."),
-                "non-graphics version leaked into history: {}",
-                r.version.display
-            );
-        }
-        assert!(releases
-            .iter()
-            .all(|r| r.version.display != "32.0.101.7085"));
+    fn history_respects_the_limit() {
+        assert_eq!(resolve_history(FIXTURE, 0xE20B, 1).unwrap().len(), 1);
     }
 
     #[test]
-    fn history_returns_empty_on_no_matches_or_malformed_json() {
-        assert!(parse_software_configurations_history("[]")
-            .unwrap()
-            .is_empty());
-        assert!(parse_software_configurations_history("not json").is_err());
+    fn empty_array_and_malformed_json_handled() {
+        assert!(resolve_release("[]", 0xE20B).unwrap().is_none());
+        assert!(resolve_release("not json", 0xE20B).is_err());
+        assert!(resolve_history("not json", 0xE20B, 5).is_err());
     }
 }

--- a/crates/driver-catalog/src/sources/nvidia.rs
+++ b/crates/driver-catalog/src/sources/nvidia.rs
@@ -367,6 +367,22 @@ mod tests {
     }
 
     #[test]
+    fn match_pfid_resolves_notebook_laptop_gpu_suffix_distinct_from_desktop() {
+        let data = serde_json::json!({
+            "desktop": { "GeForce RTX 4090": "1010" },
+            "notebook": { "GeForce RTX 4090 Laptop GPU": "1011" }
+        });
+        assert_eq!(
+            match_pfid(&data, "NVIDIA GeForce RTX 4090 Laptop GPU"),
+            Some("1011".to_string())
+        );
+        assert_eq!(
+            match_pfid(&data, "NVIDIA GeForce RTX 4090"),
+            Some("1010".to_string())
+        );
+    }
+
+    #[test]
     fn build_lookup_url_encodes_lookup_parameters() {
         let url = build_lookup_url("933", 135, true, true);
         assert!(url.contains("pfid=933"));

--- a/crates/driver-catalog/tests/pipeline.rs
+++ b/crates/driver-catalog/tests/pipeline.rs
@@ -1,0 +1,203 @@
+//! End-to-end resolution pipeline across the three GPU families. Drives the
+//! `DriverRegistry` orchestration (vendor routing → latest → `update_status` →
+//! report, plus deduped history) with a fake source so the path is exercised
+//! deterministically without touching the network. The live HTTP/parse layer is
+//! covered by each source's own unit tests, and download/verify/launch by
+//! `driver-install`'s wiremock + state-machine tests.
+
+use async_trait::async_trait;
+use driver_catalog::sources::DriverSource;
+use driver_catalog::{
+    DeviceClass, DeviceId, DriverError, DriverRegistry, DriverRelease, DriverVendor, DriverVersion,
+    OsFamily, OsTarget, ReleaseChannel, UpdateStatus,
+};
+
+struct FakeSource {
+    vendor: DriverVendor,
+    releases: Vec<DriverRelease>,
+}
+
+#[async_trait]
+impl DriverSource for FakeSource {
+    fn id(&self) -> &'static str {
+        "fake"
+    }
+
+    fn supports(&self, device: &DeviceId) -> bool {
+        device.class == DeviceClass::Gpu && device.vendor == self.vendor
+    }
+
+    async fn latest(
+        &self,
+        _client: &reqwest::Client,
+        _device: &DeviceId,
+        _os: &OsTarget,
+    ) -> Result<Option<DriverRelease>, DriverError> {
+        Ok(self.releases.first().cloned())
+    }
+
+    async fn history(
+        &self,
+        _client: &reqwest::Client,
+        _device: &DeviceId,
+        _os: &OsTarget,
+        limit: usize,
+    ) -> Result<Vec<DriverRelease>, DriverError> {
+        Ok(self.releases.iter().take(limit).cloned().collect())
+    }
+}
+
+fn release(vendor: DriverVendor, version: DriverVersion) -> DriverRelease {
+    DriverRelease {
+        vendor,
+        version,
+        channel: ReleaseChannel::Stable,
+        display_version: None,
+        is_beta: false,
+        download_url: "https://vendor/driver.exe".into(),
+        size_bytes: 1,
+        signature_subject: "subject".into(),
+        released_at: None,
+        release_notes_url: Some("https://vendor/notes".into()),
+        changelog: None,
+    }
+}
+
+fn device(vendor: DriverVendor, device_id: u16, model: &str) -> DeviceId {
+    DeviceId {
+        class: DeviceClass::Gpu,
+        vendor,
+        pci_vendor_id: 0,
+        pci_device_id: device_id,
+        model: model.into(),
+    }
+}
+
+fn os() -> OsTarget {
+    OsTarget {
+        family: OsFamily::Windows11X64,
+        dch: true,
+    }
+}
+
+fn registry() -> DriverRegistry {
+    let mut registry = DriverRegistry::empty();
+    registry.register(Box::new(FakeSource {
+        vendor: DriverVendor::Nvidia,
+        releases: vec![release(
+            DriverVendor::Nvidia,
+            DriverVersion::nvidia("610.47"),
+        )],
+    }));
+    registry.register(Box::new(FakeSource {
+        vendor: DriverVendor::Amd,
+        releases: vec![release(
+            DriverVendor::Amd,
+            DriverVersion::four_part_labeled("32.0.31007.5012", "26.5.2"),
+        )],
+    }));
+    registry.register(Box::new(FakeSource {
+        vendor: DriverVendor::Intel,
+        releases: vec![
+            release(
+                DriverVendor::Intel,
+                DriverVersion::four_part("32.0.101.8801"),
+            ),
+            release(
+                DriverVendor::Intel,
+                DriverVersion::four_part("32.0.101.8626"),
+            ),
+            release(
+                DriverVendor::Intel,
+                DriverVersion::four_part("32.0.101.8801"),
+            ),
+        ],
+    }));
+    registry
+}
+
+#[tokio::test]
+async fn nvidia_pipeline_reports_update_available_when_latest_is_newer() {
+    let client = reqwest::Client::new();
+    let report = registry()
+        .resolve(
+            &client,
+            &device(
+                DriverVendor::Nvidia,
+                0x2705,
+                "NVIDIA GeForce RTX 4070 Ti SUPER",
+            ),
+            &os(),
+            DriverVersion::nvidia("591.74"),
+        )
+        .await
+        .expect("resolve");
+    assert_eq!(report.status, UpdateStatus::UpdateAvailable);
+    assert_eq!(report.latest.unwrap().version.display, "610.47");
+}
+
+#[tokio::test]
+async fn amd_pipeline_reports_up_to_date_when_installed_matches_latest() {
+    let client = reqwest::Client::new();
+    let report = registry()
+        .resolve(
+            &client,
+            &device(DriverVendor::Amd, 0x73BF, "AMD Radeon RX 6900 XT"),
+            &os(),
+            DriverVersion::four_part("32.0.31007.5012"),
+        )
+        .await
+        .expect("resolve");
+    assert_eq!(report.status, UpdateStatus::UpToDate);
+}
+
+#[tokio::test]
+async fn intel_pipeline_is_unknown_when_installed_version_is_unparseable() {
+    let client = reqwest::Client::new();
+    let report = registry()
+        .resolve(
+            &client,
+            &device(DriverVendor::Intel, 0x9A49, "Intel Iris Xe Graphics"),
+            &os(),
+            DriverVersion::unknown(),
+        )
+        .await
+        .expect("resolve");
+    assert_eq!(report.status, UpdateStatus::Unknown);
+    assert!(
+        report.latest.is_some(),
+        "a candidate release is still surfaced"
+    );
+}
+
+#[tokio::test]
+async fn unsupported_vendor_resolves_without_a_source() {
+    let client = reqwest::Client::new();
+    let report = registry()
+        .resolve(
+            &client,
+            &device(DriverVendor::Other, 0x1234, "Some other GPU"),
+            &os(),
+            DriverVersion::four_part("1.0.0.0"),
+        )
+        .await
+        .expect("resolve");
+    assert_eq!(report.status, UpdateStatus::Unsupported);
+    assert!(report.latest.is_none());
+}
+
+#[tokio::test]
+async fn history_pipeline_dedupes_by_version_and_honours_the_limit() {
+    let client = reqwest::Client::new();
+    let history = registry()
+        .history(
+            &client,
+            &device(DriverVendor::Intel, 0x9A49, "Intel Iris Xe Graphics"),
+            &os(),
+            10,
+        )
+        .await
+        .expect("history");
+    let versions: Vec<_> = history.iter().map(|r| r.version.display.as_str()).collect();
+    assert_eq!(versions, vec!["32.0.101.8801", "32.0.101.8626"]);
+}

--- a/crates/driver-install/src/state.rs
+++ b/crates/driver-install/src/state.rs
@@ -25,6 +25,9 @@ const EXIT_OK: i32 = 0;
 const EXIT_REBOOT_REQUIRED: i32 = 3010;
 const EXIT_USER_CANCELLED: i32 = 1602;
 const EXIT_UAC_DECLINED: i32 = 1223;
+/// Intel Graphics installer: "No driver was found that can be installed on the
+/// current device" — the package's INF lists no id matching this GPU.
+const EXIT_INTEL_NO_COMPATIBLE_DEVICE: i32 = 8;
 
 impl InstallStage {
     pub fn is_terminal(self) -> bool {
@@ -76,6 +79,23 @@ pub fn classify_exit(code: i32) -> InstallStage {
         EXIT_OK | EXIT_REBOOT_REQUIRED => InstallStage::Completed,
         EXIT_USER_CANCELLED | EXIT_UAC_DECLINED => InstallStage::Cancelled,
         _ => InstallStage::Failed,
+    }
+}
+
+/// Human-facing message for a vendor installer exit code. Vendor is matched
+/// case-insensitively ("intel"/"nvidia"/"amd"); unknown codes fall back to a
+/// generic line that still surfaces the raw code for support.
+pub fn describe_exit(code: i32, vendor: &str) -> String {
+    match code {
+        EXIT_OK => "Driver installed successfully.".to_string(),
+        EXIT_REBOOT_REQUIRED => "Driver installed — restart your PC to finish.".to_string(),
+        EXIT_USER_CANCELLED | EXIT_UAC_DECLINED => "Installation cancelled.".to_string(),
+        EXIT_INTEL_NO_COMPATIBLE_DEVICE if vendor.eq_ignore_ascii_case("intel") => {
+            "This Intel driver does not list your GPU (exit code 8). It is likely OEM-locked or needs a \
+             different driver branch — get it from your laptop manufacturer or Windows Update."
+                .to_string()
+        }
+        other => format!("Installer exited with code {other}."),
     }
 }
 
@@ -148,6 +168,26 @@ mod tests {
         assert_eq!(classify_exit(1223), InstallStage::Cancelled);
         assert_eq!(classify_exit(1), InstallStage::Failed);
         assert_eq!(classify_exit(-1), InstallStage::Failed);
+    }
+
+    #[test]
+    fn describe_exit_explains_intel_code_8_only_for_intel() {
+        let intel = describe_exit(8, "intel");
+        assert!(intel.contains("exit code 8"));
+        assert!(
+            intel.to_lowercase().contains("oem-locked")
+                || intel.to_lowercase().contains("windows update")
+        );
+        assert_eq!(describe_exit(8, "nvidia"), "Installer exited with code 8.");
+    }
+
+    #[test]
+    fn describe_exit_covers_success_reboot_and_cancel() {
+        assert_eq!(describe_exit(0, "nvidia"), "Driver installed successfully.");
+        assert!(describe_exit(3010, "amd").contains("restart"));
+        assert_eq!(describe_exit(1602, "intel"), "Installation cancelled.");
+        assert_eq!(describe_exit(1223, "amd"), "Installation cancelled.");
+        assert_eq!(describe_exit(5, "amd"), "Installer exited with code 5.");
     }
 
     #[test]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dlssync-frontend",
   "private": true,
-  "version": "1.5.0",
+  "version": "1.5.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -25,6 +25,7 @@
     applyModalOpen,
   } from "./lib/stores";
   import { installApplyEventListeners } from "./lib/applyEvents";
+  import { installDriverInstallListener } from "./lib/driverInstallEvents";
 
   let theme = $state(localStorage.getItem("dlssync-theme") || "dark");
 
@@ -52,6 +53,7 @@
     }
     document.documentElement.setAttribute("data-theme", theme);
     void installApplyEventListeners();
+    void installDriverInstallListener();
     void bootstrapCatalog();
   });
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -126,6 +126,8 @@ export interface RamInfo {
 
 export interface GpuInfo {
   vendor: GpuVendor;
+  pci_vendor_id: number;
+  pci_device_id: number;
   model: string;
   driver_version: string;
   vram_bytes: number;

--- a/frontend/src/lib/driverInstallEvents.ts
+++ b/frontend/src/lib/driverInstallEvents.ts
@@ -1,0 +1,24 @@
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import { DRIVER_INSTALL_EVENT, type DriverInstallProgress } from "./api";
+import { applyDriverInstallProgress } from "./stores";
+
+let unlisten: UnlistenFn | null = null;
+
+/** Register the single app-level listener for driver-install progress. Mounted
+ *  once in `App.svelte` so progress keeps flowing into the shared store even
+ *  while the Drivers view is unmounted (e.g. the user switched tabs). */
+export async function installDriverInstallListener(): Promise<void> {
+  if (unlisten) return;
+  unlisten = await listen<DriverInstallProgress>(DRIVER_INSTALL_EVENT, (event) => {
+    applyDriverInstallProgress(event.payload);
+  });
+}
+
+export async function uninstallDriverInstallListener(): Promise<void> {
+  if (!unlisten) return;
+  try {
+    unlisten();
+  } catch {
+  }
+  unlisten = null;
+}

--- a/frontend/src/lib/drivers.ts
+++ b/frontend/src/lib/drivers.ts
@@ -35,6 +35,45 @@ export function hasDriverUpdate(report: DriverStatusReport): boolean {
   return report.status === "update_available";
 }
 
+/** Page to open for a driver: the device's own release-notes page, falling back
+ *  to a changelog notes PDF. Used both for "Release notes" and AMD's
+ *  "Open download page" action. */
+export function driverPageUrl(report: DriverStatusReport): string | null {
+  return report.latest?.release_notes_url ?? report.latest?.changelog?.notes_page_url ?? null;
+}
+
+/** An update is in-app installable only when the vendor gives a direct download
+ *  URL (NVIDIA, Intel). */
+export function canInstall(report: DriverStatusReport): boolean {
+  return report.status === "update_available" && !!report.latest?.download_url;
+}
+
+/** An update exists but there is no safe direct download (AMD: the real `.exe`
+ *  is EULA-gated and its filename is unstable) — route the user to the official
+ *  page instead of fabricating a link. */
+export function isOpenPageOnly(report: DriverStatusReport): boolean {
+  return (
+    report.status === "update_available" &&
+    !report.latest?.download_url &&
+    !!driverPageUrl(report)
+  );
+}
+
+const VENDOR_HELP_URL: Record<string, string> = {
+  intel: "https://www.intel.com/content/www/us/en/support/detect.html",
+  nvidia: "https://www.nvidia.com/Download/index.aspx",
+  amd: "https://www.amd.com/en/support/download/drivers.html",
+};
+
+/** Official "find my driver" page for a vendor — shown when status is unknown
+ *  (e.g. an OEM-locked integrated GPU) so the user is never left at a dead end. */
+export function vendorHelpUrl(vendor: string): string {
+  return (
+    VENDOR_HELP_URL[vendor] ??
+    "https://support.microsoft.com/windows/update-drivers-in-windows-ec62f46c-ff14-c91d-eead-d7126dc1f7b6"
+  );
+}
+
 export function driverUpdateCount(reports: DriverStatusReport[]): number {
   return reports.reduce((total, report) => (hasDriverUpdate(report) ? total + 1 : total), 0);
 }

--- a/frontend/src/lib/stores.ts
+++ b/frontend/src/lib/stores.ts
@@ -12,6 +12,7 @@ import {
   fetchSteamArt,
   checkDriverUpdates,
   listDriverHistory,
+  installDriver,
   type DetectedGame,
   type BackupEntry,
   type AppSettings,
@@ -19,6 +20,9 @@ import {
   type GameArt,
   type DriverStatusReport,
   type DriverReleaseDto,
+  type DriverInstallProgress,
+  type InstallStage,
+  type GpuVendor,
 } from "./api";
 import { sortDriverReports } from "./drivers";
 import { vendorLabel, familyLabel, familyShort, type UpdateStatus } from "./labels";
@@ -490,6 +494,62 @@ export async function loadDriverUpdates(): Promise<void> {
     showToast("danger", `Driver check failed: ${message}`);
   } finally {
     driverCheckInProgress.set(false);
+  }
+}
+
+/** Shared, app-level install progress for the GPU-driver updater. Lives in the
+ *  store (not in the Drivers view) so it survives unmounting when the user
+ *  switches tabs mid-download — the app-level listener in `driverInstallEvents`
+ *  keeps writing here regardless of which view is mounted. */
+export interface DriverInstallState {
+  vendor: GpuVendor | null;
+  stage: InstallStage | null;
+  message: string;
+  fraction: number | null;
+}
+
+const DRIVER_INSTALL_IDLE: DriverInstallState = {
+  vendor: null,
+  stage: null,
+  message: "",
+  fraction: null,
+};
+
+export const driverInstall: Writable<DriverInstallState> = writable({ ...DRIVER_INSTALL_IDLE });
+
+/** Fold a backend progress event into the shared state. Ignored when no install
+ *  is active so a late event cannot resurrect a cleared card. */
+export function applyDriverInstallProgress(p: DriverInstallProgress): void {
+  driverInstall.update((s) =>
+    s.vendor === null ? s : { ...s, stage: p.stage, message: p.message, fraction: p.progress },
+  );
+}
+
+/** Drive a driver install end-to-end. One install at a time; progress is
+ *  reflected in the shared `driverInstall` store and cleared on completion. */
+export async function startDriverInstall(report: DriverStatusReport): Promise<void> {
+  const url = report.latest?.download_url;
+  if (!url || get(driverInstall).vendor) return;
+  driverInstall.set({
+    vendor: report.device.vendor,
+    stage: "downloading",
+    message: "Starting…",
+    fraction: null,
+  });
+  try {
+    const outcome = await installDriver(report.device.vendor, url);
+    if (outcome.stage === "completed") {
+      showToast("success", outcome.message);
+      await loadDriverUpdates();
+    } else if (outcome.stage === "cancelled") {
+      showToast("warning", outcome.message);
+    } else {
+      showToast("danger", outcome.message);
+    }
+  } catch (err: unknown) {
+    showToast("danger", `Install failed: ${formatError(err)}`);
+  } finally {
+    driverInstall.set({ ...DRIVER_INSTALL_IDLE });
   }
 }
 

--- a/frontend/src/views/Drivers.svelte
+++ b/frontend/src/views/Drivers.svelte
@@ -1,30 +1,27 @@
 <script lang="ts">
   import { onMount } from "svelte";
-  import { listen } from "@tauri-apps/api/event";
+  import { openUrl, type DriverStatusReport, type GpuVendor } from "../lib/api";
   import {
-    openUrl,
-    installDriver,
-    DRIVER_INSTALL_EVENT,
-    type DriverStatusReport,
-    type DriverInstallProgress,
-    type InstallStage,
-    type GpuVendor,
-  } from "../lib/api";
-  import { driverStatusLabel, driverStatusTone, sortDriverReports } from "../lib/drivers";
+    driverStatusLabel,
+    driverStatusTone,
+    sortDriverReports,
+    canInstall,
+    isOpenPageOnly,
+    driverPageUrl,
+    vendorHelpUrl,
+  } from "../lib/drivers";
   import {
     driverReports,
     driverCheckInProgress,
     driverCheckError,
     loadDriverUpdates,
+    startDriverInstall,
+    driverInstall,
     showToast,
   } from "../lib/stores";
   import DlssOverridePanel from "../components/DlssOverridePanel.svelte";
   import DriverHistoryFlyout from "../components/DriverHistoryFlyout.svelte";
 
-  let installingVendor = $state<string | null>(null);
-  let installStage = $state<InstallStage | null>(null);
-  let installMessage = $state("");
-  let installFraction = $state<number | null>(null);
   let expandedModel = $state<string | null>(null);
   let historyTarget = $state<{ vendor: GpuVendor; model: string; accent: string } | null>(null);
 
@@ -43,6 +40,7 @@
   };
 
   let reports = $derived(sortDriverReports($driverReports));
+  let installBusy = $derived($driverInstall.vendor !== null);
   let nvidiaPacked = $derived(
     $driverReports.find((r) => r.device.vendor === "nvidia")?.installed.packed ?? 0,
   );
@@ -63,21 +61,12 @@
     return mb >= 1024 ? `${(mb / 1024).toFixed(2)} GB` : `${mb.toFixed(0)} MB`;
   }
 
-  function notesUrl(report: DriverStatusReport): string | null {
-    return report.latest?.release_notes_url ?? report.latest?.changelog?.notes_page_url ?? null;
-  }
-
-  function canDownload(report: DriverStatusReport): boolean {
-    return report.status === "update_available" && !!report.latest?.download_url;
-  }
-
   function hasChangelog(report: DriverStatusReport): boolean {
     const log = report.latest?.changelog;
     return !!log && (log.highlights.length > 0 || log.fixed.length > 0);
   }
 
-  async function openNotes(report: DriverStatusReport): Promise<void> {
-    const url = notesUrl(report);
+  async function open(url: string | null): Promise<void> {
     if (!url) return;
     try {
       await openUrl(url);
@@ -92,40 +81,7 @@
 
   onMount(() => {
     void loadDriverUpdates();
-    const unlisten = listen<DriverInstallProgress>(DRIVER_INSTALL_EVENT, (event) => {
-      installStage = event.payload.stage;
-      installMessage = event.payload.message;
-      installFraction = event.payload.progress;
-    });
-    return () => {
-      void unlisten.then((off) => off());
-    };
   });
-
-  async function install(report: DriverStatusReport): Promise<void> {
-    if (!report.latest?.download_url || installingVendor) return;
-    installingVendor = report.device.vendor;
-    installStage = "downloading";
-    installMessage = "Starting…";
-    installFraction = null;
-    try {
-      const outcome = await installDriver(report.device.vendor, report.latest.download_url);
-      if (outcome.stage === "completed") {
-        showToast("success", outcome.message);
-        await loadDriverUpdates();
-      } else if (outcome.stage === "cancelled") {
-        showToast("warning", outcome.message);
-      } else {
-        showToast("danger", outcome.message);
-      }
-    } catch (err) {
-      showToast("danger", `Install failed: ${err}`);
-    } finally {
-      installingVendor = null;
-      installStage = null;
-      installFraction = null;
-    }
-  }
 </script>
 
 <section class="drivers-view">
@@ -154,7 +110,10 @@
     {#each reports as report (report.device.model)}
       {@const tone = driverStatusTone(report.status)}
       {@const expanded = expandedModel === report.device.model}
-      {@const showNotes = !!notesUrl(report)}
+      {@const pageUrl = driverPageUrl(report)}
+      {@const showNotes = !!pageUrl}
+      {@const installing = $driverInstall.vendor === report.device.vendor}
+      {@const needsHelp = report.status === "unknown" || report.status === "unsupported"}
       <li class="driver-card">
         <div class="card-row">
           <div class="card-main">
@@ -174,28 +133,38 @@
             </div>
           </div>
           <div class="card-side">
-            {#if installingVendor === report.device.vendor}
-              <div class="install-live">
-                <span class="install-stage">{installStage}</span>
-                <div class="install-bar"><div class="install-fill" style:width={`${Math.round((installFraction ?? 0) * 100)}%`}></div></div>
-                <span class="install-msg">{installMessage}</span>
+            {#if installing}
+              <div class="install-live" role="status" aria-live="polite">
+                <span class="install-stage">{$driverInstall.stage}</span>
+                <div class="install-bar"><div class="install-fill" style:width={`${Math.round(($driverInstall.fraction ?? 0) * 100)}%`}></div></div>
+                <span class="install-msg">{$driverInstall.message}</span>
               </div>
             {:else}
-              {#if canDownload(report)}
+              {#if canInstall(report)}
                 {@const size = sizeLabel(report.latest?.size_bytes ?? 0)}
-                <button class="driver-update" onclick={() => install(report)} disabled={!!installingVendor}>
+                <button class="driver-update" onclick={() => startDriverInstall(report)} disabled={installBusy}>
                   <span class="driver-update-label">Update to v{report.latest?.version.display}</span>
                   {#if size}<span class="driver-update-size mono">{size}</span>{/if}
                 </button>
+              {:else if isOpenPageOnly(report)}
+                <button class="driver-update open-page" onclick={() => open(pageUrl)} disabled={installBusy}>
+                  <span class="driver-update-label">Open download page</span>
+                  <span class="ext-arrow" aria-hidden="true">↗</span>
+                </button>
               {:else}
-                <span class="driver-state" data-tone={tone}>{driverStatusLabel(report.status)}</span>
+                <div class="state-block">
+                  <span class="driver-state" data-tone={tone}>{driverStatusLabel(report.status)}</span>
+                  {#if needsHelp}
+                    <button class="help-link" onclick={() => open(vendorHelpUrl(report.device.vendor))}>Find my driver ↗</button>
+                  {/if}
+                </div>
               {/if}
               <div class="driver-secondary">
                 {#if showNotes}
                   <button
                     class="driver-icon"
-                    onclick={() => openNotes(report)}
-                    title={report.status === "update_available" && !report.latest?.download_url ? "Open the driver download page" : "Open the official release notes"}
+                    onclick={() => open(pageUrl)}
+                    title="Open the official release notes"
                     aria-label="Release notes"
                   >
                     <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
@@ -237,7 +206,7 @@
                 <p class="cl-empty">No inline notes published for this release.</p>
               {/if}
               {#if showNotes}
-                <button class="link-btn inline" onclick={() => openNotes(report)}>Full release notes ↗</button>
+                <button class="link-btn inline" onclick={() => open(pageUrl)}>Full release notes ↗</button>
               {/if}
             </div>
           {/if}
@@ -448,4 +417,21 @@
   .install-bar { width: 180px; height: 6px; border-radius: var(--radius-full); background: var(--bg-elevated); overflow: hidden; }
   .install-fill { height: 100%; background: var(--accent); transition: width 0.2s var(--ease); }
   .install-msg { font-size: 10px; color: var(--text-muted); max-width: 220px; text-align: right; }
+
+  .driver-update.open-page { background: var(--bg-elevated); color: var(--text-primary); border: 1px solid var(--border-strong); box-shadow: none; }
+  .driver-update.open-page:hover:not(:disabled) { background: var(--bg-card); border-color: var(--accent); }
+  .ext-arrow { font-size: 12px; opacity: 0.7; }
+  .state-block { display: inline-flex; flex-direction: column; align-items: flex-end; gap: 3px; }
+  .help-link { background: none; border: none; padding: 0; font-size: 11px; font-weight: 600; color: var(--accent); cursor: pointer; }
+  .help-link:hover { text-decoration: underline; }
+
+  .driver-update:focus-visible,
+  .driver-icon:focus-visible,
+  .help-link:focus-visible,
+  .changelog-toggle:focus-visible,
+  .check-btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+
+  @media (prefers-reduced-motion: reduce) {
+    .install-fill { transition: none; }
+  }
 </style>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dlssync",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "private": true,
   "scripts": {
     "dev": "tauri dev",

--- a/src-tauri/src/commands/drivers.rs
+++ b/src-tauri/src/commands/drivers.rs
@@ -3,10 +3,10 @@ use crate::state::AppState;
 use crate::system_info::{self, GpuInfo, GpuVendor, SystemInfo};
 use dll_catalog::DownloadProgress;
 use driver_catalog::{
-    consts, sources::DEFAULT_HISTORY_LIMIT, DeviceClass, DeviceId, DriverRegistry, DriverRelease,
+    sources::DEFAULT_HISTORY_LIMIT, DeviceClass, DeviceId, DriverRegistry, DriverRelease,
     DriverStatusReport, DriverVendor, DriverVersion, OsFamily, OsTarget, UpdateStatus,
 };
-use driver_install::state::{classify_exit, InstallStage};
+use driver_install::state::{classify_exit, describe_exit, InstallStage};
 use driver_install::{download_to_file, verify_signature, DownloadOpts};
 use serde::Serialize;
 use std::path::Path;
@@ -20,15 +20,6 @@ fn map_vendor(vendor: GpuVendor) -> DriverVendor {
         GpuVendor::Amd => DriverVendor::Amd,
         GpuVendor::Intel => DriverVendor::Intel,
         GpuVendor::Other => DriverVendor::Other,
-    }
-}
-
-fn pci_vendor_id(vendor: DriverVendor) -> u16 {
-    match vendor {
-        DriverVendor::Nvidia => consts::pci::NVIDIA,
-        DriverVendor::Amd => consts::pci::AMD,
-        DriverVendor::Intel => consts::pci::INTEL,
-        _ => 0,
     }
 }
 
@@ -47,8 +38,8 @@ fn device_for(gpu: &GpuInfo) -> (DeviceId, DriverVersion) {
     let device = DeviceId {
         class: DeviceClass::Gpu,
         vendor,
-        pci_vendor_id: pci_vendor_id(vendor),
-        pci_device_id: 0,
+        pci_vendor_id: gpu.pci_vendor_id,
+        pci_device_id: gpu.pci_device_id,
         model: gpu.model.clone(),
     };
     let installed = DriverVersion::from_installed(vendor, &gpu.driver_version);
@@ -271,11 +262,7 @@ pub async fn install_driver(
         .map_err(AppError::Other)?;
 
     let stage = classify_exit(exit_code);
-    let message = match stage {
-        InstallStage::Completed => "Driver installed. A reboot may be required.".to_string(),
-        InstallStage::Cancelled => "Installation cancelled.".to_string(),
-        _ => format!("Installer exited with code {exit_code}."),
-    };
+    let message = describe_exit(exit_code, &vendor);
     emit_stage(&app, stage, &message, None);
     Ok(InstallOutcome {
         stage,
@@ -332,6 +319,8 @@ mod tests {
     fn device_for_nvidia_normalizes_installed_version() {
         let gpu = GpuInfo {
             vendor: GpuVendor::Nvidia,
+            pci_vendor_id: driver_catalog::consts::pci::NVIDIA,
+            pci_device_id: 0x2705,
             model: "NVIDIA GeForce RTX 4070 Ti SUPER".into(),
             driver_version: "32.0.15.9174".into(),
             vram_bytes: 0,
@@ -339,7 +328,8 @@ mod tests {
         };
         let (device, installed) = device_for(&gpu);
         assert_eq!(device.vendor, DriverVendor::Nvidia);
-        assert_eq!(device.pci_vendor_id, consts::pci::NVIDIA);
+        assert_eq!(device.pci_vendor_id, driver_catalog::consts::pci::NVIDIA);
+        assert_eq!(device.pci_device_id, 0x2705);
         assert_eq!(installed.display, "591.74");
     }
 

--- a/src-tauri/src/system_info.rs
+++ b/src-tauri/src/system_info.rs
@@ -49,10 +49,18 @@ pub enum GpuVendor {
 #[derive(Debug, Clone, Serialize)]
 pub struct GpuInfo {
     pub vendor: GpuVendor,
+    pub pci_vendor_id: u16,
+    pub pci_device_id: u16,
     pub model: String,
     pub driver_version: String,
     pub vram_bytes: u64,
     pub recommended_runtimes: Vec<String>,
+}
+
+/// Windows PCI hardware-id fragment as it appears in a `PNPDeviceID` or an Intel
+/// `DetectionValues` entry (e.g. `VEN_10DE&DEV_2705`). Uppercase, 4-hex padded.
+pub fn hardware_id(vendor_id: u16, device_id: u16) -> String {
+    format!("VEN_{vendor_id:04X}&DEV_{device_id:04X}")
 }
 
 pub fn collect() -> SystemInfo {
@@ -184,8 +192,17 @@ fn ddr_label(smbios: u32, legacy: u32) -> String {
 
 fn collect_gpus() -> Vec<GpuInfo> {
     let mut out = collect_gpus_dxgi();
+    dedupe_adapters(&mut out);
     enrich_drivers(&mut out);
     out
+}
+
+/// Drop adapters that resolve to the same physical GPU. DXGI can surface a card
+/// more than once; identical twin cards also collapse to one driver entry. Keyed
+/// by `(vendor, device, model)` so two distinct GPUs are never merged.
+fn dedupe_adapters(gpus: &mut Vec<GpuInfo>) {
+    let mut seen = std::collections::BTreeSet::new();
+    gpus.retain(|g| seen.insert((g.pci_vendor_id, g.pci_device_id, g.model.clone())));
 }
 
 #[cfg(windows)]
@@ -225,6 +242,8 @@ fn collect_gpus_dxgi() -> Vec<GpuInfo> {
             let vendor = vendor_from_id(desc.VendorId);
             out.push(GpuInfo {
                 vendor,
+                pci_vendor_id: desc.VendorId as u16,
+                pci_device_id: desc.DeviceId as u16,
                 model,
                 driver_version: "Unknown".into(),
                 vram_bytes: desc.DedicatedVideoMemory as u64,
@@ -265,32 +284,51 @@ pub fn recommended_for(vendor: GpuVendor) -> Vec<String> {
 }
 
 #[cfg(windows)]
+type WmiRow = std::collections::HashMap<String, wmi::Variant>;
+
+#[cfg(windows)]
 fn enrich_drivers(gpus: &mut [GpuInfo]) {
-    let rows = match wmi_query("SELECT Name, DriverVersion, AdapterRAM FROM Win32_VideoController")
+    let rows = match wmi_query("SELECT Name, DriverVersion, PNPDeviceID FROM Win32_VideoController")
     {
         Ok(r) => r,
         Err(_) => return,
     };
     for gpu in gpus.iter_mut() {
-        let needle = gpu.model.to_ascii_lowercase();
-        for row in &rows {
-            let row_name = row
-                .get("Name")
-                .and_then(variant_as_string)
-                .unwrap_or_default();
-            if row_name.is_empty() {
-                continue;
-            }
-            if row_name.to_ascii_lowercase().contains(&needle)
-                || needle.contains(&row_name.to_ascii_lowercase())
-            {
-                if let Some(dv) = row.get("DriverVersion").and_then(variant_as_string) {
-                    gpu.driver_version = dv;
-                }
-                break;
-            }
+        if let Some(version) = row_for_gpu(gpu, &rows)
+            .and_then(|row| row.get("DriverVersion").and_then(variant_as_string))
+        {
+            gpu.driver_version = version;
         }
     }
+}
+
+/// Pick the `Win32_VideoController` row for this adapter. Prefers an exact PCI
+/// hardware-id match against `PNPDeviceID` — the only correct key when two GPUs
+/// of the same vendor (or an iGPU + dGPU) are present — and falls back to fuzzy
+/// model-name containment only when no row carries a matching id.
+#[cfg(windows)]
+fn row_for_gpu<'a>(gpu: &GpuInfo, rows: &'a [WmiRow]) -> Option<&'a WmiRow> {
+    if gpu.pci_device_id != 0 {
+        let want = hardware_id(gpu.pci_vendor_id, gpu.pci_device_id);
+        let by_id = rows.iter().find(|row| {
+            row.get("PNPDeviceID")
+                .and_then(variant_as_string)
+                .map(|pnp| pnp.to_ascii_uppercase().contains(&want))
+                .unwrap_or(false)
+        });
+        if by_id.is_some() {
+            return by_id;
+        }
+    }
+    let needle = gpu.model.to_ascii_lowercase();
+    rows.iter().find(|row| {
+        let name = row
+            .get("Name")
+            .and_then(variant_as_string)
+            .unwrap_or_default()
+            .to_ascii_lowercase();
+        !name.is_empty() && (name.contains(&needle) || needle.contains(&name))
+    })
 }
 
 #[cfg(not(windows))]
@@ -348,6 +386,49 @@ mod tests {
     fn ddr_label_unknown_for_unmapped_code() {
         assert_eq!(ddr_label(99, 0), "Unknown");
         assert_eq!(ddr_label(0, 0), "Unknown");
+    }
+
+    fn gpu(vendor: GpuVendor, vid: u16, did: u16, model: &str) -> GpuInfo {
+        GpuInfo {
+            vendor,
+            pci_vendor_id: vid,
+            pci_device_id: did,
+            model: model.into(),
+            driver_version: "Unknown".into(),
+            vram_bytes: 0,
+            recommended_runtimes: vec![],
+        }
+    }
+
+    #[test]
+    fn dedupe_adapters_collapses_identical_gpus_but_keeps_distinct_ones() {
+        let mut gpus = vec![
+            gpu(
+                GpuVendor::Nvidia,
+                0x10DE,
+                0x2705,
+                "NVIDIA GeForce RTX 4070 Ti SUPER",
+            ),
+            gpu(
+                GpuVendor::Nvidia,
+                0x10DE,
+                0x2705,
+                "NVIDIA GeForce RTX 4070 Ti SUPER",
+            ),
+            gpu(GpuVendor::Intel, 0x8086, 0x9A49, "Intel Iris Xe Graphics"),
+        ];
+        dedupe_adapters(&mut gpus);
+        assert_eq!(gpus.len(), 2);
+        assert!(gpus.iter().any(|g| g.vendor == GpuVendor::Intel));
+        assert_eq!(gpus.iter().filter(|g| g.pci_device_id == 0x2705).count(), 1);
+    }
+
+    #[test]
+    fn hardware_id_is_uppercase_4_hex_padded() {
+        assert_eq!(hardware_id(0x10DE, 0x2705), "VEN_10DE&DEV_2705");
+        assert_eq!(hardware_id(0x8086, 0x9A49), "VEN_8086&DEV_9A49");
+        assert_eq!(hardware_id(0x8086, 0x46A6), "VEN_8086&DEV_46A6");
+        assert_eq!(hardware_id(0x1002, 0x0B), "VEN_1002&DEV_000B");
     }
 
     #[test]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "DLSSync",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "identifier": "io.github.xt0n1-t3ch.dlssync",
   "build": {
     "beforeBuildCommand": "pnpm --filter dlssync-frontend build",

--- a/tests/contracts/driverRelease.test.ts
+++ b/tests/contracts/driverRelease.test.ts
@@ -26,11 +26,26 @@ const amdRelease = {
   channel: "stable",
   is_beta: false,
   display_version: "26.5.2",
-  download_url: "https://drivers.amd.com/drivers/whql-amd-software-adrenalin-edition-26.5.2-win11-c.exe",
+  download_url: "",
   size_bytes: 0,
   signature_subject: "Advanced Micro Devices, Inc.",
   released_at: null,
   release_notes_url: "https://www.amd.com/en/resources/support-articles/release-notes/RN-RAD-WIN-26-5-2.html",
+  changelog: null,
+};
+
+const intelIntegratedRelease = {
+  vendor: "intel",
+  version: { packed: 31000101002141, display: "31.0.101.2141", raw: "31.0.101.2141" },
+  channel: "stable",
+  is_beta: false,
+  display_version: null,
+  download_url: "https://downloadmirror.intel.com/z/win64_2141.exe",
+  size_bytes: 400000000,
+  signature_subject: "Intel Corporation",
+  released_at: "2026-04-06T00:00:00Z",
+  release_notes_url:
+    "https://www.intel.com/content/www/us/en/download/776137/intel-7th-10th-gen-processor-graphics-windows.html",
   changelog: null,
 };
 
@@ -70,7 +85,14 @@ describe("driver-release contract", () => {
     ["nvidia", nvidiaRelease],
     ["amd", amdRelease],
     ["intel", intelRelease],
+    ["intel-integrated", intelIntegratedRelease],
   ])("validates a %s release fixture against the schema", (_vendor, fixture) => {
     assertConforms(fixture, schema as never);
+  });
+
+  it("permits an empty download_url (AMD open-page model) while keeping a notes page", () => {
+    expect(amdRelease.download_url).toBe("");
+    expect(amdRelease.release_notes_url).toContain("amd.com");
+    assertConforms(amdRelease, schema as never);
   });
 });

--- a/tests/index.md
+++ b/tests/index.md
@@ -29,6 +29,7 @@ Vitest config: [frontend/vitest.config.ts](../frontend/vitest.config.ts). Tauri 
 | [dlssPresets.test.ts](unit/dlssPresets.test.ts) | `lib/dlss` | SR preset / FG-mode / FG-count option tables, preset labels, per-option description + source URL, driver-version gating (≥572.16 DLSS 4, ≥595.97 Dynamic MFG), active-override detection |
 | [anticheat.test.ts](unit/anticheat.test.ts) | `lib/anticheat` | detection flag (type-guard), joined names, dataset status note, ban-risk warning copy names the anti-cheats |
 | [catalogReleases.test.ts](unit/catalogReleases.test.ts) | `lib/catalogReleases` | `mergeFamilyReleases` across feature families: dedupe by version+sha, newest-first sort, distinct same-version files kept, empty input |
+| [driversActions.test.ts](unit/driversActions.test.ts) | `lib/drivers` | per-vendor action routing: `canInstall` (direct download only), `isOpenPageOnly` (AMD: update + no download + has page), mutual exclusivity, `driverPageUrl` notes→PDF→null fallback, `vendorHelpUrl` per-vendor finder + Windows fallback |
 
 ## Frontend — integration (`tests/integration/`)
 
@@ -38,6 +39,7 @@ Vitest config: [frontend/vitest.config.ts](../frontend/vitest.config.ts). Tauri 
 | [libraryStatus.test.ts](integration/libraryStatus.test.ts) | `relation` + Library Sort policy | mixed-library status derivation; outdated-first ordering contract (status rank → alpha) |
 | [toastStore.test.ts](integration/toastStore.test.ts) | Toast popup data layer | append/kind/message, FIFO stacking, TTL auto-dismiss (fake timers), targeted dismiss, no-op unknown id |
 | [driverStatus.test.ts](integration/driverStatus.test.ts) | `lib/drivers` | status label/tone maps, update detection + count, sort order (update→unknown→up_to_date→unsupported) + alpha tie-break + no-mutate |
+| [driverInstall.test.ts](integration/driverInstall.test.ts) | `stores.driverInstall` (UI e2e state machine) | shared install store: stray events ignored when idle; **progress survives a view change mid-download (bug-#1 regression guard)**; one-install-at-a-time; cancelled→warning / failed (Intel exit 8)→danger toast + state cleared; AMD empty-URL report never invokes install (open-page path) |
 
 ## Frontend — component render (`tests/components/`)
 
@@ -65,7 +67,7 @@ Validates the Tauri command boundary (Rust serde struct ↔ TS DTO) against the 
 
 | File | Contract | Coverage |
 |:---|:---|:---|
-| [driverRelease.test.ts](contracts/driverRelease.test.ts) | `contracts/driver-release.schema.json` | required-field set guard + NVIDIA/AMD/Intel release fixtures conform (version, changelog, display_version, release-notes URL) |
+| [driverRelease.test.ts](contracts/driverRelease.test.ts) | `contracts/driver-release.schema.json` | required-field set guard + NVIDIA/AMD/Intel(Arc)/Intel(integrated 31.x) fixtures conform; AMD empty `download_url` permitted (open-page model) with a notes page present |
 | [anticheatReport.test.ts](contracts/anticheatReport.test.ts) | `contracts/anticheat-report.schema.json` | required-field set guard + detected/clean fixtures conform; rejects an unknown detection source |
 
 ## Backend — Rust (`cargo test --workspace`)
@@ -81,7 +83,7 @@ Inline `#[cfg(test)]` per crate and per command module. All green:
 | settings / ui_prefs | `src-tauri/src/commands/settings.rs` | v2 round-trip, field defaults |
 | shell reveal | `src-tauri/src/commands/shell.rs` | `select_arg` quotes only the path, not the `/select` flag (spaced Steam paths) |
 | diagnostics | `src-tauri/src/commands/diagnostics.rs` | percent-encode (unreserved/UTF-8), body truncation, log tail, newest-first log discovery |
-| system_info | `src-tauri/src/system_info.rs` | DDR label decode, vendor-id map, per-vendor runtime recommendations |
+| system_info | `src-tauri/src/system_info.rs` | DDR label decode, vendor-id map, per-vendor runtime recommendations, `hardware_id` (uppercase 4-hex `VEN_&DEV_`), `dedupe_adapters` (collapses twin/duplicate GPUs, keeps distinct) |
 | driver-catalog | `crates/driver-catalog/src/{version,sources/*}.rs` | per-vendor version normalization (edge-case-five) + `four_part_labeled`, registry source selection, NVIDIA pfid match + Ajax parse + release-notes/date parse, Intel DSA `software-configurations.json` newest-client parse, AMD `amdversions.xml` arch-branch parse (`amd_arch` RDNA/Polaris classify) |
 | anticheat-detect | `crates/anticheat-detect/src/lib.rs` | filename fingerprint match (case-insensitive, EAC/BattlEye/Vanguard/GameGuard/XIGNCODE3/EA AC/PunkBuster/HoYoverse), `scan_dir` present/absent/empty/missing-path/depth-limit |
 | dll-catalog anti-cheat | `crates/dll-catalog/src/lib.rs` | `normalize_name` (strip punctuation/case), `AntiCheatIndex::lookup` appid precedence → normalized-name fallback, `embedded()` snapshot resolves Elden Ring, `merge` overlay precedence |

--- a/tests/integration/driverInstall.test.ts
+++ b/tests/integration/driverInstall.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { get } from "svelte/store";
+import type { DriverInstallOutcome, DriverStatusReport, GpuVendor } from "@/lib/api";
+
+let pendingResolve: ((outcome: DriverInstallOutcome) => void) | null = null;
+
+vi.mock("@/lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api")>();
+  return {
+    ...actual,
+    installDriver: vi.fn(
+      () =>
+        new Promise<DriverInstallOutcome>((resolve) => {
+          pendingResolve = resolve;
+        }),
+    ),
+    checkDriverUpdates: vi.fn(async () => []),
+  };
+});
+
+import {
+  driverInstall,
+  startDriverInstall,
+  applyDriverInstallProgress,
+  toasts,
+} from "@/lib/stores";
+
+function report(vendor: GpuVendor, downloadUrl: string | null): DriverStatusReport {
+  return {
+    device: { class: "gpu", vendor, pci_vendor_id: 0, pci_device_id: 0, model: "Test GPU" },
+    installed: { packed: 1, display: "1.0", raw: "1.0" },
+    latest:
+      downloadUrl === null
+        ? null
+        : {
+            vendor,
+            version: { packed: 2, display: "2.0", raw: "2.0" },
+            channel: "stable",
+            display_version: null,
+            is_beta: false,
+            download_url: downloadUrl,
+            size_bytes: 100,
+            signature_subject: "x",
+            released_at: null,
+            release_notes_url: "https://vendor/notes",
+            changelog: null,
+          },
+    status: "update_available",
+  };
+}
+
+function complete(outcome: DriverInstallOutcome): void {
+  expect(pendingResolve, "install_driver was invoked").not.toBeNull();
+  pendingResolve?.(outcome);
+  pendingResolve = null;
+}
+
+beforeEach(() => {
+  driverInstall.set({ vendor: null, stage: null, message: "", fraction: null });
+  toasts.set([]);
+  pendingResolve = null;
+});
+
+describe("driver install — shared store state machine", () => {
+  it("ignores progress events while no install is active", () => {
+    applyDriverInstallProgress({ stage: "downloading", message: "stray", progress: 0.4 });
+    expect(get(driverInstall).vendor).toBeNull();
+    expect(get(driverInstall).stage).toBeNull();
+  });
+
+  it("survives a view change: progress keeps updating the store mid-download", async () => {
+    const p = startDriverInstall(report("nvidia", "https://nv/driver.exe"));
+    expect(get(driverInstall).vendor).toBe("nvidia");
+    expect(get(driverInstall).stage).toBe("downloading");
+
+    applyDriverInstallProgress({ stage: "downloading", message: "Downloading driver", progress: 0.5 });
+    expect(get(driverInstall).fraction).toBe(0.5);
+    applyDriverInstallProgress({ stage: "verifying", message: "Verifying signature", progress: null });
+    expect(get(driverInstall).stage).toBe("verifying");
+    applyDriverInstallProgress({ stage: "installing", message: "Installing", progress: null });
+    expect(get(driverInstall).stage).toBe("installing");
+
+    complete({ stage: "completed", exit_code: 0, message: "Driver installed successfully." });
+    await p;
+    expect(get(driverInstall).vendor).toBeNull();
+    expect(get(toasts).at(-1)?.kind).toBe("success");
+  });
+
+  it("only one install runs at a time", async () => {
+    const first = startDriverInstall(report("intel", "https://intel/gfx.exe"));
+    expect(get(driverInstall).vendor).toBe("intel");
+    await startDriverInstall(report("nvidia", "https://nv/driver.exe"));
+    expect(get(driverInstall).vendor).toBe("intel");
+    complete({ stage: "completed", exit_code: 0, message: "done" });
+    await first;
+  });
+
+  it("maps a cancelled outcome to a warning toast and clears state", async () => {
+    const p = startDriverInstall(report("intel", "https://intel/gfx.exe"));
+    complete({ stage: "cancelled", exit_code: 1602, message: "Installation cancelled." });
+    await p;
+    expect(get(driverInstall).vendor).toBeNull();
+    expect(get(toasts).at(-1)?.kind).toBe("warning");
+  });
+
+  it("maps a failed outcome (e.g. Intel exit 8) to a danger toast and clears state", async () => {
+    const p = startDriverInstall(report("intel", "https://intel/gfx.exe"));
+    complete({ stage: "failed", exit_code: 8, message: "This Intel driver does not list your GPU (exit code 8)." });
+    await p;
+    expect(get(driverInstall).vendor).toBeNull();
+    expect(get(toasts).at(-1)?.kind).toBe("danger");
+  });
+
+  it("does nothing for a report without a direct download URL (AMD open-page path)", async () => {
+    await startDriverInstall(report("amd", ""));
+    expect(get(driverInstall).vendor).toBeNull();
+    expect(pendingResolve).toBeNull();
+  });
+});

--- a/tests/unit/driversActions.test.ts
+++ b/tests/unit/driversActions.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import type { DriverStatusReport, GpuVendor, DriverUpdateStatus } from "@/lib/api";
+import { canInstall, isOpenPageOnly, driverPageUrl, vendorHelpUrl } from "@/lib/drivers";
+
+function report(
+  vendor: GpuVendor,
+  status: DriverUpdateStatus,
+  opts: { download?: string; notes?: string | null; notesPdf?: string | null } = {},
+): DriverStatusReport {
+  const hasLatest = status === "update_available" || status === "up_to_date";
+  return {
+    device: { class: "gpu", vendor, pci_vendor_id: 0, pci_device_id: 0, model: "GPU" },
+    installed: { packed: 1, display: "1.0", raw: "1.0" },
+    latest: hasLatest
+      ? {
+          vendor,
+          version: { packed: 2, display: "2.0", raw: "2.0" },
+          channel: "stable",
+          display_version: null,
+          is_beta: false,
+          download_url: opts.download ?? "",
+          size_bytes: 0,
+          signature_subject: "x",
+          released_at: null,
+          release_notes_url: opts.notes === undefined ? "https://vendor/notes" : opts.notes,
+          changelog: opts.notesPdf
+            ? { highlights: [], fixed: [], notes_page_url: opts.notesPdf }
+            : null,
+        }
+      : null,
+    status,
+  };
+}
+
+describe("driver action routing", () => {
+  it("canInstall is true only for an available update with a direct download URL", () => {
+    expect(canInstall(report("nvidia", "update_available", { download: "https://nv/d.exe" }))).toBe(true);
+    expect(canInstall(report("intel", "update_available", { download: "https://intel/g.exe" }))).toBe(true);
+    expect(canInstall(report("amd", "update_available", { download: "" }))).toBe(false);
+    expect(canInstall(report("nvidia", "up_to_date", { download: "https://nv/d.exe" }))).toBe(false);
+  });
+
+  it("isOpenPageOnly is true for AMD-style updates: available, no download, has a page", () => {
+    expect(isOpenPageOnly(report("amd", "update_available", { download: "", notes: "https://amd/rn" }))).toBe(true);
+    expect(isOpenPageOnly(report("amd", "update_available", { download: "", notes: null }))).toBe(false);
+    expect(isOpenPageOnly(report("nvidia", "update_available", { download: "https://nv/d.exe" }))).toBe(false);
+    expect(isOpenPageOnly(report("intel", "up_to_date"))).toBe(false);
+  });
+
+  it("canInstall and isOpenPageOnly are mutually exclusive", () => {
+    const nv = report("nvidia", "update_available", { download: "https://nv/d.exe" });
+    const amd = report("amd", "update_available", { download: "", notes: "https://amd/rn" });
+    expect(canInstall(nv) && isOpenPageOnly(nv)).toBe(false);
+    expect(canInstall(amd) && isOpenPageOnly(amd)).toBe(false);
+  });
+
+  it("driverPageUrl prefers release notes, falls back to the changelog PDF, else null", () => {
+    expect(driverPageUrl(report("nvidia", "update_available", { download: "x", notes: "https://nv/rn" }))).toBe(
+      "https://nv/rn",
+    );
+    expect(
+      driverPageUrl(report("nvidia", "update_available", { download: "x", notes: null, notesPdf: "https://nv/rn.pdf" })),
+    ).toBe("https://nv/rn.pdf");
+    expect(driverPageUrl(report("nvidia", "update_available", { download: "x", notes: null }))).toBeNull();
+    expect(driverPageUrl(report("intel", "unknown"))).toBeNull();
+  });
+
+  it("vendorHelpUrl routes each vendor to its official finder, with a Windows fallback", () => {
+    expect(vendorHelpUrl("intel")).toContain("intel.com");
+    expect(vendorHelpUrl("nvidia")).toContain("nvidia.com");
+    expect(vendorHelpUrl("amd")).toContain("amd.com");
+    expect(vendorHelpUrl("other")).toContain("microsoft.com");
+  });
+});


### PR DESCRIPTION
## DLSSync 1.5.1 — driver-detection accuracy

Resolves GPU drivers by **PCI device id** for all three vendors instead of fuzzy model strings, and moves install progress to a shared store so it survives tab switches.

### Fixed
- **Intel**: match the device id against the catalog's per-package hardware-id list (`Components[].DetectionValues`) behind a Graphics-category filter — resolves the correct integrated / Arc / legacy 31.x / 15.x package with its real download URL and its own release-notes page. No match → `Unknown` (never a guess). Kills the Arc-package **exit code 8** on integrated laptops and the generic Arc release-notes link.
- **Install progress survives tab switches** — state moved to a shared, app-level store/listener (was component-local and torn down on unmount).
- **Multi-GPU**: installed driver version matched by `PNPDeviceID` (not name) so versions aren't cross-assigned; duplicate adapters deduped.

### Added
- Device-id-driven resolution for Intel/AMD/NVIDIA (AMD branch by device id with name fallback; NVIDIA notebook vs desktop locked by test).
- Drivers tab UX: "Open download page" (AMD), "Find my driver" (Unknown), `aria-live` progress, focus rings.

### Changed
- AMD opens its official download page instead of a fabricated installer URL (EULA-gated, unstable filename).
- Vendor installer exit codes get readable messages (Intel exit 8 → OEM-locked / different branch).

### Validation
- `cargo test --workspace` **264 passed / 0 failed** · `cargo clippy -D warnings` clean · `cargo fmt --check` clean
- frontend vitest **189 passed** · svelte-check **0/0**
- Live CDP smoke on a real RTX (release build): NVIDIA detection + 591.74→610.47 resolution + tab round-trip verified.

Version bumped to **1.5.1** (workspace, app, frontend, Cargo.lock, CHANGELOG).
