### PR TITLE
Release v1.5.2: catalog completeness, Streamline crash-safety, System & Components reliability

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,9 +99,26 @@ jobs:
           Write-Host "::group::target/release/bundle/nsis"
           Get-ChildItem -Path target/release/bundle/nsis -ErrorAction SilentlyContinue | Format-Table Name,Length -AutoSize
           Write-Host "::endgroup::"
+          Write-Host "::group::target/release/bundle/msi"
+          Get-ChildItem -Path target/release/bundle/msi -ErrorAction SilentlyContinue | Format-Table Name,Length -AutoSize
+          Write-Host "::endgroup::"
           Write-Host "::group::target/release (top level)"
           Get-ChildItem -Path target/release -File -ErrorAction SilentlyContinue | Where-Object { $_.Name -like '*.exe' -or $_.Name -like '*.sig' } | Format-Table Name,Length -AutoSize
           Write-Host "::endgroup::"
+
+      - name: Smoke-install MSI (silent install + uninstall)
+        shell: pwsh
+        run: |
+          $msi = Get-ChildItem -Path target/release/bundle/msi -Filter "*.msi" -File -ErrorAction SilentlyContinue | Select-Object -First 1
+          if (-not $msi) { throw "No .msi produced by tauri build" }
+          $log = Join-Path $env:RUNNER_TEMP "msi-install.log"
+          Write-Host "Installing $($msi.Name) silently…"
+          $p = Start-Process msiexec.exe -ArgumentList "/i `"$($msi.FullName)`" /quiet /norestart /l*v `"$log`"" -Wait -PassThru
+          if ($p.ExitCode -ne 0) { Get-Content $log -Tail 40 -ErrorAction SilentlyContinue; throw "MSI install failed (exit $($p.ExitCode))" }
+          Write-Host "Install OK. Uninstalling…"
+          $u = Start-Process msiexec.exe -ArgumentList "/x `"$($msi.FullName)`" /quiet /norestart" -Wait -PassThru
+          if ($u.ExitCode -ne 0) { throw "MSI uninstall failed (exit $($u.ExitCode))" }
+          Write-Host "MSI smoke-install + uninstall succeeded."
 
       - name: Build portable archive
         shell: pwsh
@@ -141,6 +158,7 @@ jobs:
             target/release/bundle/nsis/*.exe
             target/release/bundle/nsis/*.exe.sig
             target/release/bundle/nsis/*-portable.zip
+            target/release/bundle/msi/*.msi
           if-no-files-found: error
           retention-days: 7
 
@@ -208,9 +226,11 @@ jobs:
           exe=$(find release -name "*-setup.exe" -type f | head -n1)
           sig=$(find release -name "*-setup.exe.sig" -type f | head -n1)
           portable=$(find release -name "*-portable.zip" -type f | head -n1)
+          msi=$(find release -name "*.msi" -type f | head -n1)
           echo "exe=$exe" >> $GITHUB_OUTPUT
           echo "sig=$sig" >> $GITHUB_OUTPUT
           echo "portable=$portable" >> $GITHUB_OUTPUT
+          echo "msi=$msi" >> $GITHUB_OUTPUT
           echo "exe_name=$(basename "$exe")" >> $GITHUB_OUTPUT
 
       - name: Install git-cliff
@@ -293,4 +313,5 @@ jobs:
             release/*-setup.exe
             release/*-setup.exe.sig
             release/*-portable.zip
+            release/*.msi
             release/latest.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ All notable changes to DLSSync are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.2] - 2026-05-29
+
+A reliability and catalog release. The in-app catalog is complete again — DirectStorage and the full AMD and Intel upscaler history are back — and DLSS updates no longer swap the version-locked Streamline runtime that could crash games such as Starfield. The System & Components driver updater installs without hanging, snapshots each driver before updating so you can roll it back, and shows the older and latest versions of every component driver. It also carries the notification, command-palette, and game-detail work from the interface pass.
+
+### Added
+
+- System & Components shows each component's installed driver version next to the older versions still cached on your PC and the latest available one, read from the local driver store.
+- Before a system or component driver update, DLSSync exports the current driver and sets a System Restore point, then records it in a new, filterable System Drivers section in Backups where you can roll any driver back.
+- A note on the Drivers tab explains why a driver install asks for Administrator: Windows installs per-machine drivers only with elevation, so DLSSync stays unelevated and runs a signed helper with your approval.
+- Release notifications now carry the version, a short summary of the release notes, and one-click links to both the GitHub release and the Nexus Mods page — instead of only the changelog heading.
+- The notification center covers more events: GPU driver updates, system and component driver updates, and restored backups each post their own entry. Any notification with a link opens it externally.
+- Command palette: a per-command icon, a keyboard-shortcut chip (for example, G then L for Library), grouped sections (Recent, Navigate, Action, Settings), and highlighting on the characters your query matched.
+
+### Changed
+
+- DirectStorage (dstorage.dll with dstoragecore.dll) and the split FSR runtime are handled as matched sets, and the catalog build no longer overwrites the older AMD, Intel, and DirectStorage versions it used to drop.
+- After a DLL swap, DLSSync re-hashes the file it wrote and rolls back automatically when it does not match, and reports a locked file (game still running) separately from a real failure.
+- The game-detail view is now a full page instead of a slide-over panel. Opening a game shows a spacious page with a hero banner, status, update counts, the feature list, and a docked action bar; the window controls, search, notifications, and theme toggle stay visible and usable. "Back to Library" or Esc returns.
+- The command palette opens as a clean top-right panel — no full-screen dim — with an integrated search field.
+- System & Components (Drivers tab) copy rewritten to be plain and concrete.
+
+### Fixed
+
+- DLSS no longer swaps NVIDIA's version-locked Streamline runtime (the sl.* DLLs) across SDK major versions, or when an injector mod such as DLSS Enabler or OptiScaler is present — the cause of immediate crashes in games like Starfield and Subnautica 2. The upscaling DLLs (nvngx_dlss and the rest) still update normally.
+- "Not in catalog" no longer shows for DirectStorage and other technologies that are in fact covered; the catalog now carries them.
+- A System & Components driver install no longer hangs after the Administrator prompt and then disappears. It shows real progress, times out instead of freezing, and always ends with a clear result — including the per-machine "access denied" (0x80240044) case.
+- Resetting a DLSS override no longer creates an empty per-game profile that inherited the global preset. A game without an override now follows its own configuration.
+- The notification center is frosted again — the page behind it no longer shows through. The panel was moved out of the top bar so its blur applies to the page instead of being clipped.
+- The detail page's action bar no longer clips over content mid-scroll; it is an opaque docked bar.
+- A notification's link survives an app restart. It is stored with the notification, and notifications saved before this release migrate automatically.
+
 ## [1.5.1] - 2026-05-28
 
 A driver-detection accuracy release. GPU driver resolution is now keyed on the PCI device id for every
@@ -27,6 +58,7 @@ of the Arc desktop package, and install progress no longer breaks when you switc
 - AMD opens its official download page instead of a constructed installer URL. The direct `.exe` is gated behind a license prompt and its filename changes per release, so a fabricated link was unreliable; version and changelog detection are unchanged.
 - Vendor installer exit codes are reported with a readable message. Intel's "no compatible device" (exit code 8) now explains the GPU may be OEM-locked or need a different driver branch, pointing to the manufacturer or Windows Update.
 
+[1.5.2]: https://github.com/xt0n1-t3ch/DLSSync/releases/tag/v1.5.2
 [1.5.1]: https://github.com/xt0n1-t3ch/DLSSync/releases/tag/v1.5.1
 
 ## [1.5.0] - 2026-05-27

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "anticheat-detect"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "jwalk",
  "memchr",
@@ -352,7 +352,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "backup-store"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "chrono",
  "rusqlite",
@@ -1094,7 +1094,7 @@ dependencies = [
 
 [[package]]
 name = "dll-catalog"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "bytes",
  "chrono",
@@ -1117,7 +1117,7 @@ dependencies = [
 
 [[package]]
 name = "dll-scanner"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "jwalk",
  "once_cell",
@@ -1154,7 +1154,7 @@ dependencies = [
 
 [[package]]
 name = "dlssync"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "anticheat-detect",
  "anyhow",
@@ -1176,6 +1176,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "sysinfo",
+ "system-drivers",
  "tauri",
  "tauri-build",
  "tauri-plugin-autostart",
@@ -1235,7 +1236,7 @@ dependencies = [
 
 [[package]]
 name = "driver-catalog"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1251,7 +1252,7 @@ dependencies = [
 
 [[package]]
 name = "driver-install"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "dll-catalog",
  "futures-util",
@@ -2557,7 +2558,7 @@ dependencies = [
 
 [[package]]
 name = "launcher-scan"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -2694,7 +2695,7 @@ dependencies = [
 
 [[package]]
 name = "manifest-builder"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2879,7 +2880,7 @@ dependencies = [
 
 [[package]]
 name = "notifications-store"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "chrono",
  "rusqlite",
@@ -2971,7 +2972,7 @@ dependencies = [
 
 [[package]]
 name = "nvapi-drs"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "serde",
  "windows-sys 0.59.0",
@@ -3334,7 +3335,7 @@ checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "pe-version"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "pelite",
  "serde",
@@ -4700,6 +4701,18 @@ dependencies = [
  "pkg-config",
  "toml 0.8.2",
  "version-compare",
+]
+
+[[package]]
+name = "system-drivers"
+version = "1.5.2"
+dependencies = [
+ "serde",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tracing",
+ "windows 0.58.0",
+ "wmi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["src-tauri", "crates/*"]
 
 [workspace.package]
-version = "1.5.1"
+version = "1.5.2"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/xt0n1-t3ch/DLSSync"

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 </p>
 
 <p align="center">
-  <sub><b>New in v1.5:</b> a GPU driver updater for NVIDIA, AMD and Intel with full per-card version history and signature-verified installs; DLSS preset and frame-generation overrides through the NVIDIA driver profile, global or per game; a per-game anti-cheat and anti-tamper warning (Denuvo, Easy Anti-Cheat, BattlEye, VMProtect and more) before any swap; broader FSR and XeSS coverage; and a redesigned Library, Drivers tab and game drawer. See <a href="CHANGELOG.md#150---2026-05-27">CHANGELOG</a>.</sub>
+  <sub><b>New in v1.5.2:</b> the DLL catalog is complete again — DirectStorage and the full AMD and Intel upscaler history are back; DLSS no longer swaps NVIDIA's version-locked Streamline runtime that could crash games like Starfield; and the System &amp; Components driver updater installs without hanging, snapshots each driver before updating so you can roll it back, and shows older and latest versions per component. See <a href="CHANGELOG.md#152---2026-05-29">CHANGELOG</a>.</sub>
 </p>
 
 <p align="center">
@@ -166,7 +166,13 @@ The DLL-sync path has no driver, no kernel-mode hook, no in-process injection �
   </a>
 </p>
 
-The installer is a per-user NSIS bundle. It installs to `%LOCALAPPDATA%\DLSSync\` without an admin prompt and registers an Add or Remove Programs entry for clean uninstall. Subsequent versions install themselves silently via the in-app update banner.
+Each release ships three formats:
+
+- **`*-setup.exe` (NSIS, recommended)** — per-user install to `%LOCALAPPDATA%\DLSSync\`, no admin prompt, Add/Remove Programs entry, and silent in-app auto-update.
+- **`*.msi` (Windows Installer)** — a standard MSI for users and IT who prefer `msiexec` / Group Policy deployment (per-machine; smoke-installed in CI on every release).
+- **`*-portable.zip`** — no installer; lowest friction.
+
+**First run — the "unknown publisher" prompt.** DLSSync is not yet code-signed, so Windows SmartScreen may show *"Windows protected your PC"* once per version. This is **not** a virus warning — it appears for any new publisher without an established reputation. Click **More info → Run anyway**. Full, sourced explanation (and the real fixes we keep on file) in [docs/signing-reality.md](docs/signing-reality.md).
 
 CLI alternative:
 

--- a/crates/backup-store/src/lib.rs
+++ b/crates/backup-store/src/lib.rs
@@ -25,6 +25,24 @@ pub struct BackupEntry {
     pub restored_at: Option<chrono::DateTime<chrono::Utc>>,
     #[serde(default)]
     pub size_bytes: Option<u64>,
+    /// "dll" (a game DLL swap) or "driver_package" (a System & Components driver
+    /// snapshot). Legacy rows migrate to "dll".
+    #[serde(default = "default_backup_type")]
+    pub backup_type: String,
+    /// Device class for a driver_package backup (Audio/Network/…), for the
+    /// filterable System Drivers section in the Backups view.
+    #[serde(default)]
+    pub device_class: Option<String>,
+    /// Hardware id the driver_package backup belongs to.
+    #[serde(default)]
+    pub hardware_id: Option<String>,
+    /// Driver provider for a driver_package backup (Realtek, Intel, …).
+    #[serde(default)]
+    pub driver_provider: Option<String>,
+}
+
+fn default_backup_type() -> String {
+    "dll".to_string()
 }
 
 pub struct BackupStore {
@@ -65,6 +83,14 @@ impl BackupStore {
             CREATE INDEX IF NOT EXISTS idx_backups_game ON backups(game_id);
             CREATE INDEX IF NOT EXISTS idx_backups_created ON backups(created_at DESC);",
         )?;
+        ensure_column(&conn, "backup_type", "TEXT NOT NULL DEFAULT 'dll'")?;
+        ensure_column(&conn, "device_class", "TEXT")?;
+        ensure_column(&conn, "hardware_id", "TEXT")?;
+        ensure_column(&conn, "driver_provider", "TEXT")?;
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_backups_type ON backups(backup_type)",
+            [],
+        )?;
         Ok(())
     }
 
@@ -86,8 +112,9 @@ impl BackupStore {
         conn.execute(
             "INSERT INTO backups
                 (id, game_id, dll_family, dll_filename, original_path, backup_path,
-                 previous_version, previous_sha256, created_at, restored_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+                 previous_version, previous_sha256, created_at, restored_at,
+                 backup_type, device_class, hardware_id, driver_provider)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
             rusqlite::params![
                 entry.id,
                 entry.game_id,
@@ -99,6 +126,10 @@ impl BackupStore {
                 entry.previous_sha256,
                 entry.created_at.to_rfc3339(),
                 entry.restored_at.map(|d| d.to_rfc3339()),
+                entry.backup_type,
+                entry.device_class,
+                entry.hardware_id,
+                entry.driver_provider,
             ],
         )?;
         Ok(())
@@ -108,7 +139,8 @@ impl BackupStore {
         let conn = self.conn()?;
         let mut stmt = conn.prepare(
             "SELECT id, game_id, dll_family, dll_filename, original_path, backup_path,
-                    previous_version, previous_sha256, created_at, restored_at
+                    previous_version, previous_sha256, created_at, restored_at,
+                    backup_type, device_class, hardware_id, driver_provider
              FROM backups WHERE id = ?1",
         )?;
         let mut rows = stmt.query([id])?;
@@ -140,7 +172,8 @@ impl BackupStore {
         let conn = self.conn()?;
         let mut stmt = conn.prepare(
             "SELECT id, game_id, dll_family, dll_filename, original_path, backup_path,
-                    previous_version, previous_sha256, created_at, restored_at
+                    previous_version, previous_sha256, created_at, restored_at,
+                    backup_type, device_class, hardware_id, driver_provider
              FROM backups ORDER BY created_at DESC",
         )?;
         let rows = stmt.query_map([], |row| Ok(row_to_entry(row)))?;
@@ -234,6 +267,10 @@ fn row_to_entry(row: &rusqlite::Row<'_>) -> Result<BackupEntry, rusqlite::Error>
         created_at: parse_iso(&created)?,
         restored_at: restored.as_deref().map(parse_iso).transpose()?,
         size_bytes: None,
+        backup_type: row.get(10)?,
+        device_class: row.get(11)?,
+        hardware_id: row.get(12)?,
+        driver_provider: row.get(13)?,
     })
 }
 
@@ -245,6 +282,31 @@ fn parse_iso(s: &str) -> Result<chrono::DateTime<chrono::Utc>, rusqlite::Error> 
 
 fn path_str(p: &Path) -> String {
     p.to_string_lossy().into_owned()
+}
+
+/// PRAGMA-guarded additive migration: add `column` to the `backups` table when an
+/// older install's DB predates it. Mirrors the notifications-store `link` column
+/// migration so existing backups upgrade in place.
+fn ensure_column(conn: &rusqlite::Connection, column: &str, decl: &str) -> Result<(), BackupError> {
+    let mut present = false;
+    {
+        let mut stmt = conn.prepare("PRAGMA table_info(backups)")?;
+        let mut rows = stmt.query([])?;
+        while let Some(row) = rows.next()? {
+            let name: String = row.get(1)?;
+            if name.eq_ignore_ascii_case(column) {
+                present = true;
+                break;
+            }
+        }
+    }
+    if !present {
+        conn.execute(
+            &format!("ALTER TABLE backups ADD COLUMN {column} {decl}"),
+            [],
+        )?;
+    }
+    Ok(())
 }
 
 pub fn sanitize_folder_name(raw: &str) -> String {
@@ -342,7 +404,77 @@ mod tests {
             created_at: stamp,
             restored_at: None,
             size_bytes: None,
+            backup_type: "dll".into(),
+            device_class: None,
+            hardware_id: None,
+            driver_provider: None,
         }
+    }
+
+    #[test]
+    fn driver_package_backup_round_trips() {
+        let dir = tempdir().unwrap();
+        let store = fresh_store(&dir);
+        let bp = store.root_dir.join("driver-backups").join("oem42");
+        std::fs::create_dir_all(&bp).unwrap();
+        let entry = BackupEntry {
+            id: uuid::Uuid::new_v4().to_string(),
+            game_id: r"PCI\VEN_10EC&DEV_0256".into(),
+            dll_family: "Audio".into(),
+            dll_filename: "oem42.inf".into(),
+            original_path: PathBuf::from(r"PCI\VEN_10EC&DEV_0256"),
+            backup_path: bp,
+            previous_version: Some("6.0.1.1".into()),
+            previous_sha256: None,
+            created_at: chrono::Utc::now(),
+            restored_at: None,
+            size_bytes: None,
+            backup_type: "driver_package".into(),
+            device_class: Some("Audio".into()),
+            hardware_id: Some(r"PCI\VEN_10EC&DEV_0256".into()),
+            driver_provider: Some("Realtek".into()),
+        };
+        store.insert(&entry).unwrap();
+        let listed = store.list().unwrap();
+        let drv = listed
+            .iter()
+            .find(|e| e.backup_type == "driver_package")
+            .expect("driver_package backup");
+        assert_eq!(drv.device_class.as_deref(), Some("Audio"));
+        assert_eq!(drv.hardware_id.as_deref(), Some(r"PCI\VEN_10EC&DEV_0256"));
+        assert_eq!(drv.driver_provider.as_deref(), Some("Realtek"));
+    }
+
+    #[test]
+    fn legacy_db_without_new_columns_migrates_and_defaults_backup_type() {
+        let dir = tempdir().unwrap();
+        let db = dir.path().join("Backups").join("backups.db");
+        let root = dir.path().join("Backups");
+        std::fs::create_dir_all(&root).unwrap();
+        {
+            let conn = rusqlite::Connection::open(&db).unwrap();
+            conn.execute_batch(
+                "CREATE TABLE backups (
+                    id TEXT PRIMARY KEY, game_id TEXT NOT NULL, dll_family TEXT NOT NULL,
+                    dll_filename TEXT NOT NULL, original_path TEXT NOT NULL,
+                    backup_path TEXT NOT NULL, previous_version TEXT, previous_sha256 TEXT,
+                    created_at TEXT NOT NULL, restored_at TEXT
+                );",
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO backups VALUES ('legacy','steam-1','dlss_sr','nvngx_dlss.dll',
+                  'C:\\Games\\Foo\\nvngx_dlss.dll','C:\\b\\nvngx_dlss.dll','1.0','abc',
+                  '2026-01-01T00:00:00Z',NULL)",
+                [],
+            )
+            .unwrap();
+        }
+        let store = BackupStore::open(db, root).unwrap();
+        let listed = store.list().unwrap();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].backup_type, "dll");
+        assert_eq!(listed[0].device_class, None);
     }
 
     #[test]
@@ -475,7 +607,10 @@ mod tests {
         let conn =
             rusqlite::Connection::open(dir.path().join("Backups").join("backups.db")).unwrap();
         conn.execute(
-            "INSERT INTO backups VALUES ('legacy', 'steam-1', 'dlss_sr', 'b.dll',
+            "INSERT INTO backups
+                (id, game_id, dll_family, dll_filename, original_path, backup_path,
+                 previous_version, previous_sha256, created_at, restored_at)
+             VALUES ('legacy', 'steam-1', 'dlss_sr', 'b.dll',
               'C:\\Games\\Foo\\b.dll',
               'C:\\old\\backups\\steam-1\\stamp\\b.dll',
               '1.0', 'abc', '2026-01-01T00:00:00Z', NULL)",

--- a/crates/dll-catalog/src/lib.rs
+++ b/crates/dll-catalog/src/lib.rs
@@ -180,10 +180,16 @@ pub struct Release {
     pub is_dev: bool,
     #[serde(default)]
     pub min_driver: Option<String>,
+    #[serde(default = "default_hash_algorithm")]
+    pub hash_algorithm: String,
 }
 
 fn default_channel() -> String {
     "stable".to_string()
+}
+
+fn default_hash_algorithm() -> String {
+    "sha256".to_string()
 }
 
 pub const DEFAULT_MANIFEST_URL: &str =
@@ -344,6 +350,7 @@ mod tests {
             channel: "stable".into(),
             is_dev: false,
             min_driver: None,
+            hash_algorithm: "sha256".into(),
         }
     }
 

--- a/crates/dll-catalog/src/zip.rs
+++ b/crates/dll-catalog/src/zip.rs
@@ -167,6 +167,7 @@ mod tests {
             channel: "stable".into(),
             is_dev: false,
             min_driver: None,
+            hash_algorithm: "sha256".into(),
         }
     }
 

--- a/crates/dll-catalog/tests/download_resilience.rs
+++ b/crates/dll-catalog/tests/download_resilience.rs
@@ -49,6 +49,7 @@ fn release_for(filename: &str, cdn_url: &str, sha: &str, size: u64) -> Release {
         channel: "stable".into(),
         is_dev: false,
         min_driver: None,
+        hash_algorithm: "sha256".into(),
     }
 }
 

--- a/crates/dll-scanner/src/lib.rs
+++ b/crates/dll-scanner/src/lib.rs
@@ -33,7 +33,9 @@ pub enum DllFamily {
     FsrUpscalerVk,
     FsrFg,
     FsrLoader,
+    FsrDenoiser,
     DirectStorage,
+    DirectStorageCore,
 }
 
 impl DllFamily {
@@ -54,8 +56,9 @@ impl DllFamily {
             DllFamily::FsrUpscaler
             | DllFamily::FsrUpscalerVk
             | DllFamily::FsrFg
-            | DllFamily::FsrLoader => "amd",
-            DllFamily::DirectStorage => "microsoft",
+            | DllFamily::FsrLoader
+            | DllFamily::FsrDenoiser => "amd",
+            DllFamily::DirectStorage | DllFamily::DirectStorageCore => "microsoft",
         }
     }
 
@@ -77,7 +80,9 @@ impl DllFamily {
                 "fsr_upscaler"
             }
             DllFamily::FsrFg => "fsr_fg",
+            DllFamily::FsrDenoiser => "fsr_denoiser",
             DllFamily::DirectStorage => "direct_storage",
+            DllFamily::DirectStorageCore => "direct_storage_core",
         }
     }
 }
@@ -90,6 +95,104 @@ pub struct DllRecord {
     pub file_description: Option<String>,
     #[serde(default)]
     pub sha256: Option<String>,
+}
+
+/// Marker DLLs that signal a DLSS/FG injector mod (DLSS Enabler, OptiScaler,
+/// dlssg-to-fsr3) owns the Streamline set in this game tree. Matched
+/// case-insensitively by EXACT file name — a bare `nvngx.dll` is an injector
+/// proxy (real games ship `nvngx_dlss.dll` with the underscore), so generic
+/// loaders like `dxgi.dll`/`version.dll` are deliberately excluded to keep
+/// false positives at zero.
+pub const DLSS_ENABLER_MARKERS: &[&str] = &[
+    "dlss-enabler.dll",
+    "dlss-enabler-upscaler.dll",
+    "nvngx.dll",
+    "optiscaler.dll",
+    "dlssg_to_fsr3_amd_is_better.dll",
+];
+
+/// Bounded depth for the DLSS Enabler scan. The enabler DLLs sit near the game
+/// root, so a shallow early-exit walk is far cheaper than the full DLL scan and
+/// keeps enabler detection a separate, non-breaking command from `scan_install`.
+const DLSS_ENABLER_SCAN_DEPTH: usize = 4;
+
+/// Whether DLSS Enabler is installed in this game tree (bounded, early-exit walk).
+/// Kept separate from `scan_install` so the DLL-detection contract stays a plain
+/// `Vec<DllRecord>` — a partially-updated frontend/backend can never blank the
+/// whole library on a shape mismatch.
+pub fn detect_dlss_enabler(root: &Path) -> bool {
+    enabler_present_within(root, 0)
+}
+
+fn enabler_present_within(dir: &Path, depth: usize) -> bool {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return false;
+    };
+    let mut subdirs = Vec::new();
+    for entry in entries.flatten() {
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if file_type.is_file() {
+            if is_dlss_enabler_marker(&entry.file_name().to_string_lossy()) {
+                return true;
+            }
+        } else if file_type.is_dir() && depth < DLSS_ENABLER_SCAN_DEPTH {
+            let name = entry.file_name();
+            if !SKIP_DIRS.contains(name.to_string_lossy().as_ref()) {
+                subdirs.push(entry.path());
+            }
+        }
+    }
+    subdirs.iter().any(|d| enabler_present_within(d, depth + 1))
+}
+
+/// An NVIDIA Streamline plugin/interposer DLL (`sl.*.dll`). These form a single
+/// version-locked set: swapping one component (e.g. `sl.dlss_g.dll`) without the
+/// matching `sl.interposer.dll` mismatches Streamline's ABI struct versions and
+/// crashes the game on launch. Distinct from the NGX runtime DLLs
+/// (`nvngx_dlss.dll`), which the driver loads independently and are safe to swap.
+pub fn is_streamline_plugin(filename: &str) -> bool {
+    let lower = filename.to_ascii_lowercase();
+    lower.starts_with("sl.") && lower.ends_with(".dll")
+}
+
+/// Whether a single file name is a DLSS Enabler marker.
+pub fn is_dlss_enabler_marker(filename: &str) -> bool {
+    let lower = filename.to_ascii_lowercase();
+    DLSS_ENABLER_MARKERS.iter().any(|m| lower == *m)
+}
+
+/// Look for DLSS Enabler markers in `start` and up to `max_ancestors` parent
+/// directories. Streamline plugins live in deeply nested engine plugin folders
+/// while the enabler DLL sits near the game root, so the apply-time guard walks
+/// upward from the DLL being replaced.
+pub fn dlss_enabler_present_near(start: &Path, max_ancestors: usize) -> bool {
+    let mut dir = Some(start);
+    let mut hops = 0usize;
+    while let Some(current) = dir {
+        if dir_has_dlss_enabler(current) {
+            return true;
+        }
+        if hops >= max_ancestors {
+            break;
+        }
+        hops += 1;
+        dir = current.parent();
+    }
+    false
+}
+
+fn dir_has_dlss_enabler(dir: &Path) -> bool {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return false;
+    };
+    for entry in entries.flatten() {
+        if is_dlss_enabler_marker(&entry.file_name().to_string_lossy()) {
+            return true;
+        }
+    }
+    false
 }
 
 static KNOWN_DLLS: Lazy<Vec<(&'static str, DllFamily)>> = Lazy::new(|| {
@@ -117,8 +220,9 @@ static KNOWN_DLLS: Lazy<Vec<(&'static str, DllFamily)>> = Lazy::new(|| {
         ("amd_fidelityfx_loader_dx12.dll", DllFamily::FsrLoader),
         ("ffx_fsr3upscaler_x64.dll", DllFamily::FsrUpscaler),
         ("ffx_frameinterpolation_x64.dll", DllFamily::FsrFg),
+        ("amd_fidelityfx_denoiser_dx12.dll", DllFamily::FsrDenoiser),
         ("dstorage.dll", DllFamily::DirectStorage),
-        ("dstoragecore.dll", DllFamily::DirectStorage),
+        ("dstoragecore.dll", DllFamily::DirectStorageCore),
     ]
 });
 
@@ -264,5 +368,84 @@ mod tests {
         let p = dir.path().join("ghost.dll");
         let res = hash_file_capped(&p);
         assert!(res.is_err());
+    }
+
+    #[test]
+    fn streamline_plugins_recognized_case_insensitively() {
+        assert!(is_streamline_plugin("sl.dlss.dll"));
+        assert!(is_streamline_plugin("sl.dlss_g.dll"));
+        assert!(is_streamline_plugin("SL.Reflex.DLL"));
+        assert!(is_streamline_plugin("sl.interposer.dll"));
+        assert!(!is_streamline_plugin("nvngx_dlss.dll"));
+        assert!(!is_streamline_plugin("nvngx_dlssg.dll"));
+        assert!(!is_streamline_plugin("libxess.dll"));
+        assert!(!is_streamline_plugin("slime.dll"));
+    }
+
+    #[test]
+    fn dlss_enabler_markers_match_injector_dlls_not_generic_loaders() {
+        assert!(is_dlss_enabler_marker("dlss-enabler.dll"));
+        assert!(is_dlss_enabler_marker("DLSS-Enabler-Upscaler.dll"));
+        assert!(is_dlss_enabler_marker("nvngx.dll"));
+        assert!(is_dlss_enabler_marker("OptiScaler.dll"));
+        assert!(!is_dlss_enabler_marker("nvngx_dlss.dll"));
+        assert!(!is_dlss_enabler_marker("dxgi.dll"));
+        assert!(!is_dlss_enabler_marker("sl.dlss.dll"));
+    }
+
+    #[test]
+    fn dlss_enabler_present_near_walks_up_to_the_game_root() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("dlss-enabler.dll"), b"x").unwrap();
+        let nested = root
+            .path()
+            .join("Engine/Plugins/Runtime/Nvidia/Streamline/Binaries/ThirdParty/Win64");
+        std::fs::create_dir_all(&nested).unwrap();
+        assert!(dlss_enabler_present_near(&nested, 8));
+        assert!(!dlss_enabler_present_near(&nested, 2));
+    }
+
+    #[test]
+    fn detect_dlss_enabler_finds_marker_in_nested_dir_and_keeps_scan_contract() {
+        let root = tempfile::tempdir().unwrap();
+        let nested = root.path().join("Binaries/Win64");
+        std::fs::create_dir_all(&nested).unwrap();
+        std::fs::write(nested.join("dlss-enabler.dll"), b"x").unwrap();
+        std::fs::write(root.path().join("sl.dlss_g.dll"), b"x").unwrap();
+        assert!(detect_dlss_enabler(root.path()));
+        let records = scan_install(root.path()).unwrap();
+        assert!(records
+            .iter()
+            .any(|r| r.path.file_name().unwrap() == "sl.dlss_g.dll"));
+    }
+
+    #[test]
+    fn detect_dlss_enabler_is_false_without_markers() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("nvngx_dlss.dll"), b"x").unwrap();
+        assert!(!detect_dlss_enabler(root.path()));
+    }
+
+    #[test]
+    fn directstorage_core_and_fsr_denoiser_have_distinct_catalog_keys() {
+        assert_eq!(
+            DllFamily::DirectStorageCore.catalog_key(),
+            "direct_storage_core"
+        );
+        assert_eq!(DllFamily::DirectStorageCore.vendor(), "microsoft");
+        assert_eq!(DllFamily::FsrDenoiser.catalog_key(), "fsr_denoiser");
+        assert_eq!(DllFamily::FsrDenoiser.vendor(), "amd");
+    }
+
+    #[test]
+    fn scan_maps_dstoragecore_and_denoiser_to_their_own_families() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("dstoragecore.dll"), b"x").unwrap();
+        std::fs::write(root.path().join("amd_fidelityfx_denoiser_dx12.dll"), b"x").unwrap();
+        let recs = scan_install(root.path()).unwrap();
+        assert!(recs
+            .iter()
+            .any(|r| r.family == DllFamily::DirectStorageCore));
+        assert!(recs.iter().any(|r| r.family == DllFamily::FsrDenoiser));
     }
 }

--- a/crates/driver-catalog/src/sources/intel.rs
+++ b/crates/driver-catalog/src/sources/intel.rs
@@ -19,6 +19,24 @@ fn parse_iso_date(raw: &str) -> Option<chrono::DateTime<chrono::Utc>> {
         .map(|d| d.with_timezone(&chrono::Utc))
 }
 
+/// Intel's `DisplayReleaseDate` is normally RFC3339 (`2026-05-15T00:00:00Z`), but
+/// a catalog entry occasionally carries a bare `YYYY-MM-DD`. Accept both so a real
+/// graphics driver is never dropped purely over a date-format quirk.
+fn parse_release_date(raw: &str) -> Option<chrono::DateTime<chrono::Utc>> {
+    use chrono::{NaiveDate, TimeZone, Utc};
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    if let Some(dt) = parse_iso_date(trimmed) {
+        return Some(dt);
+    }
+    NaiveDate::parse_from_str(trimmed, "%Y-%m-%d")
+        .ok()
+        .and_then(|date| date.and_hms_opt(0, 0, 0))
+        .map(|naive| Utc.from_utc_datetime(&naive))
+}
+
 /// `VEN_8086&DEV_XXXX` exactly as Intel writes it in `Components[].DetectionValues`.
 fn intel_hardware_id(device_id: u16) -> String {
     format!("VEN_{:04X}&DEV_{device_id:04X}", c::PCI_VENDOR_ID)
@@ -56,7 +74,7 @@ fn entry_to_release(entry: &serde_json::Value) -> Option<DriverRelease> {
     if !token.chars().next().is_some_and(|ch| ch.is_ascii_digit()) {
         return None;
     }
-    let date = parse_iso_date(entry["DisplayReleaseDate"].as_str().unwrap_or_default())?;
+    let date = parse_release_date(entry["DisplayReleaseDate"].as_str().unwrap_or_default());
     let file0 = entry["Files"].as_array().and_then(|f| f.first());
     let download_url = file0
         .and_then(|f| f["Url"].as_str())
@@ -79,7 +97,7 @@ fn entry_to_release(entry: &serde_json::Value) -> Option<DriverRelease> {
         download_url,
         size_bytes: file0.and_then(|f| f["Size"].as_u64()).unwrap_or(0),
         signature_subject: c::PUBLISHER_SUBJECT.to_string(),
-        released_at: Some(date),
+        released_at: date,
         release_notes_url: entry["Url"]
             .as_str()
             .filter(|s| !s.is_empty())
@@ -303,5 +321,36 @@ mod tests {
         assert!(resolve_release("[]", 0xE20B).unwrap().is_none());
         assert!(resolve_release("not json", 0xE20B).is_err());
         assert!(resolve_history("not json", 0xE20B, 5).is_err());
+    }
+
+    #[test]
+    fn graphics_entry_with_alt_or_missing_date_is_still_resolved() {
+        let json = r#"[
+            {"GroupId":"1","Version":"32.0.101.9999","DisplayReleaseDate":"2026-06-01","Url":"https://intel/1","Files":[{"Url":"https://dl/9999.exe","Size":5}],"Components":[{"Category":"Graphics","DetectionValues":["VEN_8086&DEV_E20B"]}]},
+            {"GroupId":"2","Version":"32.0.101.0001","DisplayReleaseDate":"","Url":null,"Files":[{"Url":"https://dl/0001.exe","Size":3}],"Components":[{"Category":"Graphics","DetectionValues":["VEN_8086&DEV_E20B"]}]}
+        ]"#;
+        let releases = resolve_history(json, 0xE20B, 50).unwrap();
+        let versions: Vec<_> = releases
+            .iter()
+            .map(|r| r.version.display.as_str())
+            .collect();
+        assert!(
+            versions.contains(&"32.0.101.9999"),
+            "date-only entry must resolve"
+        );
+        assert!(
+            versions.contains(&"32.0.101.0001"),
+            "missing-date entry must not be silently dropped"
+        );
+        let dated = releases
+            .iter()
+            .find(|r| r.version.display == "32.0.101.9999")
+            .unwrap();
+        assert!(dated.released_at.is_some(), "YYYY-MM-DD must parse");
+        let undated = releases
+            .iter()
+            .find(|r| r.version.display == "32.0.101.0001")
+            .unwrap();
+        assert!(undated.released_at.is_none());
     }
 }

--- a/crates/driver-catalog/src/version.rs
+++ b/crates/driver-catalog/src/version.rs
@@ -1,6 +1,18 @@
 use crate::DriverVendor;
 use serde::{Deserialize, Serialize};
 
+/// A comparable driver version. Only `packed` is compared (`is_newer_than` =
+/// strict `>`); `display` is the human label and `raw` the source string.
+///
+/// Packing contract, fixed at construction per vendor:
+/// - NVIDIA (`nvidia`): the last 5 marketing digits, e.g. `32.0.15.7216` → `57216`
+///   shown as `572.16`. A shorter digit run is kept as-is (best effort).
+/// - AMD / Intel (`four_part`): the first four dot-separated lanes, each clamped to
+///   `u16::MAX`, packed big-endian (`l0<<48 | l1<<32 | l2<<16 | l3`).
+///
+/// Unparseable or empty input yields `packed == 0` — an `Unknown` that compares
+/// less than every real version. Callers must treat `0` as "version unknown",
+/// not "oldest". Comparison is packed-integer only; there are no semver rules.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DriverVersion {
     pub packed: u64,

--- a/crates/driver-install/src/launch.rs
+++ b/crates/driver-install/src/launch.rs
@@ -2,14 +2,17 @@ use crate::DriverInstallError;
 use std::mem::size_of;
 use std::os::windows::ffi::OsStrExt;
 use std::path::Path;
+use std::time::{Duration, Instant};
 use tokio_util::sync::CancellationToken;
 use windows::core::PCWSTR;
 use windows::Win32::Foundation::{CloseHandle, ERROR_CANCELLED, WAIT_OBJECT_0};
-use windows::Win32::System::Threading::{GetExitCodeProcess, WaitForSingleObject};
+use windows::Win32::System::Threading::{
+    GetExitCodeProcess, TerminateProcess, WaitForSingleObject,
+};
 use windows::Win32::UI::Shell::{ShellExecuteExW, SEE_MASK_NOCLOSEPROCESS, SHELLEXECUTEINFOW};
 use windows::Win32::UI::WindowsAndMessaging::SW_SHOWNORMAL;
 
-const UAC_DECLINED_EXIT: i32 = 1223;
+pub const UAC_DECLINED_EXIT: i32 = 1223;
 const WAIT_POLL_MS: u32 = 500;
 
 pub fn launch_and_wait(
@@ -52,6 +55,90 @@ pub fn launch_and_wait(
                 let _ = CloseHandle(info.hProcess);
                 return Err(DriverInstallError::Cancelled);
             }
+            if WaitForSingleObject(info.hProcess, WAIT_POLL_MS) == WAIT_OBJECT_0 {
+                break;
+            }
+        }
+
+        let mut code: u32 = 0;
+        let result = GetExitCodeProcess(info.hProcess, &mut code);
+        let _ = CloseHandle(info.hProcess);
+        result
+            .map_err(|error| DriverInstallError::Launch(format!("GetExitCodeProcess: {error}")))?;
+        Ok(code as i32)
+    }
+}
+
+/// Launch a fresh ELEVATED instance of `exe` (UAC "runas" verb) with `args` on
+/// its command line, wait for it to exit, and return the exit code. Returns
+/// `UAC_DECLINED_EXIT` (1223) when the user dismisses the UAC prompt. Used to run
+/// Administrator-only work (e.g. WUA driver install) out-of-process while the
+/// main app stays unelevated.
+///
+/// `on_tick` fires once per poll (~`WAIT_POLL_MS`) so the caller can stream
+/// progress (e.g. read the child's progress file) while the child runs. `cancel`
+/// and `timeout` bound the wait: on either, the elevated child is
+/// `TerminateProcess`d (never orphaned) and the call returns
+/// `DriverInstallError::Cancelled` or a timeout `Launch` error — so the UI can
+/// never freeze forever on a stuck install or UAC dialog.
+pub fn launch_elevated(
+    exe: &Path,
+    args: &str,
+    cancel: Option<&CancellationToken>,
+    timeout: Option<Duration>,
+    mut on_tick: impl FnMut(),
+) -> Result<i32, DriverInstallError> {
+    let file: Vec<u16> = exe
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+    let verb: Vec<u16> = "runas".encode_utf16().chain(std::iter::once(0)).collect();
+    let params: Vec<u16> = args.encode_utf16().chain(std::iter::once(0)).collect();
+
+    unsafe {
+        let mut info = SHELLEXECUTEINFOW {
+            cbSize: size_of::<SHELLEXECUTEINFOW>() as u32,
+            fMask: SEE_MASK_NOCLOSEPROCESS,
+            lpVerb: PCWSTR(verb.as_ptr()),
+            lpFile: PCWSTR(file.as_ptr()),
+            lpParameters: PCWSTR(params.as_ptr()),
+            nShow: SW_SHOWNORMAL.0,
+            ..Default::default()
+        };
+
+        if let Err(error) = ShellExecuteExW(&mut info) {
+            if error.code() == ERROR_CANCELLED.to_hresult() {
+                return Ok(UAC_DECLINED_EXIT);
+            }
+            return Err(DriverInstallError::Launch(format!(
+                "ShellExecuteExW(runas): {error}"
+            )));
+        }
+        if info.hProcess.is_invalid() {
+            return Err(DriverInstallError::Launch(
+                "elevated helper returned no process handle".to_string(),
+            ));
+        }
+
+        let start = Instant::now();
+        loop {
+            if cancel.is_some_and(|token| token.is_cancelled()) {
+                let _ = TerminateProcess(info.hProcess, UAC_DECLINED_EXIT as u32);
+                let _ = CloseHandle(info.hProcess);
+                return Err(DriverInstallError::Cancelled);
+            }
+            if let Some(limit) = timeout {
+                if start.elapsed() >= limit {
+                    let _ = TerminateProcess(info.hProcess, 1);
+                    let _ = CloseHandle(info.hProcess);
+                    return Err(DriverInstallError::Launch(format!(
+                        "elevated installer timed out after {}s",
+                        limit.as_secs()
+                    )));
+                }
+            }
+            on_tick();
             if WaitForSingleObject(info.hProcess, WAIT_POLL_MS) == WAIT_OBJECT_0 {
                 break;
             }

--- a/crates/manifest-builder/src/main.rs
+++ b/crates/manifest-builder/src/main.rs
@@ -26,7 +26,7 @@ struct Cli {
     #[arg(
         long,
         value_delimiter = ',',
-        default_value = "dlss_swapper,streamline,reflex,directstorage,anticheat"
+        default_value = "dlss_swapper,streamline,xess,fsr,reflex,directstorage,anticheat"
     )]
     sources: Vec<String>,
     /// Emit only the distilled anti-cheat snapshot (for the binary's embedded dataset) to this path.
@@ -59,7 +59,6 @@ struct SwapperManifest {
 #[derive(Debug, Deserialize)]
 struct SwapperEntry {
     version: String,
-    version_number: u64,
     #[serde(default)]
     internal_name: Option<String>,
     md5_hash: String,
@@ -663,7 +662,7 @@ fn merge_swapper(
     filename: &str,
     entries: &[SwapperEntry],
 ) {
-    let mut releases: Vec<Release> = entries
+    let releases: Vec<Release> = entries
         .iter()
         .map(|e| {
             let released_at = e
@@ -681,9 +680,10 @@ fn merge_swapper(
                 .unwrap_or(false);
             Release {
                 version: e.version.clone(),
-                version_packed: e.version_number,
+                version_packed: pack_version(&e.version),
                 filename: filename.to_string(),
                 sha256: e.md5_hash.clone().to_lowercase(),
+                hash_algorithm: "md5".to_string(),
                 size_bytes: e.file_size.unwrap_or(0),
                 signed: e.is_signature_valid.unwrap_or(false),
                 released_at,
@@ -712,19 +712,44 @@ fn merge_swapper(
             }
         })
         .collect();
-    releases.sort_by_key(|a| a.version_packed);
-    let latest = releases
+    upsert_family(vendors, vendor, family, releases);
+}
+
+/// Union new releases into a (vendor, family) entry instead of replacing it, so a
+/// second upstream source for the same family (e.g. FidelityFX-SDK on top of
+/// dlss-swapper FSR) extends the history rather than clobbering it. Releases are
+/// deduped by (version, filename) and `latest` is recomputed from the uniformly
+/// packed version across the merged set.
+fn upsert_family(
+    vendors: &mut BTreeMap<String, BTreeMap<String, FamilyEntry>>,
+    vendor: &str,
+    family: &str,
+    mut new_releases: Vec<Release>,
+) {
+    let fam = vendors
+        .entry(vendor.to_string())
+        .or_default()
+        .entry(family.to_string())
+        .or_insert_with(|| FamilyEntry {
+            latest: String::new(),
+            releases: Vec::new(),
+        });
+    fam.releases.append(&mut new_releases);
+    fam.releases.sort_by(|a, b| {
+        a.version_packed
+            .cmp(&b.version_packed)
+            .then_with(|| a.filename.cmp(&b.filename))
+    });
+    fam.releases
+        .dedup_by(|a, b| a.version == b.version && a.filename == b.filename);
+    fam.latest = fam
+        .releases
         .iter()
         .rev()
         .find(|r| r.channel == "stable")
-        .or_else(|| releases.last())
+        .or_else(|| fam.releases.last())
         .map(|r| r.version.clone())
         .unwrap_or_default();
-    let entry = FamilyEntry { latest, releases };
-    vendors
-        .entry(vendor.to_string())
-        .or_default()
-        .insert(family.to_string(), entry);
 }
 
 async fn ingest_github_zip_releases<F>(
@@ -783,6 +808,7 @@ where
                 version_packed,
                 filename: ext.filename.clone(),
                 sha256: ext.sha256,
+                hash_algorithm: "sha256".to_string(),
                 size_bytes: ext.size,
                 signed: ext.signed_hint,
                 released_at,
@@ -800,22 +826,8 @@ where
                 .push(release);
         }
     }
-    for ((vendor, family), mut list) in by_target {
-        list.sort_by_key(|a| a.version_packed);
-        let latest = list
-            .iter()
-            .rev()
-            .find(|r| r.channel == "stable")
-            .or_else(|| list.last())
-            .map(|r| r.version.clone())
-            .unwrap_or_default();
-        vendors.entry(vendor).or_default().insert(
-            family,
-            FamilyEntry {
-                latest,
-                releases: list,
-            },
-        );
+    for ((vendor, family), list) in by_target {
+        upsert_family(vendors, &vendor, &family, list);
     }
     Ok(())
 }
@@ -840,7 +852,8 @@ fn extract_dlls_from_zip(bytes: &[u8], rules: &[FilenameRule]) -> Result<Vec<Ext
     let cursor = std::io::Cursor::new(bytes);
     let mut zip = zip::ZipArchive::new(cursor)?;
     let mut out = Vec::new();
-    let mut seen: std::collections::HashSet<(&'static str, &'static str)> = Default::default();
+    let mut seen: std::collections::HashSet<(&'static str, &'static str, &'static str)> =
+        Default::default();
     for i in 0..zip.len() {
         let mut entry = zip.by_index(i)?;
         if !entry.is_file() {
@@ -855,7 +868,7 @@ fn extract_dlls_from_zip(bytes: &[u8], rules: &[FilenameRule]) -> Result<Vec<Ext
         let Some(rule) = rules.iter().find(|r| r.filename == base) else {
             continue;
         };
-        if !seen.insert((rule.vendor, rule.family)) {
+        if !seen.insert((rule.vendor, rule.family, rule.filename)) {
             continue;
         }
         let mut buf = Vec::with_capacity(entry.size() as usize);
@@ -895,7 +908,11 @@ fn pack_version(s: &str) -> u64 {
                 .take_while(|c| c.is_ascii_digit())
                 .collect::<String>()
         })
-        .map(|p| p.parse().unwrap_or(0))
+        .map(|p| {
+            p.parse::<u64>()
+                .map(|n| n.min(u16::MAX as u64) as u16)
+                .unwrap_or(0)
+        })
         .collect();
     let major = parts.first().copied().unwrap_or(0) as u64;
     let minor = parts.get(1).copied().unwrap_or(0) as u64;
@@ -946,11 +963,18 @@ const DS_RULES: &[FilenameRule] = &[
     },
 ];
 
+/// DirectStorage versions from the NuGet flat-container API. Uses its OWN
+/// unauthenticated client because the shared client carries a GitHub bearer for
+/// the release sources, and NuGet's Azure backend rejects any request that
+/// presents one with HTTP 403.
 async fn ingest_directstorage_nuget(
-    client: &reqwest::Client,
+    _shared: &reqwest::Client,
     vendors: &mut BTreeMap<String, BTreeMap<String, FamilyEntry>>,
 ) -> Result<()> {
     tracing::info!("fetching DirectStorage NuGet index");
+    let client = reqwest::Client::builder()
+        .user_agent("dlssync-manifest-builder/0.1 (+https://github.com/xt0n1-t3ch/DLSSync)")
+        .build()?;
     let idx_url = format!("https://api.nuget.org/v3-flatcontainer/{DS_PKG}/index.json");
     let index: NugetIndex = client
         .get(&idx_url)
@@ -979,7 +1003,7 @@ async fn ingest_directstorage_nuget(
         let pkg_url =
             format!("https://api.nuget.org/v3-flatcontainer/{DS_PKG}/{ver}/{DS_PKG}.{ver}.nupkg");
         tracing::info!(version = %ver, "downloading DirectStorage nupkg");
-        let bytes = match download_bytes(client, &pkg_url).await {
+        let bytes = match download_bytes(&client, &pkg_url).await {
             Ok(b) => b,
             Err(e) => {
                 tracing::warn!(version = %ver, "nupkg fetch failed: {e:#}");
@@ -1009,6 +1033,7 @@ async fn ingest_directstorage_nuget(
                 version_packed,
                 filename: ext.filename.clone(),
                 sha256: ext.sha256,
+                hash_algorithm: "sha256".to_string(),
                 size_bytes: ext.size,
                 signed: ext.signed_hint,
                 released_at,
@@ -1026,22 +1051,8 @@ async fn ingest_directstorage_nuget(
                 .push(release);
         }
     }
-    for ((vendor, family), mut list) in by_target {
-        list.sort_by_key(|a| a.version_packed);
-        let latest = list
-            .iter()
-            .rev()
-            .find(|r| r.channel == "stable")
-            .or_else(|| list.last())
-            .map(|r| r.version.clone())
-            .unwrap_or_default();
-        vendors.entry(vendor).or_default().insert(
-            family,
-            FamilyEntry {
-                latest,
-                releases: list,
-            },
-        );
+    for ((vendor, family), list) in by_target {
+        upsert_family(vendors, &vendor, &family, list);
     }
     Ok(())
 }
@@ -1132,5 +1143,64 @@ mod tests {
         assert_eq!(vendor_subject("amd"), "Advanced Micro Devices, Inc.");
         assert_eq!(vendor_subject("intel"), "Intel Corporation");
         assert_eq!(vendor_subject("nvidia"), "NVIDIA Corporation");
+    }
+
+    fn rel(ver: &str, file: &str) -> Release {
+        Release {
+            version: ver.to_string(),
+            version_packed: pack_version(ver),
+            filename: file.to_string(),
+            sha256: "x".into(),
+            hash_algorithm: "sha256".into(),
+            size_bytes: 0,
+            signed: false,
+            released_at: Utc::now(),
+            source: "t".into(),
+            cdn_url: "https://x/y".into(),
+            release_notes: None,
+            signature_subject: None,
+            channel: "stable".into(),
+            is_dev: false,
+            min_driver: None,
+        }
+    }
+
+    #[test]
+    fn upsert_family_unions_sources_without_clobbering_history() {
+        let mut vendors: BTreeMap<String, BTreeMap<String, FamilyEntry>> = BTreeMap::new();
+        upsert_family(
+            &mut vendors,
+            "amd",
+            "fsr_upscaler",
+            vec![
+                rel("3.1.0", "amd_fidelityfx_dx12.dll"),
+                rel("3.1.1", "amd_fidelityfx_dx12.dll"),
+                rel("3.1.2", "amd_fidelityfx_dx12.dll"),
+            ],
+        );
+        upsert_family(
+            &mut vendors,
+            "amd",
+            "fsr_upscaler",
+            vec![rel("2.0.0", "amd_fidelityfx_upscaler_dx12.dll")],
+        );
+        let fam = &vendors["amd"]["fsr_upscaler"];
+        assert_eq!(
+            fam.releases.len(),
+            4,
+            "second source must extend, not clobber, the first"
+        );
+        assert_eq!(
+            fam.latest, "3.1.2",
+            "uniform packing keeps the genuinely newest version as latest across sources"
+        );
+    }
+
+    #[test]
+    fn upsert_family_dedupes_same_version_and_filename() {
+        let mut vendors: BTreeMap<String, BTreeMap<String, FamilyEntry>> = BTreeMap::new();
+        upsert_family(&mut vendors, "amd", "fsr_fg", vec![rel("1.1.2", "a.dll")]);
+        upsert_family(&mut vendors, "amd", "fsr_fg", vec![rel("1.1.2", "a.dll")]);
+        assert_eq!(vendors["amd"]["fsr_fg"].releases.len(), 1);
     }
 }

--- a/crates/notifications-store/src/lib.rs
+++ b/crates/notifications-store/src/lib.rs
@@ -23,6 +23,9 @@ pub enum NotificationKind {
     ApplyCancelled,
     AppUpdateAvailable,
     CatalogUpdateAvailable,
+    DriverUpdateAvailable,
+    SystemDriverUpdateAvailable,
+    BackupRestored,
     ScanFailed,
     CatalogRefreshFailed,
 }
@@ -35,6 +38,9 @@ impl NotificationKind {
             Self::ApplyCancelled => "apply_cancelled",
             Self::AppUpdateAvailable => "app_update_available",
             Self::CatalogUpdateAvailable => "catalog_update_available",
+            Self::DriverUpdateAvailable => "driver_update_available",
+            Self::SystemDriverUpdateAvailable => "system_driver_update_available",
+            Self::BackupRestored => "backup_restored",
             Self::ScanFailed => "scan_failed",
             Self::CatalogRefreshFailed => "catalog_refresh_failed",
         }
@@ -47,6 +53,9 @@ impl NotificationKind {
             "apply_cancelled" => Ok(Self::ApplyCancelled),
             "app_update_available" => Ok(Self::AppUpdateAvailable),
             "catalog_update_available" => Ok(Self::CatalogUpdateAvailable),
+            "driver_update_available" => Ok(Self::DriverUpdateAvailable),
+            "system_driver_update_available" => Ok(Self::SystemDriverUpdateAvailable),
+            "backup_restored" => Ok(Self::BackupRestored),
             "scan_failed" => Ok(Self::ScanFailed),
             "catalog_refresh_failed" => Ok(Self::CatalogRefreshFailed),
             _ => Err(rusqlite::Error::InvalidQuery),
@@ -66,6 +75,8 @@ pub struct NotificationEntry {
     pub apply_id: Option<String>,
     pub game_id: Option<String>,
     pub error_class: Option<String>,
+    #[serde(default)]
+    pub link: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -105,11 +116,13 @@ impl NotificationsStore {
                 dismissed_at  TEXT,
                 apply_id      TEXT,
                 game_id       TEXT,
-                error_class   TEXT
+                error_class   TEXT,
+                link          TEXT
             );
             CREATE INDEX IF NOT EXISTS idx_notif_created ON notifications(created_at DESC);
             CREATE INDEX IF NOT EXISTS idx_notif_unread  ON notifications(read_at) WHERE read_at IS NULL;",
         )?;
+        ensure_column(&conn, "link")?;
         Ok(())
     }
 
@@ -118,8 +131,8 @@ impl NotificationsStore {
         conn.execute(
             "INSERT INTO notifications
                 (id, kind, title, body, created_at, read_at, dismissed_at,
-                 apply_id, game_id, error_class)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+                 apply_id, game_id, error_class, link)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
             rusqlite::params![
                 entry.id,
                 entry.kind.as_str(),
@@ -131,6 +144,7 @@ impl NotificationsStore {
                 entry.apply_id,
                 entry.game_id,
                 entry.error_class,
+                entry.link,
             ],
         )?;
         self.evict_to_cap_with(&conn)
@@ -164,13 +178,13 @@ impl NotificationsStore {
         let limit = filter.limit.unwrap_or(DEFAULT_LIST_LIMIT) as i64;
         let sql = if include_dismissed {
             "SELECT id, kind, title, body, created_at, read_at, dismissed_at,
-                    apply_id, game_id, error_class
+                    apply_id, game_id, error_class, link
              FROM notifications
              ORDER BY created_at DESC
              LIMIT ?1"
         } else {
             "SELECT id, kind, title, body, created_at, read_at, dismissed_at,
-                    apply_id, game_id, error_class
+                    apply_id, game_id, error_class, link
              FROM notifications
              WHERE dismissed_at IS NULL
              ORDER BY created_at DESC
@@ -270,6 +284,7 @@ fn row_to_entry(row: &rusqlite::Row<'_>) -> Result<NotificationEntry, rusqlite::
         apply_id: row.get(7)?,
         game_id: row.get(8)?,
         error_class: row.get(9)?,
+        link: row.get(10)?,
     })
 }
 
@@ -277,6 +292,20 @@ fn parse_iso(value: &str) -> Result<chrono::DateTime<chrono::Utc>, rusqlite::Err
     chrono::DateTime::parse_from_rfc3339(value)
         .map(|d| d.with_timezone(&chrono::Utc))
         .map_err(|_| rusqlite::Error::InvalidQuery)
+}
+
+fn ensure_column(conn: &rusqlite::Connection, column: &str) -> Result<(), NotificationsError> {
+    let mut stmt = conn.prepare("PRAGMA table_info(notifications)")?;
+    let existing: Vec<String> = stmt
+        .query_map([], |row| row.get::<_, String>(1))?
+        .filter_map(Result::ok)
+        .collect();
+    if !existing.iter().any(|name| name == column) {
+        conn.execute_batch(&format!(
+            "ALTER TABLE notifications ADD COLUMN {column} TEXT"
+        ))?;
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -302,6 +331,7 @@ mod tests {
             apply_id: Some(format!("apply-{title}")),
             game_id: Some(format!("steam-{title}")),
             error_class: None,
+            link: None,
         }
     }
 
@@ -352,6 +382,9 @@ mod tests {
             NotificationKind::ApplyCancelled,
             NotificationKind::AppUpdateAvailable,
             NotificationKind::CatalogUpdateAvailable,
+            NotificationKind::DriverUpdateAvailable,
+            NotificationKind::SystemDriverUpdateAvailable,
+            NotificationKind::BackupRestored,
             NotificationKind::ScanFailed,
             NotificationKind::CatalogRefreshFailed,
         ];
@@ -385,6 +418,62 @@ mod tests {
         let mut expected = signals.to_vec();
         expected.sort_by_key(|k| k.as_str());
         assert_eq!(returned, expected);
+    }
+
+    #[test]
+    fn insert_and_list_preserves_link() {
+        let dir = tempdir().unwrap();
+        let store = fresh_store(&dir);
+        let mut e = make_entry(NotificationKind::AppUpdateAvailable, "release");
+        e.link = Some("https://github.com/xt0n1-t3ch/DLSSync/releases/tag/v1.5.0".into());
+        store.insert(&e).unwrap();
+        let listed = store.list(&ListFilter::default()).unwrap();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(
+            listed[0].link.as_deref(),
+            Some("https://github.com/xt0n1-t3ch/DLSSync/releases/tag/v1.5.0")
+        );
+    }
+
+    #[test]
+    fn legacy_db_without_link_column_migrates_and_reads_none() {
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("Cache").join("notifications.db");
+        std::fs::create_dir_all(db_path.parent().unwrap()).unwrap();
+        let legacy = rusqlite::Connection::open(&db_path).unwrap();
+        legacy
+            .execute_batch(
+                "CREATE TABLE notifications (
+                    id TEXT PRIMARY KEY, kind TEXT NOT NULL, title TEXT NOT NULL, body TEXT,
+                    created_at TEXT NOT NULL, read_at TEXT, dismissed_at TEXT,
+                    apply_id TEXT, game_id TEXT, error_class TEXT
+                );",
+            )
+            .unwrap();
+        legacy
+            .execute(
+                "INSERT INTO notifications (id, kind, title, created_at)
+                 VALUES ('legacy-1', 'apply_success', 'old', ?1)",
+                rusqlite::params![chrono::Utc::now().to_rfc3339()],
+            )
+            .unwrap();
+        drop(legacy);
+
+        let store = NotificationsStore::open(db_path).unwrap();
+        let listed = store.list(&ListFilter::default()).unwrap();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].id, "legacy-1");
+        assert_eq!(listed[0].link, None);
+
+        let mut fresh = make_entry(NotificationKind::DriverUpdateAvailable, "post-migration");
+        fresh.link = Some("https://www.nexusmods.com/site/mods/1922".into());
+        store.insert(&fresh).unwrap();
+        let after = store.list(&ListFilter::default()).unwrap();
+        let migrated = after.iter().find(|e| e.id == fresh.id).unwrap();
+        assert_eq!(
+            migrated.link.as_deref(),
+            Some("https://www.nexusmods.com/site/mods/1922")
+        );
     }
 
     #[test]

--- a/crates/nvapi-drs/src/ffi.rs
+++ b/crates/nvapi-drs/src/ffi.rs
@@ -8,6 +8,7 @@ use windows_sys::Win32::System::LibraryLoader::{GetProcAddress, LoadLibraryW};
 
 type Status = i32;
 const NVAPI_OK: Status = 0;
+const NVAPI_INVALID_USER_PRIVILEGE: Status = -137;
 type NvHandle = *mut c_void;
 
 const ID_INITIALIZE: u32 = 0x0150_E828;
@@ -262,23 +263,41 @@ impl Drs {
         }
     }
 
-    unsafe fn find_or_create_app(&self, exe_path: &str) -> Result<NvHandle, String> {
+    /// Read-only profile resolution: never creates a profile. A per-game profile
+    /// that does not exist yet resolves to `None` so a READ stays side-effect-free
+    /// (opening the override UI must not inject a phantom app profile).
+    unsafe fn profile_for_read(&self, scope: &OverrideScope) -> Result<Option<NvHandle>, String> {
+        match scope {
+            OverrideScope::Global => Ok(Some(self.base_profile()?)),
+            OverrideScope::PerGame { executable_path } => self.find_app(executable_path),
+        }
+    }
+
+    unsafe fn find_app(&self, exe_path: &str) -> Result<Option<NvHandle>, String> {
         let name = exe_basename(exe_path);
         let name_wide = wide(&name);
-
-        let mut existing_profile: NvHandle = null_mut();
-        let mut existing_app: NvdrsApplicationV4 = zeroed();
-        existing_app.version = struct_version::<NvdrsApplicationV4>(NVDRS_APPLICATION_VER_NUMBER);
+        let mut profile: NvHandle = null_mut();
+        let mut app: NvdrsApplicationV4 = zeroed();
+        app.version = struct_version::<NvdrsApplicationV4>(NVDRS_APPLICATION_VER_NUMBER);
         let status = (self.fns.find_application_by_name)(
             self.session,
             name_wide.as_ptr(),
-            &mut existing_profile,
-            &mut existing_app,
+            &mut profile,
+            &mut app,
         );
-        if status == NVAPI_OK && !existing_profile.is_null() {
-            return Ok(existing_profile);
+        if status == NVAPI_OK && !profile.is_null() {
+            Ok(Some(profile))
+        } else {
+            Ok(None)
+        }
+    }
+
+    unsafe fn find_or_create_app(&self, exe_path: &str) -> Result<NvHandle, String> {
+        if let Some(profile) = self.find_app(exe_path)? {
+            return Ok(profile);
         }
 
+        let name = exe_basename(exe_path);
         let mut profile_info: NvdrsProfile = zeroed();
         profile_info.version = struct_version::<NvdrsProfile>(NVDRS_PROFILE_VER_NUMBER);
         wide_into(&mut profile_info.profile_name, &name);
@@ -299,24 +318,25 @@ impl Drs {
         Ok(profile)
     }
 
-    unsafe fn set_dword(&self, profile: NvHandle, id: u32, value: u32) -> Result<(), String> {
+    unsafe fn set_dword(&self, profile: NvHandle, id: u32, value: u32) -> Result<(), Status> {
         let mut setting: NvdrsSetting = zeroed();
         setting.version = struct_version::<NvdrsSetting>(NVDRS_SETTING_VER_NUMBER);
         setting.setting_id = id;
         setting.setting_type = NVDRS_DWORD_TYPE;
         setting.current_value.u32_value = value;
         let status = (self.fns.set_setting)(self.session, profile, &setting);
-        if status != NVAPI_OK {
-            return Err(format!("NvAPI_DRS_SetSetting(0x{id:08X}) -> {status}"));
+        if status == NVAPI_OK {
+            Ok(())
+        } else {
+            Err(status)
         }
-        Ok(())
     }
 
     unsafe fn get_dword(&self, profile: NvHandle, id: u32) -> Option<u32> {
         let mut setting: NvdrsSetting = zeroed();
         setting.version = struct_version::<NvdrsSetting>(NVDRS_SETTING_VER_NUMBER);
         let status = (self.fns.get_setting)(self.session, profile, id, &mut setting);
-        if status == NVAPI_OK {
+        if status == NVAPI_OK && setting.setting_type == NVDRS_DWORD_TYPE {
             Some(setting.current_value.u32_value)
         } else {
             None
@@ -367,20 +387,36 @@ pub fn roundtrip_dword(setting_id: u32, value: u32) -> Result<u32, String> {
     let drs = Drs::open()?;
     unsafe {
         let profile = drs.base_profile()?;
-        drs.set_dword(profile, setting_id, value)?;
+        drs.set_dword(profile, setting_id, value)
+            .map_err(|status| format!("NvAPI_DRS_SetSetting(0x{setting_id:08X}) -> {status}"))?;
         drs.get_dword(profile, setting_id)
             .ok_or_else(|| "GetSetting returned no value after SetSetting".to_string())
     }
 }
 
-pub fn apply_overrides(scope: &OverrideScope, settings: &[DrsSetting]) -> Result<(), String> {
+/// Applies every setting it can and returns the ids the driver refused for lack of
+/// privilege (`NVAPI_INVALID_USER_PRIVILEGE`) instead of aborting the whole batch —
+/// e.g. frame-generation DRS settings require an elevated process, while DLSS
+/// Super-Resolution settings do not. Any OTHER NVAPI failure still aborts.
+pub fn apply_overrides(scope: &OverrideScope, settings: &[DrsSetting]) -> Result<Vec<u32>, String> {
     let drs = Drs::open()?;
     unsafe {
         let profile = drs.profile_for(scope)?;
+        let mut needs_elevation = Vec::new();
         for setting in settings {
-            drs.set_dword(profile, setting.id, setting.value)?;
+            match drs.set_dword(profile, setting.id, setting.value) {
+                Ok(()) => {}
+                Err(NVAPI_INVALID_USER_PRIVILEGE) => needs_elevation.push(setting.id),
+                Err(status) => {
+                    return Err(format!(
+                        "NvAPI_DRS_SetSetting(0x{:08X}) -> {status}",
+                        setting.id
+                    ));
+                }
+            }
         }
-        drs.save()
+        drs.save()?;
+        Ok(needs_elevation)
     }
 }
 
@@ -390,7 +426,9 @@ pub fn read_overrides(
 ) -> Result<Vec<(u32, Option<u32>)>, String> {
     let drs = Drs::open()?;
     unsafe {
-        let profile = drs.profile_for(scope)?;
+        let Some(profile) = drs.profile_for_read(scope)? else {
+            return Ok(ids.iter().map(|&id| (id, None)).collect());
+        };
         Ok(ids
             .iter()
             .map(|&id| (id, drs.get_dword(profile, id)))
@@ -401,7 +439,9 @@ pub fn read_overrides(
 pub fn reset_overrides(scope: &OverrideScope, ids: &[u32]) -> Result<(), String> {
     let drs = Drs::open()?;
     unsafe {
-        let profile = drs.profile_for(scope)?;
+        let Some(profile) = drs.profile_for_read(scope)? else {
+            return Ok(());
+        };
         for &id in ids {
             let _ = (drs.fns.restore_default_setting)(drs.session, profile, id);
         }

--- a/crates/nvapi-drs/src/settings.rs
+++ b/crates/nvapi-drs/src/settings.rs
@@ -12,7 +12,8 @@ pub mod ids {
 }
 
 const VALUE_ON: u32 = 0x0000_0001;
-const PRESET_RECOMMENDED: u32 = 0x00FF_FFFE;
+const PRESET_RECOMMENDED: u32 = 0x00FF_FFFF;
+const PRESET_RECOMMENDED_LEGACY: u32 = 0x00FF_FFFE;
 const FRAME_GEN_MODE_FIXED: u32 = 0x0000_0002;
 const FRAME_GEN_MODE_DYNAMIC: u32 = 0x0000_0004;
 
@@ -39,10 +40,13 @@ pub enum DlssPreset {
     F,
     G,
     H,
+    I,
     J,
     K,
     L,
     M,
+    N,
+    O,
     Recommended,
 }
 
@@ -58,12 +62,38 @@ impl DlssPreset {
             DlssPreset::F => 6,
             DlssPreset::G => 7,
             DlssPreset::H => 8,
+            DlssPreset::I => 9,
             DlssPreset::J => 0x0A,
             DlssPreset::K => 0x0B,
             DlssPreset::L => 0x0C,
             DlssPreset::M => 0x0D,
+            DlssPreset::N => 0x0E,
+            DlssPreset::O => 0x0F,
             DlssPreset::Recommended => PRESET_RECOMMENDED,
         }
+    }
+
+    pub fn from_value(value: u32) -> Option<Self> {
+        Some(match value {
+            0 => DlssPreset::Default,
+            1 => DlssPreset::A,
+            2 => DlssPreset::B,
+            3 => DlssPreset::C,
+            4 => DlssPreset::D,
+            5 => DlssPreset::E,
+            6 => DlssPreset::F,
+            7 => DlssPreset::G,
+            8 => DlssPreset::H,
+            9 => DlssPreset::I,
+            0x0A => DlssPreset::J,
+            0x0B => DlssPreset::K,
+            0x0C => DlssPreset::L,
+            0x0D => DlssPreset::M,
+            0x0E => DlssPreset::N,
+            0x0F => DlssPreset::O,
+            PRESET_RECOMMENDED | PRESET_RECOMMENDED_LEGACY => DlssPreset::Recommended,
+            _ => return None,
+        })
     }
 }
 
@@ -82,6 +112,15 @@ impl FrameGenMode {
             FrameGenMode::Fixed => FRAME_GEN_MODE_FIXED,
             FrameGenMode::Dynamic => FRAME_GEN_MODE_DYNAMIC,
         }
+    }
+
+    pub fn from_value(value: u32) -> Option<Self> {
+        Some(match value {
+            0 => FrameGenMode::AppControlled,
+            FRAME_GEN_MODE_FIXED => FrameGenMode::Fixed,
+            FRAME_GEN_MODE_DYNAMIC => FrameGenMode::Dynamic,
+            _ => return None,
+        })
     }
 }
 
@@ -102,6 +141,16 @@ impl FrameGenCount {
             FrameGenCount::X3 => 2,
             FrameGenCount::X4 => 3,
         }
+    }
+
+    pub fn from_value(value: u32) -> Option<Self> {
+        Some(match value {
+            0 => FrameGenCount::AppControlled,
+            1 => FrameGenCount::X2,
+            2 => FrameGenCount::X3,
+            3 => FrameGenCount::X4,
+            _ => return None,
+        })
     }
 }
 
@@ -168,13 +217,61 @@ impl DlssOverrideConfig {
                 value: count.to_value(),
             });
         }
-        if let Some(target_fps) = self.fg_dynamic_target_fps {
+        if let Some(target_fps) = self.fg_dynamic_target_fps.filter(|&fps| fps != 0) {
             settings.push(DrsSetting {
                 id: ids::DLSS_MFG_TARGET_FRAME_RATE,
                 value: target_fps,
             });
         }
         settings
+    }
+
+    pub fn from_drs_settings(settings: &[(u32, Option<u32>)]) -> Self {
+        let get = |id: u32| -> Option<u32> {
+            settings
+                .iter()
+                .find_map(|&(i, v)| (i == id).then_some(v))
+                .flatten()
+        };
+        DlssOverrideConfig {
+            enable_sr_dll_override: get(ids::DLSS_SR_ENABLE_OVERRIDE) == Some(VALUE_ON),
+            sr_preset: get(ids::DLSS_SR_FORCED_PRESET).and_then(DlssPreset::from_value),
+            enable_fg_dll_override: get(ids::DLSS_FG_ENABLE_OVERRIDE) == Some(VALUE_ON),
+            fg_preset: get(ids::DLSS_FG_FORCED_PRESET).and_then(DlssPreset::from_value),
+            fg_mode: get(ids::DLSS_FG_FORCED_MODE).and_then(FrameGenMode::from_value),
+            fg_fixed_count: get(ids::DLSS_MFG_FIXED_COUNT).and_then(FrameGenCount::from_value),
+            fg_dynamic_target_fps: get(ids::DLSS_MFG_TARGET_FRAME_RATE).filter(|&fps| fps != 0),
+        }
+    }
+
+    pub fn active_override_count(&self) -> usize {
+        let mut count = 0;
+        if self.enable_sr_dll_override {
+            count += 1;
+        }
+        if self.enable_fg_dll_override {
+            count += 1;
+        }
+        if matches!(self.sr_preset, Some(p) if p != DlssPreset::Default) {
+            count += 1;
+        }
+        if matches!(self.fg_preset, Some(p) if p != DlssPreset::Default) {
+            count += 1;
+        }
+        if matches!(self.fg_mode, Some(m) if m != FrameGenMode::AppControlled) {
+            count += 1;
+        }
+        if matches!(self.fg_fixed_count, Some(c) if c != FrameGenCount::AppControlled) {
+            count += 1;
+        }
+        if matches!(self.fg_dynamic_target_fps, Some(fps) if fps > 0) {
+            count += 1;
+        }
+        count
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.active_override_count() == 0
     }
 }
 
@@ -188,7 +285,7 @@ mod tests {
         assert_eq!(DlssPreset::J.to_value(), 0x0A);
         assert_eq!(DlssPreset::K.to_value(), 0x0B);
         assert_eq!(DlssPreset::M.to_value(), 0x0D);
-        assert_eq!(DlssPreset::Recommended.to_value(), 0x00FF_FFFE);
+        assert_eq!(DlssPreset::Recommended.to_value(), 0x00FF_FFFF);
         assert_eq!(DlssPreset::Default.to_value(), 0);
     }
 
@@ -260,5 +357,136 @@ mod tests {
     fn resettable_ids_cover_every_override_setting() {
         assert_eq!(RESETTABLE_IDS.len(), 8);
         assert!(RESETTABLE_IDS.contains(&ids::DLSS_FG_FORCED_MODE));
+    }
+
+    #[test]
+    fn preset_from_value_inverts_to_value() {
+        for &preset in &[
+            DlssPreset::Default,
+            DlssPreset::A,
+            DlssPreset::B,
+            DlssPreset::C,
+            DlssPreset::D,
+            DlssPreset::E,
+            DlssPreset::F,
+            DlssPreset::G,
+            DlssPreset::H,
+            DlssPreset::I,
+            DlssPreset::J,
+            DlssPreset::K,
+            DlssPreset::L,
+            DlssPreset::M,
+            DlssPreset::N,
+            DlssPreset::O,
+            DlssPreset::Recommended,
+        ] {
+            assert_eq!(DlssPreset::from_value(preset.to_value()), Some(preset));
+        }
+    }
+
+    #[test]
+    fn preset_from_value_accepts_both_recommended_sentinels() {
+        assert_eq!(
+            DlssPreset::from_value(0x00FF_FFFE),
+            Some(DlssPreset::Recommended)
+        );
+        assert_eq!(
+            DlssPreset::from_value(0x00FF_FFFF),
+            Some(DlssPreset::Recommended)
+        );
+    }
+
+    #[test]
+    fn preset_from_value_covers_full_a_to_o_range_and_rejects_garbage() {
+        assert_eq!(DlssPreset::from_value(0x09), Some(DlssPreset::I));
+        assert_eq!(DlssPreset::from_value(0x0E), Some(DlssPreset::N));
+        assert_eq!(DlssPreset::from_value(0x0F), Some(DlssPreset::O));
+        assert_eq!(DlssPreset::from_value(0x10), None);
+        assert_eq!(DlssPreset::from_value(0xDEAD), None);
+    }
+
+    #[test]
+    fn frame_gen_mode_and_count_from_value_invert() {
+        for &mode in &[
+            FrameGenMode::AppControlled,
+            FrameGenMode::Fixed,
+            FrameGenMode::Dynamic,
+        ] {
+            assert_eq!(FrameGenMode::from_value(mode.to_value()), Some(mode));
+        }
+        assert_eq!(FrameGenMode::from_value(3), None);
+        for &count in &[
+            FrameGenCount::AppControlled,
+            FrameGenCount::X2,
+            FrameGenCount::X3,
+            FrameGenCount::X4,
+        ] {
+            assert_eq!(FrameGenCount::from_value(count.to_value()), Some(count));
+        }
+        assert_eq!(FrameGenCount::from_value(9), None);
+    }
+
+    fn emulate_read(written: &[DrsSetting]) -> Vec<(u32, Option<u32>)> {
+        RESETTABLE_IDS
+            .iter()
+            .map(|&id| (id, written.iter().find(|s| s.id == id).map(|s| s.value)))
+            .collect()
+    }
+
+    #[test]
+    fn config_round_trips_through_drs_settings() {
+        let cfg = DlssOverrideConfig {
+            enable_sr_dll_override: true,
+            sr_preset: Some(DlssPreset::K),
+            enable_fg_dll_override: true,
+            fg_preset: Some(DlssPreset::J),
+            fg_mode: Some(FrameGenMode::Dynamic),
+            fg_fixed_count: Some(FrameGenCount::X4),
+            fg_dynamic_target_fps: Some(240),
+        };
+        let read = emulate_read(&cfg.to_drs_settings());
+        assert_eq!(DlssOverrideConfig::from_drs_settings(&read), cfg);
+    }
+
+    #[test]
+    fn from_drs_settings_decodes_a_globally_set_preset() {
+        let read = vec![(ids::DLSS_SR_FORCED_PRESET, Some(DlssPreset::K.to_value()))];
+        let cfg = DlssOverrideConfig::from_drs_settings(&read);
+        assert_eq!(cfg.sr_preset, Some(DlssPreset::K));
+        assert_eq!(cfg.active_override_count(), 1);
+        assert!(!cfg.is_empty());
+    }
+
+    #[test]
+    fn empty_read_reconstructs_the_default_inactive_config() {
+        let read: Vec<(u32, Option<u32>)> = RESETTABLE_IDS.iter().map(|&id| (id, None)).collect();
+        let cfg = DlssOverrideConfig::from_drs_settings(&read);
+        assert_eq!(cfg, DlssOverrideConfig::default());
+        assert!(cfg.is_empty());
+        assert_eq!(cfg.active_override_count(), 0);
+    }
+
+    #[test]
+    fn unknown_drs_value_degrades_to_none_not_a_wrong_preset() {
+        let read = vec![(ids::DLSS_SR_FORCED_PRESET, Some(0x10))];
+        assert_eq!(DlssOverrideConfig::from_drs_settings(&read).sr_preset, None);
+    }
+
+    #[test]
+    fn zero_target_fps_is_treated_as_unset_both_ways() {
+        let cfg = DlssOverrideConfig {
+            fg_dynamic_target_fps: Some(0),
+            ..Default::default()
+        };
+        assert!(cfg.is_empty());
+        assert!(
+            cfg.to_drs_settings().is_empty(),
+            "a 0 fps target is not a real override and must not be written"
+        );
+        let read = emulate_read(&cfg.to_drs_settings());
+        assert_eq!(
+            DlssOverrideConfig::from_drs_settings(&read).fg_dynamic_target_fps,
+            None
+        );
     }
 }

--- a/crates/system-drivers/Cargo.toml
+++ b/crates/system-drivers/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "system-drivers"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+serde = { workspace = true, features = ["derive"] }
+thiserror.workspace = true
+tracing.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true
+
+[target.'cfg(windows)'.dependencies]
+wmi.workspace = true
+windows = { workspace = true, features = [
+    "Win32_Foundation",
+    "Win32_System_Com",
+    "Win32_System_Ole",
+    "Win32_System_Variant",
+    "Win32_System_UpdateAgent",
+    "Win32_System_Restore",
+] }

--- a/crates/system-drivers/src/classify.rs
+++ b/crates/system-drivers/src/classify.rs
@@ -1,0 +1,280 @@
+//! Device-class taxonomy. Maps the raw class token reported by WMI
+//! (`Win32_PnPSignedDriver.DeviceClass`) or WUA (`IWindowsDriverUpdate.DriverClass`)
+//! onto a small, UI-friendly set. Matching is case-insensitive and
+//! substring-based so vendor variants ("AudioEndpoint", "MEDIA") collapse.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DeviceClass {
+    Audio,
+    Display,
+    Monitor,
+    Network,
+    Bluetooth,
+    Input,
+    Storage,
+    Printer,
+    Camera,
+    Sensor,
+    Battery,
+    SmartCard,
+    Firmware,
+    Chipset,
+    System,
+    Usb,
+    Other,
+}
+
+impl DeviceClass {
+    /// Human label for the UI section header.
+    pub fn label(self) -> &'static str {
+        match self {
+            DeviceClass::Audio => "Audio",
+            DeviceClass::Display => "Display",
+            DeviceClass::Monitor => "Monitors",
+            DeviceClass::Network => "Network",
+            DeviceClass::Bluetooth => "Bluetooth",
+            DeviceClass::Input => "Keyboard & Mouse",
+            DeviceClass::Storage => "Storage",
+            DeviceClass::Printer => "Printers",
+            DeviceClass::Camera => "Cameras & Imaging",
+            DeviceClass::Sensor => "Sensors",
+            DeviceClass::Battery => "Battery & Power",
+            DeviceClass::SmartCard => "Smart Card Readers",
+            DeviceClass::Firmware => "Firmware",
+            DeviceClass::Chipset => "Chipset",
+            DeviceClass::System => "System",
+            DeviceClass::Usb => "USB Controllers",
+            DeviceClass::Other => "Other Components",
+        }
+    }
+}
+
+/// Best-effort classification from a WUA driver's class token *and* its title.
+/// WUA's `DriverClass` is frequently empty or unhelpful for software-component
+/// / extension drivers (AudioProcessingObject, Nahimic, generic Monitor INF),
+/// so when the class token yields `Other` we re-classify from the human title
+/// ("A-Volute AudioProcessingObject…" → Audio, "Dell — Monitor — …" → Display).
+pub fn classify_best(class_token: &str, title: &str) -> DeviceClass {
+    let by_class = classify(class_token);
+    if by_class == DeviceClass::Audio && is_capture_device(title) {
+        return DeviceClass::Camera;
+    }
+    if by_class != DeviceClass::Other {
+        return by_class;
+    }
+    classify(title)
+}
+
+/// True when free text names a TV tuner / capture card / camera — used to keep
+/// `MEDIA`-class capture hardware out of the Audio bucket.
+fn is_capture_device(text: &str) -> bool {
+    let s = text.to_ascii_uppercase();
+    ["TUNER", "CAPTURE", "WEBCAM", "CAMERA"]
+        .iter()
+        .any(|t| s.contains(t))
+}
+
+/// Classify a raw class token. Order matters: more specific tokens are tested
+/// before broad ones (e.g. an HID keyboard is `Input`, not `System`).
+pub fn classify(raw: &str) -> DeviceClass {
+    let s = raw.trim().to_ascii_uppercase();
+    let has = |needle: &str| s.contains(needle);
+
+    let is_capture =
+        has("TUNER") || has("CAPTURE") || has("CAMERA") || has("WEBCAM") || has("IMAGE");
+
+    if has("MONITOR") {
+        DeviceClass::Monitor
+    } else if (has("AUDIO") || s == "SOUND") || (has("MEDIA") && !is_capture) {
+        DeviceClass::Audio
+    } else if has("BLUETOOTH") {
+        DeviceClass::Bluetooth
+    } else if has("DISPLAY") {
+        DeviceClass::Display
+    } else if has("HID") || has("KEYBOARD") || has("MOUSE") {
+        DeviceClass::Input
+    } else if has("PRINT") {
+        DeviceClass::Printer
+    } else if is_capture {
+        DeviceClass::Camera
+    } else if has("SMARTCARD") || has("SMART CARD") {
+        DeviceClass::SmartCard
+    } else if has("BIOMETRIC") || has("SENSOR") {
+        DeviceClass::Sensor
+    } else if has("BATTERY") {
+        DeviceClass::Battery
+    } else if has("FIRMWARE") {
+        DeviceClass::Firmware
+    } else if has("NET") {
+        DeviceClass::Network
+    } else if has("USB") {
+        DeviceClass::Usb
+    } else if has("DISK")
+        || has("SCSI")
+        || has("STORAGE")
+        || has("HDC")
+        || has("VOLUME")
+        || has("NVME")
+    {
+        DeviceClass::Storage
+    } else if has("CHIPSET")
+        || has("SMBUS")
+        || has("SM BUS")
+        || has("HOSTBRIDGE")
+        || has("HOST BRIDGE")
+        || has("PCI BRIDGE")
+    {
+        DeviceClass::Chipset
+    } else if has("SYSTEM")
+        || has("PROCESSOR")
+        || has("COMPUTER")
+        || has("SOFTWARECOMPONENT")
+        || has("SOFTWAREDEVICE")
+        || has("EXTENSION")
+    {
+        DeviceClass::System
+    } else {
+        DeviceClass::Other
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_common_classes() {
+        assert_eq!(classify("MEDIA"), DeviceClass::Audio);
+        assert_eq!(classify("AudioEndpoint"), DeviceClass::Audio);
+        assert_eq!(classify("Display"), DeviceClass::Display);
+        assert_eq!(classify("Monitor"), DeviceClass::Monitor);
+        assert_eq!(classify("Net"), DeviceClass::Network);
+        assert_eq!(classify("Bluetooth"), DeviceClass::Bluetooth);
+        assert_eq!(classify("HIDClass"), DeviceClass::Input);
+        assert_eq!(classify("Keyboard"), DeviceClass::Input);
+        assert_eq!(classify("Mouse"), DeviceClass::Input);
+        assert_eq!(classify("USB"), DeviceClass::Usb);
+        assert_eq!(classify("DiskDrive"), DeviceClass::Storage);
+        assert_eq!(classify("System"), DeviceClass::System);
+        assert_eq!(classify("Processor"), DeviceClass::System);
+        assert_eq!(classify("Printer"), DeviceClass::Printer);
+        assert_eq!(classify("Image"), DeviceClass::Camera);
+        assert_eq!(classify("Firmware"), DeviceClass::Firmware);
+        assert_eq!(classify("Whatever"), DeviceClass::Other);
+    }
+
+    #[test]
+    fn hid_keyboard_beats_system() {
+        assert_eq!(classify("HIDClass"), DeviceClass::Input);
+    }
+
+    #[test]
+    fn audio_before_media_ambiguity() {
+        assert_eq!(classify("AUDIOENDPOINT"), DeviceClass::Audio);
+        assert_eq!(classify("MEDIA"), DeviceClass::Audio);
+    }
+
+    #[test]
+    fn classify_best_falls_back_to_title() {
+        assert_eq!(
+            classify_best("", "A-Volute AudioProcessingObject Driver Update (1.1.4.0)"),
+            DeviceClass::Audio
+        );
+        assert_eq!(
+            classify_best(
+                "SoftwareComponent",
+                "Nahimic SoftwareComponent Driver Update"
+            ),
+            DeviceClass::System
+        );
+        assert_eq!(
+            classify_best("", "Dell Inc. - Monitor - 9/2/2015 12:00:00 AM - 1.0.0.0"),
+            DeviceClass::Monitor
+        );
+        assert_eq!(
+            classify_best("", "Realtek Driver Update (1.0.934.0) - MEDIA"),
+            DeviceClass::Audio
+        );
+        assert_eq!(
+            classify_best("", "HID-compliant vendor-defined device"),
+            DeviceClass::Input
+        );
+        assert_eq!(
+            classify_best("Net", "Some vague title"),
+            DeviceClass::Network
+        );
+        assert_eq!(
+            classify_best("", "Micro-Star INT'L CO., LTD. Driver Update"),
+            DeviceClass::Other
+        );
+    }
+
+    #[test]
+    fn labels_are_nonempty() {
+        for c in [
+            DeviceClass::Audio,
+            DeviceClass::Display,
+            DeviceClass::Monitor,
+            DeviceClass::Network,
+            DeviceClass::Bluetooth,
+            DeviceClass::Input,
+            DeviceClass::Storage,
+            DeviceClass::Printer,
+            DeviceClass::Camera,
+            DeviceClass::Sensor,
+            DeviceClass::Battery,
+            DeviceClass::SmartCard,
+            DeviceClass::Firmware,
+            DeviceClass::Chipset,
+            DeviceClass::System,
+            DeviceClass::Usb,
+            DeviceClass::Other,
+        ] {
+            assert!(!c.label().is_empty());
+        }
+    }
+
+    #[test]
+    fn media_tuner_is_not_audio() {
+        assert_eq!(classify("MEDIA"), DeviceClass::Audio);
+        assert_eq!(
+            classify_best("MEDIA", "Hauppauge WinTV TV Tuner"),
+            DeviceClass::Camera
+        );
+        assert_eq!(
+            classify_best("MEDIA", "Elgato Game Capture HD60"),
+            DeviceClass::Camera
+        );
+    }
+
+    #[test]
+    fn monitor_splits_from_display() {
+        assert_eq!(classify("Monitor"), DeviceClass::Monitor);
+        assert_eq!(classify("Display"), DeviceClass::Display);
+    }
+
+    #[test]
+    fn chipset_splits_from_system() {
+        assert_eq!(classify("Chipset"), DeviceClass::Chipset);
+        assert_eq!(classify("SMBUS Controller"), DeviceClass::Chipset);
+        assert_eq!(classify("PCI Bridge"), DeviceClass::Chipset);
+        assert_eq!(classify("System"), DeviceClass::System);
+        assert_eq!(classify("SoftwareComponent"), DeviceClass::System);
+    }
+
+    #[test]
+    fn sensor_battery_smartcard_classified() {
+        assert_eq!(classify("Sensor"), DeviceClass::Sensor);
+        assert_eq!(classify("Biometric"), DeviceClass::Sensor);
+        assert_eq!(classify("Battery"), DeviceClass::Battery);
+        assert_eq!(classify("SmartCardReader"), DeviceClass::SmartCard);
+    }
+
+    #[test]
+    fn net_token_beats_usb() {
+        assert_eq!(classify("USB\\Net wireless adapter"), DeviceClass::Network);
+    }
+}

--- a/crates/system-drivers/src/inventory.rs
+++ b/crates/system-drivers/src/inventory.rs
@@ -1,0 +1,134 @@
+//! Windows device inventory via WMI `Win32_PnPSignedDriver`.
+
+use std::collections::HashMap;
+
+use crate::{classify, dedup_devices, filter_present, DeviceCatalog, DriverError, SystemDevice};
+
+type WmiRow = HashMap<String, wmi::Variant>;
+
+/// Live WMI-backed device catalog.
+pub struct WmiInventory;
+
+impl DeviceCatalog for WmiInventory {
+    fn inventory(&self) -> Result<Vec<SystemDevice>, DriverError> {
+        let rows = query(
+            "SELECT DeviceName, DeviceClass, Manufacturer, DriverVersion, DriverDate, DeviceID, \
+             InfName FROM Win32_PnPSignedDriver",
+        )
+        .map_err(DriverError::Inventory)?;
+        let devices: Vec<SystemDevice> = rows.iter().filter_map(device_from_row).collect();
+        Ok(dedup_devices(filter_present(devices)))
+    }
+}
+
+fn query(q: &str) -> Result<Vec<WmiRow>, String> {
+    let com = wmi::COMLibrary::new().map_err(|e| format!("COM: {e}"))?;
+    let conn = wmi::WMIConnection::new(com).map_err(|e| format!("WMI: {e}"))?;
+    conn.raw_query(q).map_err(|e| format!("query: {e}"))
+}
+
+/// Map a single WMI row into a [`SystemDevice`]. Rows lacking both a name and a
+/// hardware id are skipped (virtual/placeholder entries).
+fn device_from_row(row: &WmiRow) -> Option<SystemDevice> {
+    let hardware_id = string_field(row, "DeviceID")?.to_ascii_uppercase();
+    let name = string_field(row, "DeviceName")
+        .or_else(|| string_field(row, "Manufacturer"))
+        .unwrap_or_else(|| "Unknown device".to_string());
+    let class = classify(&string_field(row, "DeviceClass").unwrap_or_default());
+    let manufacturer = string_field(row, "Manufacturer").unwrap_or_default();
+    let driver_version = string_field(row, "DriverVersion").filter(|s| !s.is_empty());
+    let driver_date = string_field(row, "DriverDate").and_then(|s| cim_to_iso(&s));
+    let inf_name = string_field(row, "InfName").map(|s| s.to_ascii_lowercase());
+
+    Some(SystemDevice {
+        name,
+        class,
+        manufacturer,
+        driver_version,
+        driver_date,
+        hardware_id,
+        inf_name,
+        present: true,
+    })
+}
+
+fn string_field(row: &WmiRow, key: &str) -> Option<String> {
+    match row.get(key)? {
+        wmi::Variant::String(s) if !s.is_empty() => Some(s.clone()),
+        _ => None,
+    }
+}
+
+/// Convert a WMI CIM_DATETIME (`yyyymmddHHMMSS.ffffff±UUU`) into ISO
+/// `YYYY-MM-DD`. Returns `None` for malformed/empty input.
+pub fn cim_to_iso(cim: &str) -> Option<String> {
+    let digits: String = cim.chars().take(8).collect();
+    if digits.len() != 8 || !digits.chars().all(|c| c.is_ascii_digit()) {
+        return None;
+    }
+    let (y, rest) = digits.split_at(4);
+    let (m, d) = rest.split_at(2);
+    if m == "00" || d == "00" {
+        return None;
+    }
+    Some(format!("{y}-{m}-{d}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_cim_datetime() {
+        assert_eq!(
+            cim_to_iso("20260406000000.000000-000").as_deref(),
+            Some("2026-04-06")
+        );
+        assert_eq!(
+            cim_to_iso("20251231235959.999999+000").as_deref(),
+            Some("2025-12-31")
+        );
+        assert_eq!(cim_to_iso("").as_deref(), None);
+        assert_eq!(cim_to_iso("garbage").as_deref(), None);
+        assert_eq!(cim_to_iso("20260000000000.000000-000").as_deref(), None);
+    }
+
+    #[test]
+    fn maps_row_to_device() {
+        let mut row: WmiRow = HashMap::new();
+        row.insert(
+            "DeviceID".into(),
+            wmi::Variant::String(r"pci\ven_8086&dev_9a49\x".into()),
+        );
+        row.insert(
+            "DeviceName".into(),
+            wmi::Variant::String("Intel(R) UHD Graphics".into()),
+        );
+        row.insert("DeviceClass".into(), wmi::Variant::String("DISPLAY".into()));
+        row.insert(
+            "Manufacturer".into(),
+            wmi::Variant::String("Intel Corporation".into()),
+        );
+        row.insert(
+            "DriverVersion".into(),
+            wmi::Variant::String("31.0.101.2141".into()),
+        );
+        row.insert(
+            "DriverDate".into(),
+            wmi::Variant::String("20260406000000.000000-000".into()),
+        );
+
+        let d = device_from_row(&row).expect("device");
+        assert_eq!(d.hardware_id, r"PCI\VEN_8086&DEV_9A49\X");
+        assert_eq!(d.class, classify::DeviceClass::Display);
+        assert_eq!(d.driver_version.as_deref(), Some("31.0.101.2141"));
+        assert_eq!(d.driver_date.as_deref(), Some("2026-04-06"));
+    }
+
+    #[test]
+    fn skips_row_without_hardware_id() {
+        let mut row: WmiRow = HashMap::new();
+        row.insert("DeviceName".into(), wmi::Variant::String("Phantom".into()));
+        assert!(device_from_row(&row).is_none());
+    }
+}

--- a/crates/system-drivers/src/lib.rs
+++ b/crates/system-drivers/src/lib.rs
@@ -1,0 +1,1000 @@
+//! General PC driver engine — audio, network, Bluetooth, input, storage,
+//! chipset, USB, firmware, cameras, printers.
+//!
+//! Source of truth = the **Windows Update Agent (WUA) COM API** opted into the
+//! **Microsoft Update Catalog**, inventoried per device through WMI
+//! `Win32_PnPSignedDriver`. Only vendor-signed drivers Microsoft already
+//! distributes are offered — no OEM-site scraping (that is what makes other
+//! "driver booster" tools fragile and unsafe). An anti-downgrade guard refuses
+//! any candidate that is not provably newer than the installed driver.
+//!
+//! The COM/WMI surface lives behind the [`DeviceCatalog`] and [`UpdateSource`]
+//! traits so the orchestration (matching + anti-downgrade + grouping) is pure
+//! and unit-tested without a live Windows Update service.
+
+mod classify;
+mod snapshot;
+mod store;
+mod version;
+
+pub use classify::{classify, classify_best, DeviceClass};
+pub use snapshot::{
+    add_driver_install_args, export_driver_args, is_published_oem_inf, restore_inf_glob,
+};
+pub use store::{parse_enum_drivers, versions_by_original_name, DriverStorePackage};
+pub use version::{extract_version, is_newer, ole_date_to_iso, DriverVersion};
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+#[cfg(windows)]
+mod inventory;
+#[cfg(windows)]
+mod wua;
+
+#[cfg(windows)]
+pub use inventory::WmiInventory;
+#[cfg(windows)]
+pub use snapshot::win as driver_snapshot;
+#[cfg(windows)]
+pub use wua::WuaSource;
+
+#[derive(Debug, thiserror::Error)]
+pub enum DriverError {
+    #[error("device inventory failed: {0}")]
+    Inventory(String),
+    #[error("update search failed: {0}")]
+    Search(String),
+    #[error("install failed: {0}")]
+    Install(String),
+    #[error("update not found: {0}")]
+    NotFound(String),
+}
+
+/// An installed device + its current driver, from WMI `Win32_PnPSignedDriver`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SystemDevice {
+    pub name: String,
+    pub class: DeviceClass,
+    pub manufacturer: String,
+    pub driver_version: Option<String>,
+    /// ISO `YYYY-MM-DD`.
+    pub driver_date: Option<String>,
+    /// Raw hardware id (uppercased), e.g. `PCI\VEN_8086&DEV_9A49&SUBSYS_...`.
+    pub hardware_id: String,
+    /// The DriverStore published INF name for the installed driver, e.g.
+    /// `oem47.inf`, from WMI `InfName`. The handle `pnputil /export-driver`
+    /// needs to snapshot this device's current driver before an update.
+    #[serde(default)]
+    pub inf_name: Option<String>,
+    /// Whether the device is currently present (vs a phantom/ghost of removed
+    /// hardware). Defaults to `true` so older payloads and tests stay valid.
+    #[serde(default = "default_present")]
+    pub present: bool,
+}
+
+fn default_present() -> bool {
+    true
+}
+
+/// A candidate driver offered by Windows Update / the Microsoft Update Catalog.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct DriverUpdate {
+    /// `UpdateID:RevisionNumber` — the stable handle used to install.
+    pub update_id: String,
+    pub title: String,
+    pub class: DeviceClass,
+    pub provider: String,
+    pub driver_version: Option<String>,
+    /// ISO `YYYY-MM-DD` from `DriverVerDate`.
+    pub driver_date: Option<String>,
+    pub hardware_id: Option<String>,
+    pub size_bytes: u64,
+    /// Name of the installed device this update targets, when resolved.
+    pub target_device: Option<String>,
+    /// Installed driver version on the matched device, when resolved (for current→new display).
+    pub current_version: Option<String>,
+    /// DriverStore published INF (`oemNN.inf`) of the matched installed device,
+    /// so the install can snapshot the current driver before replacing it.
+    #[serde(default)]
+    pub target_inf: Option<String>,
+    /// Raw hardware id of the matched installed device (for the backup row).
+    #[serde(default)]
+    pub target_hardware_id: Option<String>,
+    /// Vendor support / "more info" page exposed by Windows Update, when present.
+    pub support_url: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum InstallStage {
+    Downloading,
+    Installing,
+    Completed,
+    Failed,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InstallProgress {
+    pub stage: InstallStage,
+    pub message: String,
+    pub fraction: Option<f64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InstallReport {
+    pub success: bool,
+    pub reboot_required: bool,
+    pub result_code: i32,
+    pub message: String,
+}
+
+/// Per-class group of available updates, for the UI's "System & Components" view.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeviceGroup {
+    pub class: DeviceClass,
+    pub label: String,
+    pub updates: Vec<DriverUpdate>,
+}
+
+/// Device inventory provider (WMI on Windows; fakeable in tests).
+pub trait DeviceCatalog {
+    fn inventory(&self) -> Result<Vec<SystemDevice>, DriverError>;
+}
+
+/// Driver update provider (WUA on Windows; fakeable in tests).
+pub trait UpdateSource {
+    fn search(&self) -> Result<Vec<DriverUpdate>, DriverError>;
+    fn install(
+        &self,
+        update_id: &str,
+        on_progress: &mut dyn FnMut(InstallProgress),
+    ) -> Result<InstallReport, DriverError>;
+}
+
+/// Pick the first genuinely useful vendor/info URL from WUA's candidates
+/// (`MoreInfoUrls` entries first, then `SupportUrl`). Windows Update very often
+/// returns the generic, 404-ing support hub (`support.microsoft.com/.../select/
+/// ?target=hub`); those — and non-http/empty values — are rejected so the UI can
+/// fall back to a real Microsoft Update Catalog search instead.
+pub fn pick_support_url(candidates: &[String]) -> Option<String> {
+    candidates
+        .iter()
+        .map(|s| s.trim())
+        .find(|s| is_useful_support_url(s))
+        .map(|s| s.to_string())
+}
+
+fn is_useful_support_url(u: &str) -> bool {
+    if !(u.starts_with("http://") || u.starts_with("https://")) {
+        return false;
+    }
+    !u.to_ascii_lowercase().contains("microsoft.com")
+}
+
+/// PCI vendor id of NVIDIA.
+pub const VEN_NVIDIA: &str = "VEN_10DE";
+/// PCI vendor id of AMD.
+pub const VEN_AMD: &str = "VEN_1002";
+/// PCI vendor id of Intel (covers Intel display-class iGPUs).
+pub const VEN_INTEL: &str = "VEN_8086";
+
+/// True when a hardware id + class describe a graphics adapter (discrete or
+/// integrated) rather than a monitor panel. The dedicated GPU updater owns
+/// these, so System & Components excludes them: a PCI `Display`-class device
+/// whose vendor is one of the three GPU silicon vendors.
+pub fn is_gpu(hardware_id: &str, class: DeviceClass) -> bool {
+    if class != DeviceClass::Display {
+        return false;
+    }
+    let s = hardware_id.to_ascii_uppercase();
+    if !s.starts_with("PCI\\") {
+        return false;
+    }
+    matches!(
+        hwid_core(&s).map(|(v, _)| v),
+        Some(v) if v == VEN_NVIDIA || v == VEN_AMD || v == VEN_INTEL
+    )
+}
+
+/// Extract `(vendor_token, device_token)` — e.g. `("VEN_8086", "DEV_9A49")` or
+/// `("VID_046D", "PID_C52B")` — from a hardware id, ignoring the `SUBSYS`/`REV`
+/// /instance suffixes. Both tokens must come from the SAME `\`-delimited
+/// segment so a compound id cannot pair a vendor from one device with a device
+/// id from another. Returns `None` when no single segment carries both.
+pub fn hwid_core(raw: &str) -> Option<(String, String)> {
+    let s = raw.to_ascii_uppercase();
+    for segment in s.split('\\') {
+        let vendor = find_token(segment, &["VEN_", "VID_"]);
+        let device = find_token(segment, &["DEV_", "PID_"]);
+        if let (Some(v), Some(d)) = (vendor, device) {
+            return Some((v, d));
+        }
+    }
+    None
+}
+
+fn find_token(s: &str, prefixes: &[&str]) -> Option<String> {
+    for p in prefixes {
+        if let Some(idx) = s.find(p) {
+            let start = idx;
+            let rest = &s[idx + p.len()..];
+            let hex: String = rest.chars().take_while(|c| c.is_ascii_hexdigit()).collect();
+            if !hex.is_empty() {
+                return Some(format!("{}{}", &s[start..idx + p.len()], hex));
+            }
+        }
+    }
+    None
+}
+
+/// A normalized comparison key for an installed device or an update, broad
+/// enough that the anti-downgrade guard fires on the device classes WUA most
+/// often downgrades — chipset/ACPI, OEM-audio APO (`SWC\`), HD-audio codecs and
+/// monitors — not just clean `PCI\VEN&DEV` hardware. Falls back to the leading
+/// enumerator-specific segment so two nodes of the same physical device share a
+/// key. `None` only for ids with no usable discriminator.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum HwidKey {
+    /// `(vendor_token, device_token)` from a single segment.
+    VenDev(String, String),
+    /// Monitor EDID id, e.g. `DISPLAY\DELA1A3` → `DELA1A3`.
+    Monitor(String),
+    /// ACPI / SWC / generic enumerator key, e.g. `ACPI\INTC1234` → `INTC1234`,
+    /// `SWC\VEN_...&DEV_...` collapses via [`HwidKey::VenDev`].
+    Enumerator(String, String),
+}
+
+/// Derive the broadened [`HwidKey`] used for matching + dedup.
+pub fn hwid_key(raw: &str) -> Option<HwidKey> {
+    if let Some((v, d)) = hwid_core(raw) {
+        return Some(HwidKey::VenDev(v, d));
+    }
+    let s = raw.trim().to_ascii_uppercase();
+    let mut parts = s.split('\\');
+    let enumerator = parts.next()?;
+    let descriptor = parts.next()?.trim();
+    if descriptor.is_empty() {
+        return None;
+    }
+    if enumerator == "DISPLAY" {
+        return Some(HwidKey::Monitor(descriptor.to_string()));
+    }
+    Some(HwidKey::Enumerator(
+        enumerator.to_string(),
+        descriptor.to_string(),
+    ))
+}
+
+/// True when an update's hardware id targets the given installed device, using
+/// the broadened [`HwidKey`] so ACPI/SWC/monitor devices match (and are then
+/// anti-downgrade checked) instead of silently passing unverified.
+pub fn matches_device(update: &DriverUpdate, device: &SystemDevice) -> bool {
+    match (
+        update.hardware_id.as_deref().and_then(hwid_key),
+        hwid_key(&device.hardware_id),
+    ) {
+        (Some(u), Some(d)) => u == d,
+        _ => false,
+    }
+}
+
+/// Drop phantom / non-present devices (ghosts of removed hardware) so updates
+/// cannot match hardware that is no longer installed.
+pub fn filter_present(devices: Vec<SystemDevice>) -> Vec<SystemDevice> {
+    devices.into_iter().filter(|d| d.present).collect()
+}
+
+/// Stable dedup key for one physical device: its [`HwidKey`] when derivable,
+/// else the leading two `\`-segments of the raw id (the enumerator + instance
+/// prefix) so multi-node devices collapse to one.
+fn device_dedup_key(hardware_id: &str) -> String {
+    if let Some(key) = hwid_key(hardware_id) {
+        return format!("{key:?}");
+    }
+    let s = hardware_id.to_ascii_uppercase();
+    s.split('\\').take(2).collect::<Vec<_>>().join("\\")
+}
+
+/// Collapse multi-node inventory rows (HD-audio `FUNC_xx`, USB-composite
+/// `MI_xx`, per-monitor INF entries) to one representative per physical device.
+/// The representative keeps the richest `DeviceName` and the newest
+/// `DriverDate`. Order of first appearance is preserved.
+pub fn dedup_devices(devices: Vec<SystemDevice>) -> Vec<SystemDevice> {
+    let mut order: Vec<String> = Vec::new();
+    let mut best: std::collections::HashMap<String, SystemDevice> =
+        std::collections::HashMap::new();
+    for dev in devices {
+        let key = device_dedup_key(&dev.hardware_id);
+        match best.get_mut(&key) {
+            None => {
+                order.push(key.clone());
+                best.insert(key, dev);
+            }
+            Some(cur) => {
+                if dev.name.len() > cur.name.len() {
+                    cur.name = dev.name.clone();
+                }
+                if dev.driver_date.as_deref() > cur.driver_date.as_deref() {
+                    cur.driver_date = dev.driver_date.clone();
+                    cur.driver_version = dev.driver_version.clone();
+                    cur.inf_name = dev.inf_name.clone();
+                }
+            }
+        }
+    }
+    order.into_iter().filter_map(|k| best.remove(&k)).collect()
+}
+
+/// Rank provider `a` against `b` for one device: `Less` when `a` is the better
+/// match for the device manufacturer (so it sorts first), `Greater` when `b`
+/// is, `Equal` when neither wins. An OEM/silicon-vendor provider outranks a
+/// Microsoft-generic one via a normalized lowercase token-overlap.
+fn provider_prefers(a: &str, b: &str, manufacturer: &str) -> std::cmp::Ordering {
+    let score = |p: &str| brand_affinity(p, manufacturer);
+    score(b).cmp(&score(a))
+}
+
+fn brand_affinity(provider: &str, manufacturer: &str) -> u8 {
+    let p = provider.to_ascii_lowercase();
+    let m = manufacturer.to_ascii_lowercase();
+    if p.is_empty() {
+        return 0;
+    }
+    if p.contains("microsoft") {
+        return 1;
+    }
+    let token = m.split_whitespace().next().unwrap_or("");
+    if !token.is_empty()
+        && (p.contains(token) || m.contains(p.split_whitespace().next().unwrap_or("")))
+    {
+        return 3;
+    }
+    2
+}
+
+/// True when an update describes a GPU driver (so System & Components drops it;
+/// the dedicated GPU updater owns it). An update is a GPU when its own hardware
+/// id is a GPU, or when it resolves to a GPU among the installed devices.
+fn update_is_gpu(update: &DriverUpdate, devices: &[SystemDevice]) -> bool {
+    if let Some(hwid) = update.hardware_id.as_deref() {
+        if is_gpu(hwid, update.class) {
+            return true;
+        }
+    }
+    devices
+        .iter()
+        .filter(|d| is_gpu(&d.hardware_id, d.class))
+        .any(|d| matches_device(update, d))
+}
+
+/// Anti-downgrade guard: keep only updates that are provably newer than the
+/// matched installed driver. GPU updates are excluded (the dedicated GPU
+/// updater owns them). Updates with no resolvable installed device are kept
+/// (WUA already deemed them applicable; we cannot prove a downgrade), and
+/// annotated with the matched device name when there is one.
+pub fn filter_safe_updates(
+    devices: &[SystemDevice],
+    updates: Vec<DriverUpdate>,
+) -> Vec<DriverUpdate> {
+    updates
+        .into_iter()
+        .filter_map(|mut up| {
+            if update_is_gpu(&up, devices) {
+                return None;
+            }
+            if let Some(dev) = devices.iter().find(|d| matches_device(&up, d)) {
+                let newer = is_newer(
+                    up.driver_date.as_deref(),
+                    up.driver_version.as_deref(),
+                    dev.driver_date.as_deref(),
+                    dev.driver_version.as_deref(),
+                );
+                if !newer {
+                    return None;
+                }
+                up.class = dev.class;
+                up.target_device = Some(dev.name.clone());
+                up.current_version = dev.driver_version.clone();
+                up.target_inf = dev.inf_name.clone();
+                up.target_hardware_id = Some(dev.hardware_id.clone());
+            }
+            Some(up)
+        })
+        .collect()
+}
+
+/// Collapse duplicate updates that target the same device. The Microsoft Update
+/// Catalog routinely returns one driver several times (overlapping providers,
+/// stale revisions); keep one winner per `(HwidKey-or-normalized-title)` group:
+/// the OEM/silicon-vendor provider over a Microsoft-generic one (matched to the
+/// installed device's manufacturer), then the newest by [`is_newer`]. Updates
+/// with no derivable group key pass through untouched.
+pub fn dedup_updates(devices: &[SystemDevice], updates: Vec<DriverUpdate>) -> Vec<DriverUpdate> {
+    let manufacturer_of = |up: &DriverUpdate| -> String {
+        devices
+            .iter()
+            .find(|d| matches_device(up, d))
+            .map(|d| d.manufacturer.clone())
+            .unwrap_or_default()
+    };
+    let group_key = |up: &DriverUpdate| -> Option<String> {
+        if let Some(k) = up.hardware_id.as_deref().and_then(hwid_key) {
+            return Some(format!("{k:?}"));
+        }
+        let t = up.title.to_ascii_lowercase();
+        if t.trim().is_empty() {
+            None
+        } else {
+            Some(t)
+        }
+    };
+
+    let mut order: Vec<String> = Vec::new();
+    let mut best: std::collections::HashMap<String, DriverUpdate> =
+        std::collections::HashMap::new();
+    let mut passthrough: Vec<DriverUpdate> = Vec::new();
+
+    for up in updates {
+        let Some(key) = group_key(&up) else {
+            passthrough.push(up);
+            continue;
+        };
+        match best.remove(&key) {
+            None => {
+                order.push(key.clone());
+                best.insert(key, up);
+            }
+            Some(cur) => {
+                let manufacturer = manufacturer_of(&up);
+                let keep_new = match provider_prefers(&up.provider, &cur.provider, &manufacturer) {
+                    std::cmp::Ordering::Less => true,
+                    std::cmp::Ordering::Greater => false,
+                    std::cmp::Ordering::Equal => is_newer(
+                        up.driver_date.as_deref(),
+                        up.driver_version.as_deref(),
+                        cur.driver_date.as_deref(),
+                        cur.driver_version.as_deref(),
+                    ),
+                };
+                best.insert(key, if keep_new { up } else { cur });
+            }
+        }
+    }
+
+    let mut out: Vec<DriverUpdate> = order.into_iter().filter_map(|k| best.remove(&k)).collect();
+    out.append(&mut passthrough);
+    out
+}
+
+/// Group safe updates by device class, newest-titled first within a group,
+/// classes in their enum order. Empty classes are omitted.
+pub fn group_by_class(updates: Vec<DriverUpdate>) -> Vec<DeviceGroup> {
+    let mut by_class: BTreeMap<DeviceClass, Vec<DriverUpdate>> = BTreeMap::new();
+    for up in updates {
+        by_class.entry(up.class).or_default().push(up);
+    }
+    by_class
+        .into_iter()
+        .map(|(class, mut updates)| {
+            updates.sort_by(|a, b| a.title.cmp(&b.title));
+            DeviceGroup {
+                class,
+                label: class.label().to_string(),
+                updates,
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dev(name: &str, class: DeviceClass, hwid: &str, ver: &str, date: &str) -> SystemDevice {
+        SystemDevice {
+            name: name.into(),
+            class,
+            manufacturer: "Test".into(),
+            driver_version: Some(ver.into()),
+            driver_date: Some(date.into()),
+            hardware_id: hwid.into(),
+            inf_name: None,
+            present: true,
+        }
+    }
+
+    fn dev_mfg(
+        name: &str,
+        class: DeviceClass,
+        hwid: &str,
+        ver: &str,
+        date: &str,
+        manufacturer: &str,
+    ) -> SystemDevice {
+        SystemDevice {
+            manufacturer: manufacturer.into(),
+            ..dev(name, class, hwid, ver, date)
+        }
+    }
+
+    fn upd(
+        title: &str,
+        class: DeviceClass,
+        hwid: Option<&str>,
+        ver: Option<&str>,
+        date: &str,
+    ) -> DriverUpdate {
+        DriverUpdate {
+            update_id: format!("{title}:1"),
+            title: title.into(),
+            class,
+            provider: "Test".into(),
+            driver_version: ver.map(Into::into),
+            driver_date: Some(date.into()),
+            hardware_id: hwid.map(Into::into),
+            size_bytes: 1000,
+            target_device: None,
+            current_version: None,
+            target_inf: None,
+            target_hardware_id: None,
+            support_url: None,
+        }
+    }
+
+    #[test]
+    fn pick_support_url_rejects_generic_hub_and_prefers_real() {
+        assert_eq!(
+            pick_support_url(&["https://support.microsoft.com/en-us/select/?target=hub".into()]),
+            None
+        );
+        assert_eq!(
+            pick_support_url(&[
+                "https://learn.microsoft.com/en-us/windows-hardware/drivers/dashboard/hardware-submission-support".into(),
+                "http://sysdev.microsoft.com/support/default.aspx".into(),
+            ]),
+            None
+        );
+        assert_eq!(
+            pick_support_url(&["https://www.dell.com/support/home/drivers/123".into()]).as_deref(),
+            Some("https://www.dell.com/support/home/drivers/123")
+        );
+        assert_eq!(
+            pick_support_url(&[
+                "  ".into(),
+                "https://support.microsoft.com/en-us/select/?target=hub".into(),
+                "https://www.realtek.com/downloads/audio".into(),
+            ])
+            .as_deref(),
+            Some("https://www.realtek.com/downloads/audio")
+        );
+        assert_eq!(
+            pick_support_url(&["".into(), "ftp://x".into(), "javascript:1".into()]),
+            None
+        );
+    }
+
+    #[test]
+    fn hwid_core_extracts_pair_ignoring_suffix() {
+        assert_eq!(
+            hwid_core(r"PCI\VEN_8086&DEV_9A49&SUBSYS_22128086&REV_01\3&11583659&0&10"),
+            Some(("VEN_8086".into(), "DEV_9A49".into()))
+        );
+        assert_eq!(
+            hwid_core(r"USB\VID_046D&PID_C52B\5&abc"),
+            Some(("VID_046D".into(), "PID_C52B".into()))
+        );
+        assert_eq!(hwid_core("ROOT\\SYSTEM"), None);
+    }
+
+    #[test]
+    fn matches_device_by_ven_dev_across_casing_and_suffix() {
+        let d = dev(
+            "Intel UHD",
+            DeviceClass::Display,
+            r"PCI\VEN_8086&DEV_9A49&SUBSYS_X&REV_01\inst",
+            "31.0.101.999",
+            "2026-04-06",
+        );
+        let u = upd(
+            "Intel - Display - 31.0.101.2141",
+            DeviceClass::Display,
+            Some(r"pci\ven_8086&dev_9a49"),
+            Some("31.0.101.2141"),
+            "2026-05-15",
+        );
+        assert!(matches_device(&u, &d));
+    }
+
+    #[test]
+    fn anti_downgrade_drops_older_and_equal() {
+        let devices = vec![dev(
+            "Intel Wi-Fi 6 AX201",
+            DeviceClass::Network,
+            r"PCI\VEN_8086&DEV_A0F0\x",
+            "22.100.0.2141",
+            "2026-04-06",
+        )];
+        let older = upd(
+            "Intel - Net - 22.100.0.500",
+            DeviceClass::Network,
+            Some(r"pci\ven_8086&dev_a0f0"),
+            Some("22.100.0.500"),
+            "2026-01-01",
+        );
+        let same = upd(
+            "Intel - Net - 22.100.0.2141",
+            DeviceClass::Network,
+            Some(r"pci\ven_8086&dev_a0f0"),
+            Some("22.100.0.2141"),
+            "2026-04-06",
+        );
+        let newer = upd(
+            "Intel - Net - 22.100.0.8000",
+            DeviceClass::Network,
+            Some(r"pci\ven_8086&dev_a0f0"),
+            Some("22.100.0.8000"),
+            "2026-05-15",
+        );
+
+        let kept = filter_safe_updates(&devices, vec![older, same, newer]);
+        assert_eq!(kept.len(), 1);
+        assert_eq!(kept[0].title, "Intel - Net - 22.100.0.8000");
+        assert_eq!(
+            kept[0].target_device.as_deref(),
+            Some("Intel Wi-Fi 6 AX201")
+        );
+    }
+
+    #[test]
+    fn matched_device_class_overrides_vague_update_class() {
+        let devices = vec![dev(
+            "Realtek High Definition Audio",
+            DeviceClass::Audio,
+            r"HDAUDIO\FUNC_01&VEN_10EC&DEV_0256\x",
+            "6.0.1.1",
+            "2025-01-01",
+        )];
+        let vague = upd(
+            "A-Volute AudioProcessingObject Driver Update",
+            DeviceClass::Other,
+            Some(r"hdaudio\func_01&ven_10ec&dev_0256"),
+            Some("1.1.4.0"),
+            "2026-02-02",
+        );
+        let kept = filter_safe_updates(&devices, vec![vague]);
+        assert_eq!(kept.len(), 1);
+        assert_eq!(kept[0].class, DeviceClass::Audio);
+        assert_eq!(
+            kept[0].target_device.as_deref(),
+            Some("Realtek High Definition Audio")
+        );
+        assert_eq!(kept[0].current_version.as_deref(), Some("6.0.1.1"));
+    }
+
+    #[test]
+    fn matched_update_carries_inf_and_hardware_id_for_snapshot() {
+        let mut device = dev(
+            "Realtek High Definition Audio",
+            DeviceClass::Audio,
+            r"HDAUDIO\FUNC_01&VEN_10EC&DEV_0256\x",
+            "6.0.1.1",
+            "2025-01-01",
+        );
+        device.inf_name = Some("oem47.inf".into());
+        let newer = upd(
+            "Realtek - MEDIA - 6.0.2.0",
+            DeviceClass::Audio,
+            Some(r"hdaudio\func_01&ven_10ec&dev_0256"),
+            Some("6.0.2.0"),
+            "2026-04-01",
+        );
+        let kept = filter_safe_updates(&[device], vec![newer]);
+        assert_eq!(kept.len(), 1);
+        assert_eq!(kept[0].target_inf.as_deref(), Some("oem47.inf"));
+        assert_eq!(
+            kept[0].target_hardware_id.as_deref(),
+            Some(r"HDAUDIO\FUNC_01&VEN_10EC&DEV_0256\x")
+        );
+    }
+
+    #[test]
+    fn keeps_update_with_no_matching_device() {
+        let devices = vec![dev(
+            "Realtek Audio",
+            DeviceClass::Audio,
+            r"HDAUDIO\FUNC_01&VEN_10EC&DEV_0256\x",
+            "6.0.1.1",
+            "2025-01-01",
+        )];
+        let net = upd(
+            "Intel - Net - 12.19.2.50",
+            DeviceClass::Network,
+            Some(r"PCI\VEN_8086&DEV_15BB"),
+            Some("12.19.2.50"),
+            "2026-02-02",
+        );
+        let kept = filter_safe_updates(&devices, vec![net]);
+        assert_eq!(kept.len(), 1);
+        assert_eq!(kept[0].target_device, None);
+    }
+
+    #[test]
+    fn groups_by_class_sorted() {
+        let updates = vec![
+            upd("B audio", DeviceClass::Audio, None, None, "2026-01-01"),
+            upd("A audio", DeviceClass::Audio, None, None, "2026-01-01"),
+            upd("Net thing", DeviceClass::Network, None, None, "2026-01-01"),
+        ];
+        let groups = group_by_class(updates);
+        assert_eq!(groups.len(), 2);
+        assert_eq!(groups[0].class, DeviceClass::Audio);
+        assert_eq!(groups[0].updates[0].title, "A audio");
+        assert_eq!(groups[0].label, "Audio");
+        assert_eq!(groups[1].class, DeviceClass::Network);
+    }
+
+    fn upd_provider(
+        title: &str,
+        class: DeviceClass,
+        hwid: Option<&str>,
+        ver: Option<&str>,
+        date: &str,
+        provider: &str,
+    ) -> DriverUpdate {
+        DriverUpdate {
+            provider: provider.into(),
+            ..upd(title, class, hwid, ver, date)
+        }
+    }
+
+    #[test]
+    fn is_gpu_only_for_pci_display_vendors() {
+        assert!(is_gpu(
+            r"PCI\VEN_10DE&DEV_2D05&SUBSYS_X\inst",
+            DeviceClass::Display
+        ));
+        assert!(is_gpu(r"PCI\VEN_1002&DEV_164E", DeviceClass::Display));
+        assert!(is_gpu(r"PCI\VEN_8086&DEV_9A49", DeviceClass::Display));
+        assert!(!is_gpu(r"DISPLAY\DELA1A3\4&abc", DeviceClass::Monitor));
+        assert!(!is_gpu(r"PCI\VEN_8086&DEV_A0F0", DeviceClass::Network));
+        assert!(!is_gpu(r"PCI\VEN_1234&DEV_5678", DeviceClass::Display));
+    }
+
+    #[test]
+    fn gpu_updates_excluded_monitor_kept() {
+        let devices = vec![
+            dev(
+                "NVIDIA GeForce RTX",
+                DeviceClass::Display,
+                r"PCI\VEN_10DE&DEV_2D05\x",
+                "560.0.0.0",
+                "2026-01-01",
+            ),
+            dev(
+                "Intel UHD",
+                DeviceClass::Display,
+                r"PCI\VEN_8086&DEV_9A49\x",
+                "31.0.101.2141",
+                "2026-01-01",
+            ),
+            dev(
+                "Dell Monitor",
+                DeviceClass::Monitor,
+                r"DISPLAY\DELA1A3\4&edid",
+                "1.0.0.0",
+                "2024-01-01",
+            ),
+        ];
+        let updates = vec![
+            upd(
+                "NVIDIA - Display - 565.0.0.0",
+                DeviceClass::Display,
+                Some(r"pci\ven_10de&dev_2d05"),
+                Some("565.0.0.0"),
+                "2026-05-01",
+            ),
+            upd(
+                "Intel - Display - 31.0.101.8000",
+                DeviceClass::Display,
+                Some(r"pci\ven_8086&dev_9a49"),
+                Some("31.0.101.8000"),
+                "2026-05-01",
+            ),
+            upd(
+                "Dell - Monitor - 1.1.0.0",
+                DeviceClass::Monitor,
+                Some(r"display\dela1a3"),
+                Some("1.1.0.0"),
+                "2026-05-01",
+            ),
+        ];
+        let kept = filter_safe_updates(&devices, updates);
+        assert_eq!(kept.len(), 1);
+        assert_eq!(kept[0].class, DeviceClass::Monitor);
+        assert_eq!(kept[0].target_device.as_deref(), Some("Dell Monitor"));
+    }
+
+    #[test]
+    fn hwid_core_is_segment_aware() {
+        assert_eq!(
+            hwid_core(r"PCI\VEN_8086&DEV_9A49&SUBSYS_22128086&REV_01\3&11583659&0&10"),
+            Some(("VEN_8086".into(), "DEV_9A49".into()))
+        );
+        let crafted = r"PCI\VEN_8086&SUBSYS_X\DEV_10DE_inst";
+        assert_eq!(hwid_core(crafted), None);
+    }
+
+    #[test]
+    fn hwid_key_broadens_acpi_swc_monitor() {
+        assert_eq!(
+            hwid_key(r"ACPI\INTC1234\3&inst"),
+            Some(HwidKey::Enumerator("ACPI".into(), "INTC1234".into()))
+        );
+        assert_eq!(
+            hwid_key(r"DISPLAY\DELA1A3\4&edid"),
+            Some(HwidKey::Monitor("DELA1A3".into()))
+        );
+        assert_eq!(
+            hwid_key(r"SWC\VEN_10EC&DEV_1234\x"),
+            Some(HwidKey::VenDev("VEN_10EC".into(), "DEV_1234".into()))
+        );
+        assert_eq!(hwid_key("ROOT"), None);
+    }
+
+    #[test]
+    fn anti_downgrade_fires_on_acpi_swc() {
+        let devices = vec![dev(
+            "Intel Chipset",
+            DeviceClass::Chipset,
+            r"ACPI\INTC1234\inst",
+            "2.0.0.0",
+            "2026-04-01",
+        )];
+        let older = upd(
+            "Intel - System - 1.0.0.0",
+            DeviceClass::System,
+            Some(r"ACPI\INTC1234"),
+            Some("1.0.0.0"),
+            "2025-01-01",
+        );
+        let kept = filter_safe_updates(&devices, vec![older]);
+        assert!(
+            kept.is_empty(),
+            "an older ACPI update must now be dropped by the anti-downgrade guard"
+        );
+    }
+
+    #[test]
+    fn dedup_devices_collapses_multifunction_and_composite() {
+        let devices = vec![
+            dev(
+                "Realtek Audio",
+                DeviceClass::Audio,
+                r"HDAUDIO\FUNC_01&VEN_10EC&DEV_0256\1",
+                "6.0.1.1",
+                "2025-01-01",
+            ),
+            dev(
+                "Realtek Audio Codec",
+                DeviceClass::Audio,
+                r"HDAUDIO\FUNC_02&VEN_10EC&DEV_0256\2",
+                "6.0.1.1",
+                "2025-06-01",
+            ),
+            dev(
+                "Logitech A",
+                DeviceClass::Input,
+                r"USB\VID_046D&PID_C52B&MI_00\3",
+                "1.0",
+                "2024-01-01",
+            ),
+            dev(
+                "Logitech B",
+                DeviceClass::Input,
+                r"USB\VID_046D&PID_C52B&MI_01\4",
+                "1.0",
+                "2024-01-01",
+            ),
+        ];
+        let out = dedup_devices(devices);
+        assert_eq!(out.len(), 2);
+        let audio = out.iter().find(|d| d.class == DeviceClass::Audio).unwrap();
+        assert_eq!(audio.name, "Realtek Audio Codec");
+        assert_eq!(audio.driver_date.as_deref(), Some("2025-06-01"));
+    }
+
+    #[test]
+    fn dedup_updates_prefers_oem_then_newest() {
+        let devices = vec![dev_mfg(
+            "Realtek Audio",
+            DeviceClass::Audio,
+            r"HDAUDIO\FUNC_01&VEN_10EC&DEV_0256\x",
+            "6.0.1.0",
+            "2025-01-01",
+            "Realtek Semiconductor Corp.",
+        )];
+        let generic = upd_provider(
+            "Generic High Definition Audio",
+            DeviceClass::Audio,
+            Some(r"hdaudio\func_01&ven_10ec&dev_0256"),
+            Some("10.0.0.1"),
+            "2026-05-01",
+            "Microsoft",
+        );
+        let oem = upd_provider(
+            "Realtek - MEDIA - 6.0.2.0",
+            DeviceClass::Audio,
+            Some(r"hdaudio\func_01&ven_10ec&dev_0256"),
+            Some("6.0.2.0"),
+            "2026-04-01",
+            "Realtek Semiconductor Corp.",
+        );
+        let out = dedup_updates(&devices, vec![generic, oem]);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].provider, "Realtek Semiconductor Corp.");
+    }
+
+    #[test]
+    fn dedup_updates_collapses_revisions_when_provider_equal() {
+        let devices: Vec<SystemDevice> = vec![];
+        let old_rev = upd(
+            "Intel - Net - 22.100.0.1",
+            DeviceClass::Network,
+            Some(r"PCI\VEN_8086&DEV_A0F0"),
+            Some("22.100.0.1"),
+            "2026-01-01",
+        );
+        let new_rev = upd(
+            "Intel - Net - 22.250.0.1",
+            DeviceClass::Network,
+            Some(r"PCI\VEN_8086&DEV_A0F0"),
+            Some("22.250.0.1"),
+            "2026-05-01",
+        );
+        let out = dedup_updates(&devices, vec![old_rev, new_rev]);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].driver_version.as_deref(), Some("22.250.0.1"));
+    }
+
+    #[test]
+    fn filter_present_drops_phantoms() {
+        let mut ghost = dev(
+            "Old Headset",
+            DeviceClass::Audio,
+            r"USB\VID_1234&PID_5678\x",
+            "1.0",
+            "2020-01-01",
+        );
+        ghost.present = false;
+        let live = dev(
+            "Current NIC",
+            DeviceClass::Network,
+            r"PCI\VEN_8086&DEV_A0F0\x",
+            "1.0",
+            "2026-01-01",
+        );
+        let out = filter_present(vec![ghost, live]);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].name, "Current NIC");
+    }
+
+    #[test]
+    fn cross_segment_pair_is_rejected() {
+        let device = dev(
+            "Some device",
+            DeviceClass::Other,
+            r"PCI\VEN_8086&SUBSYS_X\DEV_10DE_inst",
+            "1.0",
+            "2026-01-01",
+        );
+        let update = upd(
+            "Mismatched",
+            DeviceClass::Other,
+            Some(r"PCI\VEN_8086&DEV_10DE"),
+            Some("2.0"),
+            "2026-05-01",
+        );
+        assert!(!matches_device(&update, &device));
+    }
+}

--- a/crates/system-drivers/src/snapshot.rs
+++ b/crates/system-drivers/src/snapshot.rs
@@ -1,0 +1,195 @@
+//! DriverStore snapshot + rollback for System & Components driver updates.
+//!
+//! Before installing a non-GPU driver, the elevated install child snapshots the
+//! currently-installed driver package from the local DriverStore via
+//! `pnputil /export-driver` and lays down a System Restore checkpoint. A bad
+//! update can then be rolled back either by re-installing the exported package
+//! (`pnputil /add-driver /install`) or via Windows System Restore. Only
+//! vendor-signed packages already on the machine are ever touched — no scraping,
+//! no unsigned binaries.
+//!
+//! The `pnputil` argument vectors are pure (unit-tested); the process launch,
+//! file IO and `SRSetRestorePointW` FFI live behind `#[cfg(windows)]` and are
+//! exercised by the `#[ignore]`d admin integration test plus manual validation.
+
+/// True when `name` is a DriverStore published package name (`oemNN.inf`), the
+/// only handle `pnputil /export-driver` accepts. Guards the export against being
+/// handed an arbitrary path or a vendor INF name.
+pub fn is_published_oem_inf(name: &str) -> bool {
+    let lower = name.to_ascii_lowercase();
+    let Some(rest) = lower.strip_prefix("oem") else {
+        return false;
+    };
+    let Some(digits) = rest.strip_suffix(".inf") else {
+        return false;
+    };
+    !digits.is_empty() && digits.chars().all(|c| c.is_ascii_digit())
+}
+
+/// `pnputil` arguments to export one DriverStore package (`oemNN.inf`) into the
+/// `dest` directory.
+pub fn export_driver_args(published_name: &str, dest: &str) -> Vec<String> {
+    vec![
+        "/export-driver".to_string(),
+        published_name.to_string(),
+        dest.to_string(),
+    ]
+}
+
+/// `pnputil` arguments to (re)install every INF found under an exported snapshot
+/// — `/subdirs` recurses, `/install` forces the package onto matching devices so
+/// an explicit user rollback wins even when Windows considers the live driver
+/// newer.
+pub fn add_driver_install_args(inf_glob: &str) -> Vec<String> {
+    vec![
+        "/add-driver".to_string(),
+        inf_glob.to_string(),
+        "/subdirs".to_string(),
+        "/install".to_string(),
+    ]
+}
+
+/// The `*.inf` spec `pnputil /add-driver … /subdirs` expects to find every INF
+/// inside a recursively-exported snapshot directory.
+pub fn restore_inf_glob(export_dir: &str) -> String {
+    let trimmed = export_dir.trim_end_matches(['\\', '/']);
+    format!("{trimmed}\\*.inf")
+}
+
+#[cfg(windows)]
+pub mod win {
+    use super::{
+        add_driver_install_args, export_driver_args, is_published_oem_inf, restore_inf_glob,
+    };
+    use std::os::windows::process::CommandExt;
+    use std::path::Path;
+    use std::process::Command;
+
+    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
+    fn run_pnputil(args: &[String]) -> Result<String, String> {
+        let output = Command::new("pnputil.exe")
+            .args(args)
+            .creation_flags(CREATE_NO_WINDOW)
+            .output()
+            .map_err(|e| format!("failed to launch pnputil: {e}"))?;
+        let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+        if output.status.success() {
+            return Ok(stdout);
+        }
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        Err(format!(
+            "pnputil exited with code {}: {} {}",
+            output.status.code().unwrap_or(-1),
+            stdout.trim(),
+            stderr.trim()
+        ))
+    }
+
+    /// Snapshot the installed driver package `published_name` (`oemNN.inf`) into
+    /// `dest`, creating `dest` first. Requires Administrator (run inside the
+    /// elevated install child).
+    pub fn export_driver(published_name: &str, dest: &Path) -> Result<(), String> {
+        if !is_published_oem_inf(published_name) {
+            return Err(format!(
+                "refusing to export a non-DriverStore name: {published_name}"
+            ));
+        }
+        std::fs::create_dir_all(dest).map_err(|e| format!("create snapshot dir: {e}"))?;
+        let dest_str = dest.to_string_lossy();
+        run_pnputil(&export_driver_args(published_name, &dest_str)).map(|_| ())
+    }
+
+    /// Roll back by re-installing every INF in a previously-exported snapshot
+    /// directory. Requires Administrator.
+    pub fn restore_driver(export_dir: &Path) -> Result<(), String> {
+        if !export_dir.is_dir() {
+            return Err(format!(
+                "snapshot directory not found: {}",
+                export_dir.display()
+            ));
+        }
+        let glob = restore_inf_glob(&export_dir.to_string_lossy());
+        run_pnputil(&add_driver_install_args(&glob)).map(|_| ())
+    }
+
+    /// Lay down a `DEVICE_DRIVER_INSTALL` System Restore checkpoint named
+    /// `description`. Returns `Ok(true)` when a checkpoint was created,
+    /// `Ok(false)` when System Restore is disabled or throttled (the 24h
+    /// `SystemRestorePointCreationFrequency` window) — never an error, because the
+    /// exported package snapshot is the dependable rollback and the checkpoint is
+    /// only a secondary safety net. Requires Administrator.
+    pub fn create_restore_point(description: &str) -> Result<bool, String> {
+        use windows::Win32::System::Restore::{
+            SRSetRestorePointW, BEGIN_SYSTEM_CHANGE, DEVICE_DRIVER_INSTALL, END_SYSTEM_CHANGE,
+            RESTOREPOINTINFOW, STATEMGRSTATUS,
+        };
+
+        let mut desc = [0u16; 256];
+        for (slot, ch) in desc.iter_mut().zip(description.encode_utf16().take(255)) {
+            *slot = ch;
+        }
+
+        unsafe {
+            let mut info = RESTOREPOINTINFOW {
+                dwEventType: BEGIN_SYSTEM_CHANGE,
+                dwRestorePtType: DEVICE_DRIVER_INSTALL,
+                llSequenceNumber: 0,
+                szDescription: desc,
+            };
+            let mut status = STATEMGRSTATUS::default();
+            if !SRSetRestorePointW(&info, &mut status).as_bool() {
+                return Ok(false);
+            }
+            let sequence = status.llSequenceNumber;
+            info.dwEventType = END_SYSTEM_CHANGE;
+            info.llSequenceNumber = sequence;
+            let _ = SRSetRestorePointW(&info, &mut status);
+            Ok(true)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recognizes_driverstore_published_names_only() {
+        assert!(is_published_oem_inf("oem47.inf"));
+        assert!(is_published_oem_inf("OEM0.INF"));
+        assert!(!is_published_oem_inf("nahimicv3.inf"));
+        assert!(!is_published_oem_inf("oem.inf"));
+        assert!(!is_published_oem_inf("oem47"));
+        assert!(!is_published_oem_inf(r"C:\Windows\INF\oem47.inf"));
+        assert!(!is_published_oem_inf(""));
+    }
+
+    #[test]
+    fn export_args_are_positional() {
+        assert_eq!(
+            export_driver_args("oem47.inf", r"C:\snap\oem47"),
+            vec!["/export-driver", "oem47.inf", r"C:\snap\oem47"]
+        );
+    }
+
+    #[test]
+    fn install_args_force_and_recurse() {
+        assert_eq!(
+            add_driver_install_args(r"C:\snap\oem47\*.inf"),
+            vec![
+                "/add-driver",
+                r"C:\snap\oem47\*.inf",
+                "/subdirs",
+                "/install"
+            ]
+        );
+    }
+
+    #[test]
+    fn restore_glob_appends_inf_spec_and_normalizes_separator() {
+        assert_eq!(restore_inf_glob(r"C:\snap\oem47"), r"C:\snap\oem47\*.inf");
+        assert_eq!(restore_inf_glob(r"C:\snap\oem47\"), r"C:\snap\oem47\*.inf");
+        assert_eq!(restore_inf_glob("C:/snap/oem47/"), r"C:/snap/oem47\*.inf");
+    }
+}

--- a/crates/system-drivers/src/store.rs
+++ b/crates/system-drivers/src/store.rs
@@ -1,0 +1,209 @@
+//! Parsing the local Windows DriverStore via `pnputil /enum-drivers`.
+//!
+//! Windows Update returns only the single newest applicable driver per device,
+//! and WMI reports only the currently-installed version. The DriverStore is the
+//! one no-scrape source of *previously-installed* (superseded) versions still
+//! cached on disk — so it backs the "older versions" column for the System &
+//! Components view. Packages that share an `original_name` (e.g. `nahimicv3.inf`)
+//! are versions of the same driver; the newest is whichever ranks highest by
+//! [`crate::is_newer`].
+
+use crate::is_newer;
+use std::collections::BTreeMap;
+
+/// One third-party driver package in the local DriverStore.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct DriverStorePackage {
+    /// Store-assigned published name, e.g. `oem28.inf`.
+    pub published_name: String,
+    /// The INF's original (vendor) name, e.g. `nahimicv3.inf` — the stable key
+    /// that ties multiple store versions of one driver together.
+    pub original_name: String,
+    pub provider: String,
+    pub class: String,
+    /// Four-part driver version, e.g. `2.2.0.134`.
+    pub version: String,
+    /// ISO `YYYY-MM-DD` parsed from the `MM/DD/YYYY` `pnputil` date, when present.
+    pub date: Option<String>,
+}
+
+fn field<'a>(line: &'a str, label: &str) -> Option<&'a str> {
+    let (key, value) = line.split_once(':')?;
+    if key.trim().eq_ignore_ascii_case(label) {
+        Some(value.trim())
+    } else {
+        None
+    }
+}
+
+/// `pnputil` prints the version line as `MM/DD/YYYY V.V.V.V`. Split into an ISO
+/// date + the version token; either part may be absent.
+fn split_driver_version(raw: &str) -> (Option<String>, String) {
+    let mut parts = raw.split_whitespace();
+    let first = parts.next().unwrap_or("");
+    let rest: Vec<&str> = parts.collect();
+    if rest.is_empty() {
+        return (None, first.to_string());
+    }
+    (mdy_to_iso(first), rest.join(" "))
+}
+
+fn mdy_to_iso(mdy: &str) -> Option<String> {
+    let p: Vec<&str> = mdy.split('/').collect();
+    if p.len() != 3 {
+        return None;
+    }
+    let (m, d, y) = (p[0], p[1], p[2]);
+    if m.len() > 2
+        || d.len() > 2
+        || y.len() != 4
+        || !p.iter().all(|s| s.chars().all(|c| c.is_ascii_digit()))
+    {
+        return None;
+    }
+    Some(format!("{y}-{m:0>2}-{d:0>2}"))
+}
+
+/// Parse the full text of `pnputil /enum-drivers` into one entry per package.
+/// Unknown/localized field labels are simply skipped, so a non-English Windows
+/// yields fewer fields rather than a crash.
+pub fn parse_enum_drivers(output: &str) -> Vec<DriverStorePackage> {
+    let mut out: Vec<DriverStorePackage> = Vec::new();
+    let mut cur: Option<DriverStorePackage> = None;
+    let push = |cur: &mut Option<DriverStorePackage>, out: &mut Vec<DriverStorePackage>| {
+        if let Some(pkg) = cur.take() {
+            if !pkg.published_name.is_empty() {
+                out.push(pkg);
+            }
+        }
+    };
+    for line in output.lines() {
+        let line = line.trim();
+        if let Some(v) = field(line, "Published Name") {
+            push(&mut cur, &mut out);
+            cur = Some(DriverStorePackage {
+                published_name: v.to_string(),
+                ..Default::default()
+            });
+        } else if let Some(pkg) = cur.as_mut() {
+            if let Some(v) = field(line, "Original Name") {
+                pkg.original_name = v.to_string();
+            } else if let Some(v) = field(line, "Provider Name") {
+                pkg.provider = v.to_string();
+            } else if let Some(v) = field(line, "Class Name") {
+                pkg.class = v.to_string();
+            } else if let Some(v) = field(line, "Driver Version") {
+                let (date, version) = split_driver_version(v);
+                pkg.date = date;
+                pkg.version = version;
+            }
+        }
+    }
+    push(&mut cur, &mut out);
+    out
+}
+
+/// Group packages by `original_name`, newest-first within each group, so the UI
+/// can show "v2.2.0.134 (current) · v2.2.0.130" for one driver. Empty/unknown
+/// original names are dropped.
+pub fn versions_by_original_name(
+    packages: &[DriverStorePackage],
+) -> BTreeMap<String, Vec<DriverStorePackage>> {
+    let mut map: BTreeMap<String, Vec<DriverStorePackage>> = BTreeMap::new();
+    for pkg in packages {
+        if pkg.original_name.is_empty() {
+            continue;
+        }
+        map.entry(pkg.original_name.to_ascii_lowercase())
+            .or_default()
+            .push(pkg.clone());
+    }
+    for group in map.values_mut() {
+        group.sort_by(|a, b| {
+            if is_newer(
+                a.date.as_deref(),
+                Some(&a.version),
+                b.date.as_deref(),
+                Some(&b.version),
+            ) {
+                std::cmp::Ordering::Less
+            } else if is_newer(
+                b.date.as_deref(),
+                Some(&b.version),
+                a.date.as_deref(),
+                Some(&a.version),
+            ) {
+                std::cmp::Ordering::Greater
+            } else {
+                std::cmp::Ordering::Equal
+            }
+        });
+    }
+    map
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = "Microsoft PnP Utility
+
+Published Name:     oem28.inf
+Original Name:      amdgpio2.inf
+Provider Name:      Advanced Micro Devices, Inc
+Class Name:         System
+Class GUID:         {4d36e97d-e325-11ce-bfc1-08002be10318}
+Driver Version:     08/20/2024 2.2.0.134
+Signer Name:        Microsoft Windows Hardware Compatibility Publisher
+
+Published Name:     oem11.inf
+Original Name:      amdgpio2.inf
+Provider Name:      Advanced Micro Devices, Inc
+Class Name:         System
+Class GUID:         {4d36e97d-e325-11ce-bfc1-08002be10318}
+Driver Version:     09/15/2022 2.2.0.130
+Signer Name:        Microsoft Windows Hardware Compatibility Publisher
+
+Published Name:     oem5.inf
+Original Name:      nahimicv3.inf
+Provider Name:      A-Volute
+Class Name:         MEDIA
+Driver Version:     11/20/2025 1.1.4.0
+";
+
+    #[test]
+    fn parses_each_package_block() {
+        let pkgs = parse_enum_drivers(SAMPLE);
+        assert_eq!(pkgs.len(), 3);
+        assert_eq!(pkgs[0].published_name, "oem28.inf");
+        assert_eq!(pkgs[0].original_name, "amdgpio2.inf");
+        assert_eq!(pkgs[0].provider, "Advanced Micro Devices, Inc");
+        assert_eq!(pkgs[0].version, "2.2.0.134");
+        assert_eq!(pkgs[0].date.as_deref(), Some("2024-08-20"));
+        assert_eq!(pkgs[2].original_name, "nahimicv3.inf");
+        assert_eq!(pkgs[2].version, "1.1.4.0");
+    }
+
+    #[test]
+    fn groups_superseded_versions_newest_first() {
+        let pkgs = parse_enum_drivers(SAMPLE);
+        let by_name = versions_by_original_name(&pkgs);
+        let amd = by_name.get("amdgpio2.inf").expect("amd group");
+        assert_eq!(amd.len(), 2);
+        assert_eq!(amd[0].version, "2.2.0.134", "newest first");
+        assert_eq!(amd[1].version, "2.2.0.130");
+    }
+
+    #[test]
+    fn ignores_preamble_and_blank_lines() {
+        assert!(parse_enum_drivers("Microsoft PnP Utility\n\n\n").is_empty());
+        assert!(parse_enum_drivers("").is_empty());
+    }
+
+    #[test]
+    fn version_line_without_date_keeps_version() {
+        let (date, version) = split_driver_version("10.0.26100.1");
+        assert_eq!(date, None);
+        assert_eq!(version, "10.0.26100.1");
+    }
+}

--- a/crates/system-drivers/src/version.rs
+++ b/crates/system-drivers/src/version.rs
@@ -1,0 +1,223 @@
+//! Pure driver-version + driver-date logic for the anti-downgrade guard.
+//!
+//! Windows Update / the Microsoft Update Catalog is known to surface driver
+//! packages that are OLDER than what a device already runs. The guard never
+//! offers a candidate unless it is provably newer than the installed driver.
+//! "Newer" is decided on driver DATE first (the only field both WMI and WUA
+//! report reliably) and on the dotted version as a tie-break.
+
+/// A dotted numeric driver version, e.g. `31.0.101.2141`. Compared
+/// component-by-component, zero-padded so `31.0.101.2141` > `31.0.101.999`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DriverVersion(pub Vec<u64>);
+
+impl DriverVersion {
+    /// Parse a dotted numeric version. Non-numeric tails are ignored; returns
+    /// `None` when no leading numeric component is found.
+    pub fn parse(raw: &str) -> Option<Self> {
+        let mut parts = Vec::new();
+        for seg in raw.trim().split('.') {
+            let digits: String = seg.chars().take_while(|c| c.is_ascii_digit()).collect();
+            if digits.is_empty() {
+                break;
+            }
+            match digits.parse::<u64>() {
+                Ok(n) => parts.push(n),
+                Err(_) => break,
+            }
+        }
+        if parts.is_empty() {
+            None
+        } else {
+            Some(DriverVersion(parts))
+        }
+    }
+
+    /// Order against another version, padding the shorter with zeros.
+    pub fn cmp_padded(&self, other: &DriverVersion) -> std::cmp::Ordering {
+        let len = self.0.len().max(other.0.len());
+        for i in 0..len {
+            let a = self.0.get(i).copied().unwrap_or(0);
+            let b = other.0.get(i).copied().unwrap_or(0);
+            match a.cmp(&b) {
+                std::cmp::Ordering::Equal => continue,
+                ord => return ord,
+            }
+        }
+        std::cmp::Ordering::Equal
+    }
+}
+
+/// Extract the first dotted version (`\d+(\.\d+){1,3}`) embedded in free text
+/// such as a WUA update title ("Intel - Display - 31.0.101.2141"). Returns the
+/// matched substring so it can be displayed and parsed.
+pub fn extract_version(text: &str) -> Option<String> {
+    let bytes = text.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i].is_ascii_digit() {
+            let start = i;
+            let mut dots = 0usize;
+            while i < bytes.len() {
+                if bytes[i].is_ascii_digit() {
+                    i += 1;
+                } else if bytes[i] == b'.' && i + 1 < bytes.len() && bytes[i + 1].is_ascii_digit() {
+                    dots += 1;
+                    i += 1;
+                } else {
+                    break;
+                }
+            }
+            if dots >= 1 {
+                return Some(text[start..i].to_string());
+            }
+        } else {
+            i += 1;
+        }
+    }
+    None
+}
+
+/// Convert an OLE automation date (days since 1899-12-30, as returned by
+/// `IWindowsDriverUpdate::DriverVerDate`) into an ISO `YYYY-MM-DD` string.
+/// Uses Howard Hinnant's civil-from-days algorithm; pure integer math.
+pub fn ole_date_to_iso(ole: f64) -> Option<String> {
+    if !ole.is_finite() || ole <= 0.0 {
+        return None;
+    }
+    let days_since_unix = ole.floor() as i64 - 25569;
+    let (y, m, d) = civil_from_days(days_since_unix);
+    Some(format!("{y:04}-{m:02}-{d:02}"))
+}
+
+/// `(year, month, day)` from a count of days since 1970-01-01 (may be negative).
+fn civil_from_days(z: i64) -> (i64, u32, u32) {
+    let z = z + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = z - era * 146_097;
+    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = (doy - (153 * mp + 2) / 5 + 1) as u32;
+    let m = (if mp < 10 { mp + 3 } else { mp - 9 }) as u32;
+    (if m <= 2 { y + 1 } else { y }, m, d)
+}
+
+/// Decide whether `candidate` is strictly newer than `installed` for the
+/// anti-downgrade guard. Date dominates; dotted version breaks ties; when
+/// neither side is comparable the candidate is treated as NOT newer (refuse).
+///
+/// `*_date` are ISO `YYYY-MM-DD` (lexicographically ordered == chronological).
+pub fn is_newer(
+    candidate_date: Option<&str>,
+    candidate_version: Option<&str>,
+    installed_date: Option<&str>,
+    installed_version: Option<&str>,
+) -> bool {
+    match (candidate_date, installed_date) {
+        (Some(c), Some(i)) if c != i => return c > i,
+        _ => {}
+    }
+    if let (Some(c), Some(i)) = (candidate_version, installed_version) {
+        if let (Some(cv), Some(iv)) = (DriverVersion::parse(c), DriverVersion::parse(i)) {
+            return cv.cmp_padded(&iv) == std::cmp::Ordering::Greater;
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cmp::Ordering;
+
+    #[test]
+    fn parses_dotted_versions() {
+        assert_eq!(
+            DriverVersion::parse("31.0.101.2141").unwrap().0,
+            vec![31, 0, 101, 2141]
+        );
+        assert_eq!(DriverVersion::parse("560.94").unwrap().0, vec![560, 94]);
+        assert!(DriverVersion::parse("").is_none());
+        assert!(DriverVersion::parse("n/a").is_none());
+        assert_eq!(
+            DriverVersion::parse("32.0.101.8801-beta").unwrap().0,
+            vec![32, 0, 101, 8801]
+        );
+    }
+
+    #[test]
+    fn compares_padded() {
+        let a = DriverVersion::parse("31.0.101.2141").unwrap();
+        let b = DriverVersion::parse("31.0.101.999").unwrap();
+        assert_eq!(a.cmp_padded(&b), Ordering::Greater);
+        let c = DriverVersion::parse("31.0.101").unwrap();
+        let d = DriverVersion::parse("31.0.101.0").unwrap();
+        assert_eq!(c.cmp_padded(&d), Ordering::Equal);
+        let e = DriverVersion::parse("10.0.19041.1").unwrap();
+        let f = DriverVersion::parse("10.0.19041.2").unwrap();
+        assert_eq!(e.cmp_padded(&f), Ordering::Less);
+    }
+
+    #[test]
+    fn extracts_version_from_title() {
+        assert_eq!(
+            extract_version("Intel - Display - 31.0.101.2141").as_deref(),
+            Some("31.0.101.2141")
+        );
+        assert_eq!(
+            extract_version("Realtek Semiconductor Corp. - MEDIA - 6.0.9605.1").as_deref(),
+            Some("6.0.9605.1")
+        );
+        assert_eq!(extract_version("No version here").as_deref(), None);
+        assert_eq!(extract_version("Update 5 of 10").as_deref(), None);
+    }
+
+    #[test]
+    fn ole_date_converts() {
+        assert_eq!(ole_date_to_iso(45000.0).as_deref(), Some("2023-03-15"));
+        assert_eq!(ole_date_to_iso(46172.0).as_deref(), Some("2026-05-30"));
+        assert_eq!(ole_date_to_iso(0.0), None);
+        assert_eq!(ole_date_to_iso(f64::NAN), None);
+    }
+
+    #[test]
+    fn newer_by_date() {
+        assert!(is_newer(Some("2026-05-15"), None, Some("2026-04-06"), None));
+        assert!(!is_newer(
+            Some("2026-03-01"),
+            None,
+            Some("2026-04-06"),
+            None
+        ));
+        assert!(!is_newer(
+            Some("2026-04-06"),
+            None,
+            Some("2026-04-06"),
+            None
+        ));
+    }
+
+    #[test]
+    fn newer_by_version_when_dates_tie() {
+        assert!(is_newer(
+            Some("2026-04-06"),
+            Some("31.0.101.2141"),
+            Some("2026-04-06"),
+            Some("31.0.101.999"),
+        ));
+        assert!(!is_newer(
+            Some("2026-04-06"),
+            Some("31.0.101.500"),
+            Some("2026-04-06"),
+            Some("31.0.101.999"),
+        ));
+    }
+
+    #[test]
+    fn refuses_when_uncomparable() {
+        assert!(!is_newer(Some("2026-05-15"), None, None, None));
+        assert!(!is_newer(None, None, None, None));
+    }
+}

--- a/crates/system-drivers/src/wua.rs
+++ b/crates/system-drivers/src/wua.rs
@@ -1,0 +1,202 @@
+//! Windows Update Agent (WUA) COM driver source.
+//!
+//! Searches `IsInstalled=0 and Type='Driver'` against the Microsoft Update
+//! Catalog service (`ServerSelection=ssOthers` + the MU `ServiceID`), falling
+//! back to default Windows Update when the catalog service is unavailable.
+//! Download + install reuse the same WUA session. Only vendor-signed drivers
+//! Microsoft distributes are ever returned — no scraping.
+
+use windows::core::{Interface, BSTR};
+use windows::Win32::System::Com::{
+    CoCreateInstance, CoInitializeEx, CLSCTX_INPROC_SERVER, COINIT_APARTMENTTHREADED,
+};
+use windows::Win32::System::Ole::VarUI8FromDec;
+use windows::Win32::System::UpdateAgent::{
+    orcSucceeded, orcSucceededWithErrors, ssOthers, ssWindowsUpdate, IUpdateCollection,
+    IUpdateSession, IWindowsDriverUpdate, ServerSelection, UpdateCollection, UpdateSession,
+};
+
+use crate::{
+    classify_best, extract_version, ole_date_to_iso, pick_support_url, DriverError, DriverUpdate,
+    InstallProgress, InstallReport, InstallStage, UpdateSource,
+};
+
+/// Microsoft Update service id (enables the broader Microsoft Update Catalog).
+const MICROSOFT_UPDATE_SERVICE_ID: &str = "7971f918-a847-4430-9279-4a52d1efe18d";
+const DRIVER_CRITERIA: &str = "IsInstalled=0 and Type='Driver'";
+
+/// Live WUA-backed driver update source.
+pub struct WuaSource;
+
+impl UpdateSource for WuaSource {
+    fn search(&self) -> Result<Vec<DriverUpdate>, DriverError> {
+        match unsafe { search_with(ssOthers, Some(MICROSOFT_UPDATE_SERVICE_ID)) } {
+            Ok(v) => Ok(v),
+            Err(_) => unsafe { search_with(ssWindowsUpdate, None) }
+                .map_err(|e| DriverError::Search(e.to_string())),
+        }
+    }
+
+    fn install(
+        &self,
+        update_id: &str,
+        on_progress: &mut dyn FnMut(InstallProgress),
+    ) -> Result<InstallReport, DriverError> {
+        unsafe { install_impl(update_id, on_progress) }
+    }
+}
+
+unsafe fn init_com() {
+    let _ = CoInitializeEx(None, COINIT_APARTMENTTHREADED);
+}
+
+unsafe fn make_session() -> windows::core::Result<IUpdateSession> {
+    init_com();
+    CoCreateInstance(&UpdateSession, None, CLSCTX_INPROC_SERVER)
+}
+
+unsafe fn search_with(
+    server: ServerSelection,
+    service_id: Option<&str>,
+) -> windows::core::Result<Vec<DriverUpdate>> {
+    let session = make_session()?;
+    let searcher = session.CreateUpdateSearcher()?;
+    searcher.SetServerSelection(server)?;
+    if let Some(id) = service_id {
+        searcher.SetServiceID(&BSTR::from(id))?;
+    }
+    let result = searcher.Search(&BSTR::from(DRIVER_CRITERIA))?;
+    let coll = result.Updates()?;
+    let count = coll.Count()?;
+
+    let mut out = Vec::with_capacity(count.max(0) as usize);
+    for i in 0..count {
+        let update = coll.get_Item(i)?;
+        let title = update.Title().map(|b| b.to_string()).unwrap_or_default();
+        let identity = update.Identity()?;
+        let update_id = format!("{}:{}", identity.UpdateID()?, identity.RevisionNumber()?);
+        let size_bytes = update
+            .MaxDownloadSize()
+            .ok()
+            .and_then(|d| VarUI8FromDec(&d).ok())
+            .unwrap_or(0);
+        let mut url_candidates: Vec<String> = Vec::new();
+        if let Ok(more) = update.MoreInfoUrls() {
+            if let Ok(count) = more.Count() {
+                for j in 0..count {
+                    if let Ok(u) = more.get_Item(j) {
+                        url_candidates.push(u.to_string());
+                    }
+                }
+            }
+        }
+        if let Ok(s) = update.SupportUrl() {
+            url_candidates.push(s.to_string());
+        }
+        let support_url = pick_support_url(&url_candidates);
+
+        let (provider, class_raw, hardware_id, driver_date) =
+            match update.cast::<IWindowsDriverUpdate>() {
+                Ok(drv) => (
+                    drv.DriverProvider()
+                        .map(|b| b.to_string())
+                        .unwrap_or_default(),
+                    drv.DriverClass().map(|b| b.to_string()).unwrap_or_default(),
+                    drv.DriverHardwareID()
+                        .ok()
+                        .map(|b| b.to_string())
+                        .filter(|s| !s.is_empty()),
+                    drv.DriverVerDate().ok().and_then(ole_date_to_iso),
+                ),
+                Err(_) => (String::new(), String::new(), None, None),
+            };
+
+        out.push(DriverUpdate {
+            update_id,
+            class: classify_best(&class_raw, &title),
+            provider,
+            driver_version: extract_version(&title),
+            driver_date,
+            hardware_id,
+            size_bytes,
+            target_device: None,
+            current_version: None,
+            target_inf: None,
+            target_hardware_id: None,
+            support_url,
+            title,
+        });
+    }
+    Ok(out)
+}
+
+unsafe fn install_impl(
+    update_id: &str,
+    on_progress: &mut dyn FnMut(InstallProgress),
+) -> Result<InstallReport, DriverError> {
+    let map_err = |e: windows::core::Error| DriverError::Install(e.to_string());
+
+    let session = make_session().map_err(map_err)?;
+    let searcher = session.CreateUpdateSearcher().map_err(map_err)?;
+    let _ = searcher.SetServerSelection(ssOthers);
+    let _ = searcher.SetServiceID(&BSTR::from(MICROSOFT_UPDATE_SERVICE_ID));
+    let result = searcher
+        .Search(&BSTR::from(DRIVER_CRITERIA))
+        .map_err(map_err)?;
+    let found = result.Updates().map_err(map_err)?;
+    let count = found.Count().map_err(map_err)?;
+
+    let mut target = None;
+    for i in 0..count {
+        let u = found.get_Item(i).map_err(map_err)?;
+        let id = u.Identity().map_err(map_err)?;
+        let this = format!(
+            "{}:{}",
+            id.UpdateID().map_err(map_err)?,
+            id.RevisionNumber().map_err(map_err)?
+        );
+        if this == update_id {
+            target = Some(u);
+            break;
+        }
+    }
+    let update = target.ok_or_else(|| DriverError::NotFound(update_id.to_string()))?;
+    let _ = update.AcceptEula();
+
+    let coll: IUpdateCollection =
+        CoCreateInstance(&UpdateCollection, None, CLSCTX_INPROC_SERVER).map_err(map_err)?;
+    coll.Add(&update).map_err(map_err)?;
+
+    on_progress(InstallProgress {
+        stage: InstallStage::Downloading,
+        message: "Downloading driver from Windows Update…".to_string(),
+        fraction: None,
+    });
+    let downloader = session.CreateUpdateDownloader().map_err(map_err)?;
+    downloader.SetUpdates(&coll).map_err(map_err)?;
+    downloader.Download().map_err(map_err)?;
+
+    on_progress(InstallProgress {
+        stage: InstallStage::Installing,
+        message: "Installing driver…".to_string(),
+        fraction: None,
+    });
+    let installer = session.CreateUpdateInstaller().map_err(map_err)?;
+    installer.SetUpdates(&coll).map_err(map_err)?;
+    let res = installer.Install().map_err(map_err)?;
+
+    let code = res.ResultCode().map_err(map_err)?;
+    let reboot_required = res.RebootRequired().map(|b| b.0 != 0).unwrap_or(false);
+    let success = code == orcSucceeded || code == orcSucceededWithErrors;
+
+    Ok(InstallReport {
+        success,
+        reboot_required,
+        result_code: code.0,
+        message: if success {
+            "Driver installed successfully.".to_string()
+        } else {
+            format!("Windows Update returned result code {}.", code.0)
+        },
+    })
+}

--- a/crates/system-drivers/tests/pipeline.rs
+++ b/crates/system-drivers/tests/pipeline.rs
@@ -1,0 +1,233 @@
+//! End-to-end pipeline test against fake WMI/WUA boundaries: inventory →
+//! search → anti-downgrade filter → group-by-class, with no live Windows
+//! Update service. Proves the orchestration the real commands run.
+
+use system_drivers::{
+    dedup_updates, filter_safe_updates, group_by_class, DeviceCatalog, DeviceClass, DriverError,
+    DriverUpdate, InstallProgress, InstallReport, InstallStage, SystemDevice, UpdateSource,
+};
+
+struct FakeInventory(Vec<SystemDevice>);
+impl DeviceCatalog for FakeInventory {
+    fn inventory(&self) -> Result<Vec<SystemDevice>, DriverError> {
+        Ok(self.0.clone())
+    }
+}
+
+struct FakeSource(Vec<DriverUpdate>);
+impl UpdateSource for FakeSource {
+    fn search(&self) -> Result<Vec<DriverUpdate>, DriverError> {
+        Ok(self.0.clone())
+    }
+    fn install(
+        &self,
+        update_id: &str,
+        on_progress: &mut dyn FnMut(InstallProgress),
+    ) -> Result<InstallReport, DriverError> {
+        on_progress(InstallProgress {
+            stage: InstallStage::Downloading,
+            message: "downloading".into(),
+            fraction: None,
+        });
+        on_progress(InstallProgress {
+            stage: InstallStage::Installing,
+            message: "installing".into(),
+            fraction: None,
+        });
+        Ok(InstallReport {
+            success: true,
+            reboot_required: false,
+            result_code: 2,
+            message: format!("installed {update_id}"),
+        })
+    }
+}
+
+fn device(name: &str, class: DeviceClass, hwid: &str, ver: &str, date: &str) -> SystemDevice {
+    SystemDevice {
+        name: name.into(),
+        class,
+        manufacturer: "Vendor".into(),
+        driver_version: Some(ver.into()),
+        driver_date: Some(date.into()),
+        hardware_id: hwid.into(),
+        inf_name: None,
+        present: true,
+    }
+}
+
+fn update(title: &str, class: DeviceClass, hwid: &str, ver: &str, date: &str) -> DriverUpdate {
+    DriverUpdate {
+        update_id: format!("{title}:1"),
+        title: title.into(),
+        class,
+        provider: "Vendor".into(),
+        driver_version: Some(ver.into()),
+        driver_date: Some(date.into()),
+        hardware_id: Some(hwid.into()),
+        size_bytes: 1234,
+        target_device: None,
+        current_version: None,
+        target_inf: None,
+        target_hardware_id: None,
+        support_url: None,
+    }
+}
+
+#[test]
+fn full_scan_pipeline_filters_and_groups() {
+    let inventory = FakeInventory(vec![
+        device(
+            "Realtek High Definition Audio",
+            DeviceClass::Audio,
+            r"HDAUDIO\FUNC_01&VEN_10EC&DEV_0256\x",
+            "6.0.9461.1",
+            "2025-08-01",
+        ),
+        device(
+            "Intel(R) Wi-Fi 6 AX201",
+            DeviceClass::Network,
+            r"PCI\VEN_8086&DEV_A0F0&SUBSYS_X\x",
+            "22.250.0.4",
+            "2026-03-01",
+        ),
+    ]);
+
+    let updates = vec![
+        update(
+            "Realtek - MEDIA - 6.0.9600.1",
+            DeviceClass::Audio,
+            r"hdaudio\func_01&ven_10ec&dev_0256",
+            "6.0.9600.1",
+            "2026-04-10",
+        ),
+        update(
+            "Intel - Net - 22.100.0.1",
+            DeviceClass::Network,
+            r"pci\ven_8086&dev_a0f0",
+            "22.100.0.1",
+            "2025-12-01",
+        ),
+        update(
+            "Intel - Bluetooth - 23.10.0.2",
+            DeviceClass::Bluetooth,
+            r"USB\VID_8087&PID_0026",
+            "23.10.0.2",
+            "2026-05-01",
+        ),
+    ];
+
+    let devices = inventory.inventory().unwrap();
+    let found = FakeSource(updates).search().unwrap();
+    let safe = filter_safe_updates(&devices, found);
+
+    assert_eq!(safe.len(), 2);
+    let audio = safe.iter().find(|u| u.class == DeviceClass::Audio).unwrap();
+    assert_eq!(
+        audio.target_device.as_deref(),
+        Some("Realtek High Definition Audio")
+    );
+    let bt = safe
+        .iter()
+        .find(|u| u.class == DeviceClass::Bluetooth)
+        .unwrap();
+    assert_eq!(bt.target_device, None);
+    assert!(!safe.iter().any(|u| u.class == DeviceClass::Network));
+
+    let groups = group_by_class(safe);
+    assert_eq!(groups.len(), 2);
+    assert_eq!(groups[0].class, DeviceClass::Audio);
+    assert_eq!(groups[1].class, DeviceClass::Bluetooth);
+}
+
+#[test]
+fn hybrid_gpu_excluded_components_kept_and_deduped() {
+    let inventory = FakeInventory(vec![
+        device(
+            "NVIDIA GeForce RTX 4070",
+            DeviceClass::Display,
+            r"PCI\VEN_10DE&DEV_2D05&SUBSYS_X\x",
+            "560.0.0.0",
+            "2026-01-01",
+        ),
+        device(
+            "Intel(R) Iris Xe Graphics",
+            DeviceClass::Display,
+            r"PCI\VEN_8086&DEV_9A49\x",
+            "31.0.101.2141",
+            "2026-01-01",
+        ),
+        device(
+            "Realtek High Definition Audio",
+            DeviceClass::Audio,
+            r"HDAUDIO\FUNC_01&VEN_10EC&DEV_0256\x",
+            "6.0.9461.1",
+            "2025-08-01",
+        ),
+    ]);
+
+    let updates = vec![
+        update(
+            "NVIDIA - Display - 565.0.0.0",
+            DeviceClass::Display,
+            r"pci\ven_10de&dev_2d05",
+            "565.0.0.0",
+            "2026-05-01",
+        ),
+        update(
+            "Intel - Display - 31.0.101.8000",
+            DeviceClass::Display,
+            r"pci\ven_8086&dev_9a49",
+            "31.0.101.8000",
+            "2026-05-01",
+        ),
+        update(
+            "Realtek - MEDIA - 6.0.9600.1",
+            DeviceClass::Audio,
+            r"hdaudio\func_01&ven_10ec&dev_0256",
+            "6.0.9600.1",
+            "2026-04-10",
+        ),
+        update(
+            "Realtek - MEDIA - 6.0.9600.1 (mirror)",
+            DeviceClass::Audio,
+            r"hdaudio\func_01&ven_10ec&dev_0256",
+            "6.0.9600.1",
+            "2026-04-10",
+        ),
+    ];
+
+    let devices = inventory.inventory().unwrap();
+    let found = FakeSource(updates).search().unwrap();
+    let safe = filter_safe_updates(&devices, found);
+    let deduped = dedup_updates(&devices, safe);
+
+    assert!(
+        !deduped.iter().any(|u| u.class == DeviceClass::Display),
+        "no GPU/display updates should survive"
+    );
+    let audio: Vec<_> = deduped
+        .iter()
+        .filter(|u| u.class == DeviceClass::Audio)
+        .collect();
+    assert_eq!(audio.len(), 1, "duplicate Realtek update collapsed to one");
+
+    let groups = group_by_class(deduped);
+    assert_eq!(groups.len(), 1);
+    assert_eq!(groups[0].class, DeviceClass::Audio);
+}
+
+#[test]
+fn install_reports_progress_stages_and_success() {
+    let src = FakeSource(vec![]);
+    let mut stages = Vec::new();
+    let report = src
+        .install("Some-Update:1", &mut |p| stages.push(p.stage))
+        .unwrap();
+    assert_eq!(
+        stages,
+        vec![InstallStage::Downloading, InstallStage::Installing]
+    );
+    assert!(report.success);
+    assert_eq!(report.result_code, 2);
+}

--- a/crates/system-drivers/tests/snapshot_win.rs
+++ b/crates/system-drivers/tests/snapshot_win.rs
@@ -1,0 +1,45 @@
+//! `#[ignore]`d Windows-only integration smoke for the DriverStore snapshot
+//! path. Exporting a package is NON-destructive (it copies the package out of
+//! the store), so this is safe to run on a real machine; the rollback /
+//! restore-point paths mutate the system and stay manual.
+//!
+//! Run on a Windows host with: `cargo test -p system-drivers --test snapshot_win -- --ignored`.
+
+#![cfg(windows)]
+
+use std::os::windows::process::CommandExt;
+use std::process::Command;
+use system_drivers::{driver_snapshot, parse_enum_drivers};
+
+const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
+#[test]
+#[ignore = "touches the live DriverStore via pnputil; run manually on Windows"]
+fn exports_a_real_driverstore_package() {
+    let output = Command::new("pnputil.exe")
+        .args(["/enum-drivers"])
+        .creation_flags(CREATE_NO_WINDOW)
+        .output()
+        .expect("run pnputil /enum-drivers");
+    let text = String::from_utf8_lossy(&output.stdout);
+    let packages = parse_enum_drivers(&text);
+    let Some(pkg) = packages.into_iter().find(|p| !p.published_name.is_empty()) else {
+        eprintln!("no third-party DriverStore packages present; nothing to export");
+        return;
+    };
+
+    let dir = tempfile::tempdir().expect("temp dir");
+    let dest = dir.path().join("snapshot");
+    driver_snapshot::export_driver(&pkg.published_name, &dest)
+        .unwrap_or_else(|e| panic!("export {} failed: {e}", pkg.published_name));
+
+    let exported = std::fs::read_dir(&dest)
+        .expect("read snapshot dir")
+        .filter_map(|e| e.ok())
+        .count();
+    assert!(
+        exported > 0,
+        "export produced no files for {}",
+        pkg.published_name
+    );
+}

--- a/docs/signing-reality.md
+++ b/docs/signing-reality.md
@@ -1,0 +1,108 @@
+# Code signing & SmartScreen — the honest reality
+
+This document records, with sources, why DLSSync still triggers a Windows
+"unknown publisher" prompt, what this release does to reduce the friction
+**without any certificate or paid account**, and the two real fixes kept on file
+for when we choose to enable them.
+
+## The honest truth
+
+**Without a code-signing certificate, the SmartScreen / "Windows protected your
+PC" prompt cannot be fully removed.** Everything else is friction reduction, not
+elimination.
+
+- **Self-signed certificates do nothing for SmartScreen.** A self-signed cert is
+  treated exactly like no signature — it carries no reputation and no trusted
+  chain. (Microsoft Learn, *SmartScreen* + *Authenticode* docs.)
+- **There is no stealthy / automatic / "black-hat" way to manufacture a trusted
+  signature.** The only mechanisms that produce a *trusted* Authenticode
+  signature are (a) a real, identity-validated code-signing certificate from a
+  CA, or (b) the Microsoft Store's re-signing of an MSIX. Anything else that
+  claims to "auto-generate a trusted signature" or "bypass SmartScreen" is
+  fraudulent or malware:
+  - The *Fox Tempest* "Malware-Signing-as-a-Service" operation abused Azure
+    Trusted Signing with fraudulent identities to sign malware — **Microsoft
+    dismantled it (May 2026)**. Using stolen/fraudulent certs is a criminal
+    supply-chain compromise, not an option.
+  - "SmartScreen bypass" / "FUD crypter" tools are themselves malware. Shipping
+    that fingerprint gets DLSSync **classified as malware** by Defender — the
+    exact opposite of building user trust, and **irreversible** once the
+    reputation is poisoned.
+
+So: we do **not** self-sign, and we do **not** ship any evasion fingerprint.
+That would actively harm the project. Instead we minimize friction honestly and
+let reputation accrue.
+
+## What this release does (no cert, no account)
+
+1. **A clean, well-formed MSI** (alongside the NSIS installer and the portable
+   zip). The MSI is a standard Windows Installer package with a stable
+   **UpgradeCode** (`ebeac857-6d46-4dea-aeb1-cc5254ffae31`) so upgrades and
+   uninstalls are clean, and it is **smoke-installed in CI** (silent install +
+   uninstall) on every release so a broken package never ships.
+2. **Pristine PE metadata + app manifest, no packers/obfuscation.** Correct
+   version-info, company/product strings, and execution-level/DPI/long-path
+   awareness so Defender's *antivirus* heuristics don't false-positive. We never
+   pack or obfuscate the binary (packers are a malware signal).
+3. **A stable download URL + artifact naming family**, release to release, so
+   SmartScreen reputation accrues to a steady hash lineage instead of resetting
+   every version. The portable zip is offered as a lower-friction alternative
+   (no installer elevation).
+4. **Honest first-run guidance** (README + below) for the one-time
+   *More info → Run anyway* step, so users aren't scared off while reputation
+   builds.
+
+### MSI vs NSIS — which to download
+
+- **NSIS `*-setup.exe` (recommended for most users):** per-user install
+  (`currentUser`, no admin elevation), tray integration, and **in-place
+  auto-update** via the Tauri updater.
+- **MSI `*.msi`:** a standard Windows Installer package for users and IT who
+  prefer MSI (Group Policy / `msiexec` deployment). It is per-machine (the MSI
+  norm) and does not participate in the in-app auto-updater.
+- **Portable `*-portable.zip`:** no installer at all; lowest friction.
+
+> Note on per-user MSI: a per-user MSI requires a hand-authored WiX template
+> (`InstallScope=perUser`). We deliberately did **not** hand-roll one this
+> release — an untested custom installer template is a worse risk than shipping
+> the standard per-machine MSI, and the per-user need is already covered by the
+> NSIS installer. Per-user MSI is a documented future option.
+
+## First run — getting past the prompt (one time)
+
+When you launch the installer the first time, Windows SmartScreen may show
+*"Windows protected your PC"*. This is expected for any app from a publisher
+without an established reputation yet — it is **not** a virus warning.
+
+1. Click **More info**.
+2. Click **Run anyway**.
+
+You only do this once per version. You can verify the download first: every
+DLSSync binary keeps its original **vendor Authenticode signature** on the
+redistributed DLLs, and release artifacts are published only from the tagged CI
+build at `github.com/xt0n1-t3ch/DLSSync/releases`.
+
+## The real fixes (deferred, on file)
+
+When we choose to invest, either of these removes the prompt for real:
+
+- **SignPath.io OSS (free for open-source).** An identity-validated
+  Authenticode certificate; SmartScreen reputation then builds against a trusted
+  publisher. The CI is already wired for it — the `sign-windows` job runs only
+  when the `SIGNPATH_ENABLED` repo variable is `true` (see
+  [`.github/workflows/SIGNPATH.md`](../.github/workflows/SIGNPATH.md)). It stays
+  dormant until enabled.
+- **Microsoft Store (MSIX).** The Store re-signs the package with a trusted
+  chain and there is no SmartScreen prompt at all; the Store also handles
+  updates. Requires a one-time developer account.
+
+Both are intentionally **out of scope for this release** (no account/cert this
+time) and documented here so the decision is explicit and reversible.
+
+## Sources
+
+- Microsoft Learn — *Microsoft Defender SmartScreen overview*; *Authenticode*;
+  *MSIX app signing*.
+- Microsoft Security Blog / MSRC — *Fox Tempest* Trusted-Signing abuse takedown
+  (May 2026).
+- SignPath.io — *Open-source code signing* program documentation.

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,6 @@
+# Brandfetch Logo API client id — enables dynamic real logos for the System & Components
+# long-tail vendors (Realtek, Nahimic, Synaptics, Gigabyte, Logitech, ...) that are not in the
+# bundled offline simple-icons set. Register a free client id at https://brandfetch.com/developers
+# (the Logo API is free, no attribution required). Leave unset to keep those vendors as text labels.
+# The core GPU vendors (NVIDIA/AMD/Intel/Microsoft/...) always render from bundled offline marks.
+VITE_BRANDFETCH_CLIENT_ID=

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dlssync-frontend",
   "private": true,
-  "version": "1.5.1",
+  "version": "1.5.2",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -39,6 +39,7 @@
     "@tauri-apps/plugin-process": "^2.0.0",
     "@tauri-apps/plugin-shell": "^2.0.0",
     "@tauri-apps/plugin-store": "^2.0.0",
-    "@tauri-apps/plugin-updater": "^2.0.0"
+    "@tauri-apps/plugin-updater": "^2.0.0",
+    "simple-icons": "^16.21.0"
   }
 }

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -1,14 +1,17 @@
 <script lang="ts">
   import { onMount } from "svelte";
-  import { fly } from "svelte/transition";
+  import { fade, fly } from "svelte/transition";
   import Sidebar from "./components/Sidebar.svelte";
   import TopBar from "./components/TopBar.svelte";
   import Toast from "./components/Toast.svelte";
   import UpdateBanner from "./components/UpdateBanner.svelte";
   import CommandPalette from "./components/CommandPalette.svelte";
+  import NotificationsBell from "./components/NotificationsBell.svelte";
   import ShortcutOverlay from "./components/ShortcutOverlay.svelte";
   import ApplyProgressModal from "./components/ApplyProgressModal.svelte";
+  import ActivityDock from "./components/ActivityDock.svelte";
   import Library from "./views/Library.svelte";
+  import GameDetailDrawer from "./components/GameDetailDrawer.svelte";
   import Catalog from "./views/Catalog.svelte";
   import Backups from "./views/Backups.svelte";
   import Drivers from "./views/Drivers.svelte";
@@ -23,9 +26,14 @@
     bootstrapCatalog,
     requestThemeToggle,
     applyModalOpen,
+    notificationsOpen,
   } from "./lib/stores";
+  import { activeArt, clearActiveArt } from "./lib/artContext";
   import { installApplyEventListeners } from "./lib/applyEvents";
-  import { installDriverInstallListener } from "./lib/driverInstallEvents";
+  import {
+    installDriverInstallListener,
+    installSystemDriverListener,
+  } from "./lib/driverInstallEvents";
 
   let theme = $state(localStorage.getItem("dlssync-theme") || "dark");
 
@@ -54,6 +62,7 @@
     document.documentElement.setAttribute("data-theme", theme);
     void installApplyEventListeners();
     void installDriverInstallListener();
+    void installSystemDriverListener();
     void bootstrapCatalog();
   });
 
@@ -67,8 +76,9 @@
   });
 
   $effect(() => {
-    if ($currentView !== "library" && $drawerGameId) {
-      drawerGameId.set(null);
+    if ($currentView !== "library") {
+      clearActiveArt();
+      if ($drawerGameId) drawerGameId.set(null);
     }
   });
 
@@ -89,63 +99,141 @@
   });
 </script>
 
-<Sidebar />
-<div class="main-wrapper" class:sidebar-collapsed={collapsed} data-drawer-open={$drawerGameId ? "true" : "false"}>
-  <TopBar onToggleTheme={toggleTheme} {theme} />
-  <main class="main-content">
-    <div class="main-inner">
-      {#if $currentView === "library"}
-        <div in:fly={{ y: 8, duration: 200 }}><Library /></div>
-      {:else if $currentView === "catalog"}
-        <div in:fly={{ y: 8, duration: 200 }}><Catalog /></div>
-      {:else if $currentView === "backups"}
-        <div in:fly={{ y: 8, duration: 200 }}><Backups /></div>
-      {:else if $currentView === "drivers"}
-        <div in:fly={{ y: 8, duration: 200 }}><Drivers /></div>
-      {:else if $currentView === "settings"}
-        <div in:fly={{ y: 8, duration: 200 }}>
-          <Settings onToggleTheme={toggleTheme} currentTheme={theme} />
-        </div>
-      {:else if $currentView === "about"}
-        <div in:fly={{ y: 8, duration: 200 }}><About /></div>
-      {/if}
-    </div>
-  </main>
+<div class="app-shell">
+  <div class="app-ambient" aria-hidden="true">
+    <div class="ambient-mesh"></div>
+    {#if $activeArt}
+      <img class="ambient-art" src={$activeArt} alt="" transition:fade={{ duration: 600 }} />
+    {/if}
+    <div class="ambient-grain"></div>
+  </div>
+  <Sidebar />
+  <div class="app-main" class:sidebar-collapsed={collapsed}>
+    <TopBar onToggleTheme={toggleTheme} {theme} />
+    <main class="main-content">
+      <div class="main-inner">
+        {#if $currentView === "library" && $drawerGameId}
+          <div in:fly={{ y: 8, duration: 200 }}>
+            <GameDetailDrawer
+              gameId={$drawerGameId}
+              onClose={() => drawerGameId.set(null)}
+              onApplyStart={() => applyModalOpen.set(true)}
+            />
+          </div>
+        {:else if $currentView === "library"}
+          <div in:fly={{ y: 8, duration: 200 }}><Library /></div>
+        {:else if $currentView === "catalog"}
+          <div in:fly={{ y: 8, duration: 200 }}><Catalog /></div>
+        {:else if $currentView === "backups"}
+          <div in:fly={{ y: 8, duration: 200 }}><Backups /></div>
+        {:else if $currentView === "drivers"}
+          <div in:fly={{ y: 8, duration: 200 }}><Drivers /></div>
+        {:else if $currentView === "settings"}
+          <div in:fly={{ y: 8, duration: 200 }}>
+            <Settings onToggleTheme={toggleTheme} currentTheme={theme} />
+          </div>
+        {:else if $currentView === "about"}
+          <div in:fly={{ y: 8, duration: 200 }}><About /></div>
+        {/if}
+      </div>
+    </main>
+  </div>
 </div>
 <Toast />
+<ActivityDock />
 <UpdateBanner />
 <CommandPalette />
+<NotificationsBell open={$notificationsOpen} onClose={() => notificationsOpen.set(false)} />
 <ShortcutOverlay />
 {#if $applyModalOpen}
   <ApplyProgressModal onClose={() => applyModalOpen.set(false)} />
 {/if}
 
 <style>
-  .main-wrapper {
-    margin-left: var(--sidebar-width);
-    min-height: 100vh;
+  /* One cohesive floating app surface (sidebar + topbar + content integrated),
+     on the subtle ambient backdrop. Rounded + overflow-clipped = the "docker" feel. */
+  /* Edge-to-edge: the app fills the window (no inner margin → no square frame).
+     The window's own corners are rounded by the OS. */
+  .app-shell {
+    position: fixed;
+    inset: 0;
+    z-index: 1;
+    display: flex;
+    overflow: hidden;
+    background: transparent;
+  }
+  .app-ambient {
+    position: absolute;
+    inset: 0;
+    z-index: 0;
+    overflow: hidden;
+    pointer-events: none;
+    background: var(--bg-base);
+  }
+  .ambient-mesh {
+    position: absolute;
+    inset: -20%;
+    background:
+      radial-gradient(ellipse 72% 62% at 5% 0%, var(--ambient-glow-1), transparent 60%),
+      radial-gradient(ellipse 60% 55% at 98% 6%, var(--ambient-glow-2), transparent 62%),
+      radial-gradient(ellipse 82% 78% at 0% 100%, var(--ambient-glow-3), transparent 60%);
+    animation: ambient-drift 64s ease-in-out infinite alternate;
+  }
+  /* Tidal-style art tint: a heavily blurred + darkened copy of the focused game's
+     cover, behind all chrome so the frosted glass refracts real colour. */
+  .ambient-art {
+    position: absolute;
+    inset: -15%;
+    width: 130%;
+    height: 130%;
+    object-fit: cover;
+    filter: blur(var(--art-blur)) saturate(var(--art-sat)) brightness(var(--art-dim));
+    opacity: var(--art-opacity);
+    pointer-events: none;
+    -webkit-mask-image:
+      linear-gradient(to right, #000 var(--art-edge-left), transparent var(--art-edge-left-fade)),
+      linear-gradient(to bottom, #000 var(--art-edge-top), transparent var(--art-edge-top-fade));
+    mask-image:
+      linear-gradient(to right, #000 var(--art-edge-left), transparent var(--art-edge-left-fade)),
+      linear-gradient(to bottom, #000 var(--art-edge-top), transparent var(--art-edge-top-fade));
+    mask-composite: add;
+  }
+  @keyframes ambient-drift {
+    from { transform: translate3d(0, 0, 0) scale(1); }
+    to { transform: translate3d(2.5%, -2%, 0) scale(1.1); }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .ambient-mesh { animation: none; }
+  }
+  .ambient-grain {
+    position: absolute;
+    inset: 0;
+    background-image: var(--noise-url);
+    opacity: 0.4;
+    mix-blend-mode: overlay;
+  }
+  /* The content column: the topbar overlays the top so scrolling content frosts
+     under it (real glass), and the sidebar is an integrated column to the left. */
+  .app-main {
+    position: relative;
+    z-index: 1;
+    flex: 1;
+    min-width: 0;
     display: flex;
     flex-direction: column;
-    transition: margin-left 0.22s var(--ease), padding-right 0.24s var(--ease);
-  }
-  .main-wrapper.sidebar-collapsed {
-    margin-left: var(--sidebar-width-collapsed);
-  }
-  .main-wrapper[data-drawer-open="true"] {
-    padding-right: var(--drawer-width);
-  }
-  @media (max-width: 1300px) {
-    .main-wrapper[data-drawer-open="true"] { padding-right: 0; }
   }
   .main-content {
     flex: 1;
     overflow-y: auto;
-    max-height: calc(100vh - var(--topbar-height));
-    background: var(--bg-app);
+    background: transparent;
+    padding-top: var(--topbar-height);
   }
   .main-inner {
     max-width: var(--content-max);
-    padding: 28px 32px 24px;
+    padding: clamp(18px, 2.4vw, 36px) clamp(18px, 3.2vw, 48px) clamp(16px, 2vw, 28px);
     margin: 0 auto;
+  }
+  @media (max-width: 720px) {
+    .main-inner { padding: 16px 16px 20px; }
   }
 </style>

--- a/frontend/src/components/ActivityDock.svelte
+++ b/frontend/src/components/ActivityDock.svelte
@@ -1,0 +1,152 @@
+<script lang="ts">
+  import { fly } from "svelte/transition";
+  import { dockItems, applyModalOpen, currentView } from "../lib/stores";
+
+  let items = $derived($dockItems);
+  let count = $derived(items.length);
+  let primary = $derived(items[0] ?? null);
+
+  let fraction = $derived.by<number | null>(() => {
+    const known = items.map((i) => i.fraction).filter((f): f is number => f !== null);
+    if (known.length === 0) return null;
+    return known.reduce((a, b) => a + b, 0) / known.length;
+  });
+
+  let headline = $derived(
+    count === 0
+      ? ""
+      : count === 1
+        ? primary!.label
+        : `${count} tasks running`,
+  );
+  let substage = $derived(count === 1 && primary ? primary.stage.replace(/_/g, " ") : "in progress");
+  let failed = $derived(items.some((i) => i.stage === "failed"));
+
+  function expand(): void {
+    if (items.some((i) => i.kind === "apply")) {
+      applyModalOpen.set(true);
+    } else {
+      currentView.set("drivers");
+    }
+  }
+</script>
+
+{#if count > 0}
+  <aside
+    class="activity-dock glass-panel"
+    class:is-failed={failed}
+    role="status"
+    aria-live="polite"
+    aria-label="Background activity"
+    transition:fly={{ y: 90, duration: 240 }}
+  >
+    <span class="dock-dot" aria-hidden="true"></span>
+    <div class="dock-body">
+      <div class="dock-text">
+        <span class="dock-headline">{headline}</span>
+        <span class="dock-stage">{substage}</span>
+      </div>
+      <div class="dock-track" class:indeterminate={fraction === null}>
+        {#if fraction !== null}
+          <div class="dock-fill" style:width={`${Math.round(fraction * 100)}%`}></div>
+        {:else}
+          <div class="dock-fill dock-fill-indeterminate"></div>
+        {/if}
+      </div>
+    </div>
+    <button class="dock-expand" onclick={expand} title="Show details" aria-label="Show details">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="18 15 12 9 6 15" /></svg>
+    </button>
+  </aside>
+{/if}
+
+<style>
+  .activity-dock {
+    position: fixed;
+    left: 50%;
+    bottom: 16px;
+    transform: translateX(-50%);
+    z-index: 90;
+    width: min(560px, calc(100vw - var(--sidebar-width) - 64px));
+    height: var(--dock-height);
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    padding: 0 14px 0 18px;
+    border-radius: var(--radius-xl);
+    box-shadow: var(--glass-edge), var(--shadow-lg);
+  }
+
+  .dock-dot {
+    width: 9px;
+    height: 9px;
+    border-radius: 50%;
+    background: var(--accent);
+    box-shadow: 0 0 0 0 var(--accent-glow);
+    flex-shrink: 0;
+    animation: dockPulse 1.8s var(--ease) infinite;
+  }
+  @keyframes dockPulse {
+    0% { box-shadow: 0 0 0 0 var(--accent-glow); }
+    70% { box-shadow: 0 0 0 7px transparent; }
+    100% { box-shadow: 0 0 0 0 transparent; }
+  }
+
+  .dock-body { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 6px; }
+  .dock-text { display: flex; align-items: baseline; gap: 8px; min-width: 0; }
+  .dock-headline {
+    font-size: var(--fs-sm);
+    font-weight: 600;
+    color: var(--text-primary);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .dock-stage {
+    font-size: var(--fs-2xs);
+    color: var(--text-muted);
+    text-transform: capitalize;
+    white-space: nowrap;
+    flex-shrink: 0;
+  }
+  .dock-track {
+    height: 4px;
+    border-radius: var(--radius-full);
+    background: var(--bg-elevated);
+    overflow: hidden;
+  }
+  .dock-fill {
+    height: 100%;
+    background: linear-gradient(90deg, var(--accent-progress), color-mix(in oklab, var(--accent-progress) 60%, #ffffff));
+    box-shadow: 0 0 8px color-mix(in oklab, var(--accent-progress) 55%, transparent);
+    border-radius: inherit;
+    transition: width var(--dur-normal) var(--ease);
+  }
+  .activity-dock.is-failed .dock-fill { background: var(--danger); box-shadow: none; }
+  .activity-dock.is-failed .dock-dot { background: var(--danger); animation: none; }
+  .dock-fill-indeterminate {
+    width: 36%;
+    animation: dockSlide 1.3s var(--ease) infinite;
+  }
+  @keyframes dockSlide {
+    0% { transform: translateX(-120%); }
+    100% { transform: translateX(320%); }
+  }
+  .dock-expand {
+    width: 32px;
+    height: 32px;
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: var(--radius-md);
+    color: var(--text-secondary);
+    transition: background var(--dur-fast) var(--ease), color var(--dur-fast) var(--ease);
+  }
+  .dock-expand:hover { background: var(--bg-elevated); color: var(--text-primary); }
+  .dock-expand:focus-visible { outline: none; box-shadow: var(--shadow-ring); }
+
+  @media (prefers-reduced-motion: reduce) {
+    .dock-dot, .dock-fill-indeterminate { animation: none; }
+  }
+</style>

--- a/frontend/src/components/ApplyProgressModal.svelte
+++ b/frontend/src/components/ApplyProgressModal.svelte
@@ -516,7 +516,7 @@
   }}
   tabindex="-1"
 ></div>
-<div class="modal" transition:fly={{ y: 20, duration: 200 }} role="dialog" aria-labelledby="apply-modal-title">
+<div class="modal glass-dialog" transition:fly={{ y: 20, duration: 200 }} role="dialog" aria-labelledby="apply-modal-title">
   <header class="modal-head">
     <div class="head-left">
       <div class="head-eyebrow-row">
@@ -553,7 +553,7 @@
       </div>
     </div>
     <button
-      class="modal-close"
+      class="dialog-close"
       onclick={() => allDone && dismiss()}
       disabled={!allDone}
       title={allDone ? "Close" : "Cancel running applies first"}
@@ -893,20 +893,15 @@
     width: clamp(680px, 60vw, 920px);
     max-width: 96vw;
     max-height: 92vh;
-    background: var(--bg-card);
-    border: 1px solid var(--border);
-    border-radius: var(--radius-3xl);
-    box-shadow: var(--shadow-lg);
     display: grid;
     grid-template-rows: auto auto 1fr auto;
     z-index: 201;
-    overflow: hidden;
     isolation: isolate;
   }
   .modal-head {
-    padding: 24px 28px 16px;
+    padding: 24px 56px 16px 28px;
     display: grid;
-    grid-template-columns: 1fr auto;
+    grid-template-columns: 1fr;
     gap: 14px;
     align-items: start;
   }
@@ -955,21 +950,8 @@
   .stat-chip.stat-failed .stat-num { color: var(--badge-red-fg); }
   .stat-chip.stat-failed .stat-word { color: var(--badge-red-fg); opacity: 0.75; }
   .head-files-summary { font-size: var(--fs-xs); color: var(--text-muted); font-variant-numeric: tabular-nums; margin-left: 4px; }
-  .modal-close {
-    width: 36px;
-    height: 36px;
-    padding: 0;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    border-radius: var(--radius-lg);
-    color: var(--text-muted);
-    background: transparent;
-    transition: background var(--dur-fast) var(--ease), color var(--dur-fast) var(--ease);
-  }
-  .modal-close:hover:not(:disabled) { background: var(--bg-card-hover); color: var(--text-primary); }
-  .modal-close:focus-visible { outline: none; box-shadow: var(--shadow-ring); }
-  .modal-close:disabled { opacity: 0.35; cursor: not-allowed; }
+  .dialog-close:disabled { opacity: 0.35; cursor: not-allowed; }
+  .dialog-close:disabled:hover { background: transparent; color: var(--text-muted); }
 
   .progress-track {
     height: 3px;

--- a/frontend/src/components/BrandMark.svelte
+++ b/frontend/src/components/BrandMark.svelte
@@ -1,0 +1,91 @@
+<script lang="ts">
+  import {
+    BRANDS,
+    brandfetchLogoUrl,
+    resolveBrandDomain,
+    resolveBrandKey,
+    type BrandKey,
+  } from "../lib/brands";
+
+  let {
+    key = undefined,
+    label = undefined,
+    size = 14,
+    showLabel = true,
+    tone = "color",
+  }: {
+    key?: string | null;
+    label?: string;
+    size?: number;
+    showLabel?: boolean;
+    tone?: "mono" | "color";
+  } = $props();
+
+  let resolved = $derived<BrandKey | null>(resolveBrandKey(key));
+  let brand = $derived(resolved ? BRANDS[resolved] : null);
+  let remoteUrl = $derived(brand ? null : brandfetchLogoUrl(resolveBrandDomain(key), { size: size * 2 }));
+  let remoteFailed = $state(false);
+  let showRemote = $derived(!brand && !!remoteUrl && !remoteFailed);
+  let text = $derived(label ?? brand?.label ?? key ?? "");
+  let accent = $derived(brand && tone === "color" ? `var(${brand.accentVar})` : "currentColor");
+
+  $effect(() => {
+    void remoteUrl;
+    remoteFailed = false;
+  });
+</script>
+
+<span class="brand-mark" data-tone={tone} title={text} aria-label={text}>
+  {#if brand}
+    <svg
+      class="brand-glyph"
+      style:width={`${size}px`}
+      style:height={`${size}px`}
+      style:color={accent}
+      viewBox={brand.viewBox}
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      <path d={brand.path} />
+    </svg>
+  {:else if showRemote}
+    <img
+      class="brand-img"
+      src={remoteUrl}
+      alt=""
+      width={size}
+      height={size}
+      loading="lazy"
+      aria-hidden="true"
+      onerror={() => (remoteFailed = true)}
+    />
+  {/if}
+  {#if showLabel && text}
+    <span class="brand-label">{text}</span>
+  {/if}
+</span>
+
+<style>
+  .brand-mark {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    min-width: 0;
+  }
+  .brand-glyph {
+    flex-shrink: 0;
+    display: block;
+  }
+  .brand-img {
+    flex-shrink: 0;
+    display: block;
+    object-fit: contain;
+    border-radius: var(--radius-xs, 3px);
+  }
+  .brand-label {
+    line-height: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+</style>

--- a/frontend/src/components/CatalogVersionsFlyout.svelte
+++ b/frontend/src/components/CatalogVersionsFlyout.svelte
@@ -214,8 +214,7 @@
 </script>
 
 <div class="flyout-backdrop" role="presentation" onclick={onClose} onkeydown={handleKey} tabindex="-1"></div>
-<div class="flyout" transition:fly={{ y: -8, duration: 160 }} role="dialog" aria-label={headerTitle} tabindex="-1" onkeydown={handleKey}>
-  <div class="vendor-stripe" style:background={accent}></div>
+<div class="flyout glass-dialog" transition:fly={{ y: -8, duration: 160 }} style:--edge-color={accent} role="dialog" aria-label={headerTitle} tabindex="-1" onkeydown={handleKey}>
   <header class="flyout-head">
     {#if mode === "versions" && catalogKey === "advanced"}
       <button class="flyout-back" onclick={backToModules} aria-label="Back to modules">
@@ -229,7 +228,7 @@
       <span class="title-line">{headerTitle}</span>
       <span class="subtitle-line">{headerSubtitle}</span>
     </div>
-    <button class="flyout-close" onclick={onClose} aria-label="Close">
+    <button class="dialog-close" onclick={onClose} aria-label="Close">
       <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
     </button>
   </header>
@@ -369,31 +368,20 @@
     transform: translate(-50%, -50%);
     width: min(720px, 94vw);
     max-height: 84vh;
-    background: var(--bg-card);
-    border: 1px solid var(--border-strong);
-    border-radius: var(--radius-lg);
-    box-shadow: var(--shadow-lg);
     display: flex;
     flex-direction: column;
     z-index: 221;
-    overflow: hidden;
-  }
-  .vendor-stripe {
-    position: absolute;
-    top: 0; left: 0; right: 0;
-    height: 3px;
-    opacity: 0.9;
   }
   .flyout-head {
-    padding: 18px 20px 14px;
+    padding: 18px 52px 14px 20px;
     border-bottom: 1px solid var(--border);
     display: grid;
-    grid-template-columns: auto 44px 1fr auto;
+    grid-template-columns: auto 44px 1fr;
     gap: 14px;
     align-items: center;
   }
-  .flyout-head:has(.flyout-back) { grid-template-columns: 30px 44px 1fr auto; }
-  .flyout-head:not(:has(.flyout-back)) { grid-template-columns: 44px 1fr auto; }
+  .flyout-head:has(.flyout-back) { grid-template-columns: 30px 44px 1fr; }
+  .flyout-head:not(:has(.flyout-back)) { grid-template-columns: 44px 1fr; }
   .flyout-back {
     width: 28px;
     height: 28px;
@@ -416,17 +404,6 @@
   .flyout-title { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
   .title-line { font-size: var(--fs-lg); font-weight: 700; color: var(--text-primary); letter-spacing: var(--letter-tight); }
   .subtitle-line { font-size: var(--fs-sm); color: var(--text-secondary); line-height: 1.4; }
-  .flyout-close {
-    width: 30px;
-    height: 30px;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    color: var(--text-muted);
-    border-radius: var(--radius-sm);
-    flex-shrink: 0;
-  }
-  .flyout-close:hover { background: var(--bg-elevated); color: var(--text-primary); }
 
   .flyout-toolbar {
     padding: 10px 20px;

--- a/frontend/src/components/CommandPalette.svelte
+++ b/frontend/src/components/CommandPalette.svelte
@@ -21,39 +21,128 @@
     LIBRARY_VIEW_MODES,
     LIBRARY_DENSITIES,
     matchCommands,
+    matchedIndices,
+    highlightSegments,
     pushRecentCommand,
     isModifierComboMatch,
     type PaletteCommand,
     type CommandCategory,
   } from "../lib/ux";
   import { getAppPaths, revealPath } from "../lib/api";
+  import Search from "@lucide/svelte/icons/search";
+  import Command from "@lucide/svelte/icons/command";
+  import LayoutGrid from "@lucide/svelte/icons/layout-grid";
+  import LayoutList from "@lucide/svelte/icons/layout-list";
+  import Layers from "@lucide/svelte/icons/layers";
+  import Archive from "@lucide/svelte/icons/archive";
+  import Settings from "@lucide/svelte/icons/settings";
+  import Info from "@lucide/svelte/icons/info";
+  import DownloadCloud from "@lucide/svelte/icons/download-cloud";
+  import RefreshCw from "@lucide/svelte/icons/refresh-cw";
+  import RotateCw from "@lucide/svelte/icons/rotate-cw";
+  import ArrowUpCircle from "@lucide/svelte/icons/arrow-up-circle";
+  import Undo2 from "@lucide/svelte/icons/undo-2";
+  import Folder from "@lucide/svelte/icons/folder";
+  import FolderArchive from "@lucide/svelte/icons/folder-archive";
+  import ScrollText from "@lucide/svelte/icons/scroll-text";
+  import SunMoon from "@lucide/svelte/icons/sun-moon";
+  import Rows3 from "@lucide/svelte/icons/rows-3";
+  import SlidersHorizontal from "@lucide/svelte/icons/sliders-horizontal";
+  import Radar from "@lucide/svelte/icons/radar";
+  import Image from "@lucide/svelte/icons/image";
+  import Wrench from "@lucide/svelte/icons/wrench";
+
+  const ICONS: Record<string, typeof LayoutGrid> = {
+    "layout-grid": LayoutGrid,
+    "layout-list": LayoutList,
+    layers: Layers,
+    archive: Archive,
+    settings: Settings,
+    info: Info,
+    "download-cloud": DownloadCloud,
+    "refresh-cw": RefreshCw,
+    "rotate-cw": RotateCw,
+    "arrow-up-circle": ArrowUpCircle,
+    "undo-2": Undo2,
+    folder: Folder,
+    "folder-archive": FolderArchive,
+    "scroll-text": ScrollText,
+    "sun-moon": SunMoon,
+    "rows-3": Rows3,
+    "sliders-horizontal": SlidersHorizontal,
+    radar: Radar,
+    image: Image,
+    wrench: Wrench,
+  };
 
   let query = $state("");
   let selectedIndex = $state(0);
   let category = $state<"all" | CommandCategory>("all");
   let inputEl: HTMLInputElement | undefined = $state();
+  let resultsEl: HTMLDivElement | undefined = $state();
 
   const categories: readonly ("all" | CommandCategory)[] = ["all", "navigate", "action", "settings"];
+  const RESULT_CATEGORIES: readonly CommandCategory[] = ["navigate", "action", "settings"];
 
   let recentIds = $derived($settings?.ui_prefs.command_palette_recent ?? []);
 
-  let baseCommands = $derived.by(() => {
-    if (!query.trim() && recentIds.length > 0) {
-      const recentSet = new Set(recentIds);
-      const recents = recentIds
-        .map((id) => COMMANDS.find((c) => c.id === id))
-        .filter((c): c is PaletteCommand => c !== undefined);
-      const rest = COMMANDS.filter((c) => !recentSet.has(c.id));
-      return [...recents, ...rest];
+  interface ResultItem {
+    cmd: PaletteCommand;
+    ranges: number[];
+    index: number;
+  }
+  interface ResultGroup {
+    key: string;
+    label: string;
+    items: ResultItem[];
+  }
+
+  let view = $derived.by<{ groups: ResultGroup[]; flat: PaletteCommand[] }>(() => {
+    const q = query.trim();
+    const raw: { key: string; label: string; cmds: { cmd: PaletteCommand; ranges: number[] }[] }[] = [];
+
+    if (!q) {
+      if (category === "all" && recentIds.length > 0) {
+        const recents = recentIds
+          .map((id) => COMMANDS.find((c) => c.id === id))
+          .filter((c): c is PaletteCommand => c !== undefined);
+        if (recents.length > 0) {
+          raw.push({ key: "recent", label: "Recent", cmds: recents.map((cmd) => ({ cmd, ranges: [] })) });
+        }
+      }
+      const exclude = new Set(category === "all" ? recentIds : []);
+      for (const cat of RESULT_CATEGORIES) {
+        if (category !== "all" && category !== cat) continue;
+        const cmds = COMMANDS.filter((c) => c.category === cat && !exclude.has(c.id)).map((cmd) => ({ cmd, ranges: [] as number[] }));
+        if (cmds.length > 0) raw.push({ key: cat, label: COMMAND_CATEGORY_LABELS[cat], cmds });
+      }
+    } else {
+      const pool = category === "all" ? COMMANDS : COMMANDS.filter((c) => c.category === category);
+      const matches = matchCommands(q, pool);
+      for (const cat of RESULT_CATEGORIES) {
+        if (category !== "all" && category !== cat) continue;
+        const cmds = matches
+          .filter((m) => m.command.category === cat)
+          .map((m) => ({ cmd: m.command, ranges: matchedIndices(q, m.command.title) }));
+        if (cmds.length > 0) raw.push({ key: cat, label: COMMAND_CATEGORY_LABELS[cat], cmds });
+      }
     }
-    return COMMANDS;
+
+    const flat: PaletteCommand[] = [];
+    const groups: ResultGroup[] = raw.map((g) => ({
+      key: g.key,
+      label: g.label,
+      items: g.cmds.map(({ cmd, ranges }) => {
+        const item: ResultItem = { cmd, ranges, index: flat.length };
+        flat.push(cmd);
+        return item;
+      }),
+    }));
+    return { groups, flat };
   });
 
-  let filtered = $derived.by(() => {
-    const pool = category === "all" ? baseCommands : baseCommands.filter((c) => c.category === category);
-    const matches = matchCommands(query, pool);
-    return matches.map((m) => m.command);
-  });
+  let groups = $derived(view.groups);
+  let flat = $derived(view.flat);
 
   $effect(() => {
     if ($commandPaletteOpen) {
@@ -64,7 +153,15 @@
   });
 
   $effect(() => {
-    if (selectedIndex >= filtered.length) selectedIndex = Math.max(0, filtered.length - 1);
+    if (selectedIndex >= flat.length) selectedIndex = Math.max(0, flat.length - 1);
+  });
+
+  $effect(() => {
+    if (!$commandPaletteOpen) return;
+    void selectedIndex;
+    void tick().then(() => {
+      resultsEl?.querySelector(".result.active")?.scrollIntoView({ block: "nearest" });
+    });
   });
 
   onMount(() => {
@@ -194,19 +291,19 @@
     }
     if (e.key === "ArrowDown") {
       e.preventDefault();
-      if (filtered.length === 0) return;
-      selectedIndex = (selectedIndex + 1) % filtered.length;
+      if (flat.length === 0) return;
+      selectedIndex = (selectedIndex + 1) % flat.length;
       return;
     }
     if (e.key === "ArrowUp") {
       e.preventDefault();
-      if (filtered.length === 0) return;
-      selectedIndex = (selectedIndex - 1 + filtered.length) % filtered.length;
+      if (flat.length === 0) return;
+      selectedIndex = (selectedIndex - 1 + flat.length) % flat.length;
       return;
     }
     if (e.key === "Enter") {
       e.preventDefault();
-      const cmd = filtered[selectedIndex];
+      const cmd = flat[selectedIndex];
       if (cmd) void runCommand(cmd);
     }
   }
@@ -228,9 +325,7 @@
   >
     <div class="palette" style="max-width: {COMMAND_PALETTE_MAX_WIDTH_PX}px; max-height: {COMMAND_PALETTE_MAX_HEIGHT_PX}px;">
       <div class="palette-search">
-        <svg class="palette-search-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-          <circle cx="11" cy="11" r="7"/><line x1="21" y1="21" x2="16.65" y2="16.65"/>
-        </svg>
+        <Search class="palette-search-icon" size={18} strokeWidth={2.2} />
         <input
           bind:this={inputEl}
           bind:value={query}
@@ -240,6 +335,7 @@
           spellcheck="false"
           autocomplete="off"
         />
+        <kbd class="palette-search-kbd">Esc</kbd>
       </div>
 
       <div class="palette-categories">
@@ -253,26 +349,50 @@
         <span class="tab-hint">Tab to cycle</span>
       </div>
 
-      <div class="palette-results">
-        {#if filtered.length === 0}
-          <div class="empty">No matching commands</div>
+      <div class="palette-results" bind:this={resultsEl}>
+        {#if flat.length === 0}
+          <div class="palette-empty">
+            <span class="palette-empty-mark" aria-hidden="true"><Command size={20} strokeWidth={2} /></span>
+            <span class="palette-empty-title">No commands match “{query.trim()}”</span>
+            <span class="palette-empty-hint">Try a view name, a vendor, or an action.</span>
+          </div>
         {:else}
-          {#each filtered as cmd, i (cmd.id)}
-            <button
-              class="result"
-              class:active={i === selectedIndex}
-              onclick={() => void runCommand(cmd)}
-              onmouseenter={() => { selectedIndex = i; }}
-            >
-              <span class="result-tag" data-cat={cmd.category}>{COMMAND_CATEGORY_LABELS[cmd.category]}</span>
-              <span class="title">{cmd.title}</span>
-              {#if !query.trim() && recentIds.includes(cmd.id)}
-                <span class="recent-tag">recent</span>
-              {/if}
-              {#if i === selectedIndex}
-                <span class="enter-hint" aria-hidden="true">↵</span>
-              {/if}
-            </button>
+          {#each groups as group (group.key)}
+            <div class="result-group" data-cat={group.key}>
+              <div class="result-group-head">{group.label}</div>
+              {#each group.items as item (item.cmd.id)}
+                {@const Icon = ICONS[item.cmd.icon] ?? Command}
+                <button
+                  class="result"
+                  class:active={item.index === selectedIndex}
+                  data-cat={item.cmd.category}
+                  onclick={() => void runCommand(item.cmd)}
+                  onmouseenter={() => { selectedIndex = item.index; }}
+                >
+                  <span class="result-icon" data-cat={item.cmd.category} aria-hidden="true"><Icon size={16} strokeWidth={2} /></span>
+                  <span class="result-text">
+                    <span class="result-title">
+                      {#each highlightSegments(item.cmd.title, item.ranges) as seg}
+                        {#if seg.hit}<mark class="result-hl">{seg.text}</mark>{:else}{seg.text}{/if}
+                      {/each}
+                    </span>
+                    {#if item.cmd.hint}
+                      <span class="result-hint">{item.cmd.hint}</span>
+                    {/if}
+                  </span>
+                  {#if item.cmd.shortcut}
+                    <span class="result-shortcut" aria-hidden="true">
+                      {#each item.cmd.shortcut as key}
+                        <kbd>{key.toUpperCase()}</kbd>
+                      {/each}
+                    </span>
+                  {/if}
+                  {#if item.index === selectedIndex}
+                    <span class="enter-hint" aria-hidden="true">↵</span>
+                  {/if}
+                </button>
+              {/each}
+            </div>
           {/each}
         {/if}
       </div>
@@ -291,19 +411,19 @@
   .palette-backdrop {
     position: fixed;
     inset: 0;
-    background: var(--bg-overlay);
-    backdrop-filter: blur(8px);
-    -webkit-backdrop-filter: blur(8px);
+    background: transparent;
     z-index: 200;
     display: flex;
     align-items: flex-start;
-    justify-content: center;
-    padding-top: 12vh;
+    justify-content: flex-end;
+    padding: calc(var(--topbar-height) + 6px) 12px 0;
     animation: fadeIn var(--dur-fast) var(--ease-out);
   }
   .palette {
-    width: 92%;
-    background: var(--bg-card);
+    width: min(460px, calc(100vw - 24px));
+    background: var(--glass-strong);
+    backdrop-filter: var(--glass-blur);
+    -webkit-backdrop-filter: var(--glass-blur);
     border: 1px solid var(--border);
     border-radius: var(--radius-2xl);
     box-shadow: var(--shadow-lg);
@@ -315,28 +435,40 @@
   .palette-search {
     display: flex;
     align-items: center;
-    gap: 14px;
-    padding: 20px 22px;
+    gap: 12px;
+    padding: 15px 16px;
     color: var(--text-muted);
   }
-  .palette-search-icon { flex-shrink: 0; }
+  .palette-search :global(.palette-search-icon) { flex-shrink: 0; color: var(--text-muted); }
   .palette-search input {
     flex: 1;
+    min-width: 0;
     background: transparent;
     border: none;
     color: var(--text-primary);
-    font-size: 19px;
+    font-size: 16px;
     font-weight: 500;
     letter-spacing: var(--letter-tight);
     padding: 0;
     outline: none;
   }
   .palette-search input::placeholder { color: var(--text-placeholder); font-weight: 400; }
+  .palette-search input::selection { background: var(--accent-soft); color: var(--text-primary); }
+  .palette-search-kbd {
+    flex-shrink: 0;
+    font-size: var(--fs-2xs);
+    font-weight: 600;
+    color: var(--text-muted);
+    padding: 2px 6px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border);
+    background: var(--bg-card);
+  }
   .palette-categories {
     display: flex;
     align-items: center;
     gap: 4px;
-    padding: 0 18px 12px;
+    padding: 0 16px 12px;
   }
   .category {
     font-size: var(--fs-xs);
@@ -353,46 +485,94 @@
   .palette-results {
     flex: 1;
     overflow-y: auto;
-    padding: 6px 10px;
+    padding: 6px 8px 8px;
     border-top: 1px solid var(--border);
   }
-  .empty {
-    padding: 32px 16px;
-    text-align: center;
-    color: var(--text-muted);
-    font-size: var(--fs-sm);
-  }
-  .result {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-    width: 100%;
-    padding: 11px 14px;
-    border-radius: var(--radius-lg);
-    text-align: left;
-    color: var(--text-secondary);
-    transition: background var(--dur-fast) var(--ease), color var(--dur-fast) var(--ease);
-  }
-  .result.active { background: var(--accent-soft); color: var(--text-primary); }
-  .result-tag {
-    flex-shrink: 0;
-    width: 64px;
+  .result-group { padding: 4px 0; }
+  .result-group-head {
+    padding: 8px 12px 4px;
     font-size: var(--fs-2xs);
     font-weight: 700;
     text-transform: uppercase;
     letter-spacing: var(--letter-wider);
     color: var(--text-muted);
   }
-  .result-tag[data-cat="navigate"] { color: var(--badge-blue-fg); }
-  .result-tag[data-cat="action"] { color: var(--badge-green-fg); }
-  .result-tag[data-cat="settings"] { color: var(--badge-purple-fg); }
-  .title { flex: 1; font-size: var(--fs-sm); font-weight: 500; }
-  .recent-tag {
-    font-size: 9px;
+  .palette-empty {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 6px;
+    padding: 40px 16px;
+    text-align: center;
+  }
+  .palette-empty-mark {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 44px;
+    height: 44px;
+    border-radius: var(--radius-lg);
+    background: var(--bg-elevated);
     color: var(--text-muted);
-    text-transform: uppercase;
-    letter-spacing: var(--letter-wider);
+    margin-bottom: 4px;
+  }
+  .palette-empty-title { font-size: var(--fs-sm); font-weight: 600; color: var(--text-primary); }
+  .palette-empty-hint { font-size: var(--fs-xs); color: var(--text-muted); }
+  .result {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    width: 100%;
+    padding: 9px 12px;
+    border-radius: var(--radius-lg);
+    text-align: left;
+    color: var(--text-secondary);
+    transition: background var(--dur-fast) var(--ease), color var(--dur-fast) var(--ease);
+  }
+  .result.active { background: var(--accent-soft); color: var(--text-primary); }
+  .result-icon {
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 30px;
+    height: 30px;
+    border-radius: var(--radius-md);
+    background: var(--bg-elevated);
+    color: var(--text-muted);
+  }
+  .result-icon[data-cat="navigate"] { color: var(--badge-blue-fg); background: color-mix(in oklab, var(--badge-blue-fg) 14%, transparent); }
+  .result-icon[data-cat="action"] { color: var(--badge-green-fg); background: color-mix(in oklab, var(--badge-green-fg) 14%, transparent); }
+  .result-icon[data-cat="settings"] { color: var(--badge-purple-fg); background: color-mix(in oklab, var(--badge-purple-fg) 14%, transparent); }
+  .result-text { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 1px; }
+  .result-title { font-size: var(--fs-sm); font-weight: 500; color: inherit; }
+  .result-hl {
+    background: transparent;
+    color: var(--accent);
     font-weight: 700;
+  }
+  .result.active .result-hl { color: var(--accent); }
+  .result-hint {
+    font-size: var(--fs-2xs);
+    color: var(--text-muted);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .result-shortcut { flex-shrink: 0; display: inline-flex; gap: 3px; }
+  .result-shortcut kbd {
+    min-width: 18px;
+    height: 18px;
+    padding: 0 5px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: var(--fs-2xs);
+    font-weight: 600;
+    color: var(--text-muted);
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
   }
   .enter-hint {
     flex-shrink: 0;

--- a/frontend/src/components/ContextMenu.svelte
+++ b/frontend/src/components/ContextMenu.svelte
@@ -1,0 +1,172 @@
+<script lang="ts" module>
+  export type ContextMenuAction = "open_folder" | "scan" | "pin" | "hide";
+  export interface ContextMenuItem {
+    action: ContextMenuAction;
+    label: string;
+  }
+</script>
+
+<script lang="ts">
+  import { tick } from "svelte";
+
+  let { x, y, items, onSelect, onClose }: {
+    x: number;
+    y: number;
+    items: ContextMenuItem[];
+    onSelect: (action: ContextMenuAction) => void;
+    onClose: () => void;
+  } = $props();
+
+  const ICONS: Record<ContextMenuAction, string> = {
+    open_folder: "M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z",
+    scan: "M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15",
+    pin: "M12 17v5M9 10.76a2 2 0 0 1-1.11 1.79l-1.78.9A2 2 0 0 0 5 15.24V16a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-.76a2 2 0 0 0-1.11-1.79l-1.78-.9A2 2 0 0 1 15 10.76V7a1 1 0 0 1 1-1 2 2 0 0 0 0-4H8a2 2 0 0 0 0 4 1 1 0 0 1 1 1z",
+    hide: "M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8zM4.93 4.93l14.14 14.14",
+  };
+
+  let menuEl = $state<HTMLElement | undefined>(undefined);
+  let clamped = $state<{ left: number; top: number } | null>(null);
+  let pos = $derived(clamped ?? { left: x, top: y });
+
+  $effect(() => {
+    void tick().then(() => {
+      if (!menuEl) return;
+      const rect = menuEl.getBoundingClientRect();
+      const margin = 8;
+      let left = x;
+      let top = y;
+      if (left + rect.width > window.innerWidth - margin) {
+        left = Math.max(margin, window.innerWidth - rect.width - margin);
+      }
+      if (top + rect.height > window.innerHeight - margin) {
+        top = Math.max(margin, window.innerHeight - rect.height - margin);
+      }
+      clamped = { left, top };
+      const first = menuEl.querySelector<HTMLElement>('[role="menuitem"]');
+      first?.focus();
+    });
+  });
+
+  function buttons(): HTMLElement[] {
+    if (!menuEl) return [];
+    return Array.from(menuEl.querySelectorAll<HTMLElement>('[role="menuitem"]'));
+  }
+
+  function moveFocus(delta: number): void {
+    const list = buttons();
+    if (list.length === 0) return;
+    const idx = list.findIndex((b) => b === document.activeElement);
+    const next = (idx + delta + list.length) % list.length;
+    list[next].focus();
+  }
+
+  function onKey(e: KeyboardEvent): void {
+    switch (e.key) {
+      case "ArrowDown":
+        e.preventDefault();
+        moveFocus(1);
+        break;
+      case "ArrowUp":
+        e.preventDefault();
+        moveFocus(-1);
+        break;
+      case "Home":
+        e.preventDefault();
+        buttons()[0]?.focus();
+        break;
+      case "End": {
+        e.preventDefault();
+        const list = buttons();
+        list[list.length - 1]?.focus();
+        break;
+      }
+      case "Escape":
+        e.preventDefault();
+        onClose();
+        break;
+    }
+  }
+
+  function choose(action: ContextMenuAction): void {
+    onSelect(action);
+    onClose();
+  }
+</script>
+
+<svelte:window
+  onpointerdown={(e) => {
+    if (menuEl && !menuEl.contains(e.target as Node)) onClose();
+  }}
+  onresize={onClose}
+/>
+
+<div
+  class="context-menu glass-panel"
+  bind:this={menuEl}
+  role="menu"
+  tabindex="-1"
+  aria-label="Game actions"
+  style:left="{pos.left}px"
+  style:top="{pos.top}px"
+  onkeydown={onKey}
+>
+  {#each items as item (item.action)}
+    <button
+      class="ctx-item press"
+      class:is-danger={item.action === "hide"}
+      role="menuitem"
+      tabindex="-1"
+      onclick={() => choose(item.action)}
+    >
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <path d={ICONS[item.action]} />
+      </svg>
+      <span>{item.label}</span>
+    </button>
+  {/each}
+</div>
+
+<style>
+  .context-menu {
+    position: fixed;
+    z-index: 220;
+    min-width: 168px;
+    padding: 5px;
+    border-radius: var(--radius-md);
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+  }
+  .ctx-item {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    width: 100%;
+    padding: 8px 10px;
+    border: none;
+    background: transparent;
+    color: var(--text-secondary);
+    font-size: var(--fs-sm);
+    font-weight: 500;
+    text-align: left;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    transition: background var(--dur-fast) var(--ease), color var(--dur-fast) var(--ease);
+  }
+  .ctx-item svg { flex-shrink: 0; color: var(--text-muted); }
+  .ctx-item:hover,
+  .ctx-item:focus-visible {
+    outline: none;
+    background: var(--bg-elevated);
+    color: var(--text-primary);
+  }
+  .ctx-item:hover svg,
+  .ctx-item:focus-visible svg { color: var(--accent); }
+  .ctx-item.is-danger:hover,
+  .ctx-item.is-danger:focus-visible {
+    background: var(--danger-dim);
+    color: var(--danger);
+  }
+  .ctx-item.is-danger:hover svg,
+  .ctx-item.is-danger:focus-visible svg { color: var(--danger); }
+</style>

--- a/frontend/src/components/DlssOverridePanel.svelte
+++ b/frontend/src/components/DlssOverridePanel.svelte
@@ -3,10 +3,11 @@
   import {
     applyDlssOverride,
     resetDlssOverride,
-    readDlssOverride,
+    readDlssOverrideConfig,
     openUrl,
     type OverrideScope,
     type DlssOverrideConfig,
+    type DlssOverrideSource,
     type DlssPreset,
     type FrameGenMode,
     type FrameGenCount,
@@ -51,6 +52,16 @@
   let config = $state<DlssOverrideConfig>(emptyDlssConfig());
   let busy = $state(false);
   let activeCount = $state(0);
+  let source = $state<DlssOverrideSource>("none");
+  let sourceLabel = $derived(
+    source === "none"
+      ? null
+      : source === "per_game"
+        ? "From NVIDIA driver"
+        : scope.scope === "global"
+          ? "Set in NVIDIA driver"
+          : "Inherited from Global default",
+  );
 
   let dlss4Ok = $derived(driverPacked === 0 || dlss4Available(driverPacked));
   let dynamicOk = $derived(driverPacked === 0 || dynamicMfgAvailable(driverPacked));
@@ -61,10 +72,13 @@
 
   async function refresh(): Promise<void> {
     try {
-      const values = await readDlssOverride(scope);
-      activeCount = values.filter((v) => v.value != null && v.value !== 0).length;
+      const readback = await readDlssOverrideConfig(scope);
+      config = readback.config;
+      activeCount = readback.active_count;
+      source = readback.source;
     } catch {
       activeCount = 0;
+      source = "none";
     }
   }
 
@@ -81,8 +95,15 @@
   async function apply(): Promise<void> {
     busy = true;
     try {
-      await applyDlssOverride(scope, config);
-      showToast("success", "DLSS override applied — restart the game to take effect.");
+      const outcome = await applyDlssOverride(scope, config);
+      if (outcome.needs_elevation) {
+        showToast(
+          "warning",
+          "Super Resolution applied. Frame-generation overrides need administrator — relaunch DLSSync as administrator to apply them.",
+        );
+      } else {
+        showToast("success", "DLSS override applied — restart the game to take effect.");
+      }
       await refresh();
     } catch (err) {
       showToast("danger", `Apply failed: ${err}`);
@@ -110,6 +131,10 @@
   <div class="dlss-head">
     <h4>DLSS Overrides{scope.scope === "global" ? " — Global default" : ""}</h4>
     {#if activeCount > 0}<span class="dlss-active">{activeCount} active</span>{/if}
+    {#if sourceLabel}<span class="dlss-source">{sourceLabel}</span>{/if}
+    <button class="dlss-refresh" onclick={refresh} title="Re-read the current values from the NVIDIA driver">
+      Refresh from driver
+    </button>
   </div>
 
   {#if !dlss4Ok}
@@ -237,6 +262,27 @@
     background: var(--update-dim, var(--accent-dim));
     color: var(--update, var(--accent));
   }
+  .dlss-source {
+    font-size: 11px;
+    font-weight: 600;
+    padding: 2px 8px;
+    border-radius: var(--radius-full);
+    background: var(--bg-elevated);
+    color: var(--text-secondary);
+  }
+  .dlss-refresh {
+    margin-left: auto;
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--text-secondary);
+    padding: 4px 8px;
+    border-radius: var(--radius-sm);
+    background: transparent;
+    white-space: nowrap;
+    transition: color var(--dur-fast) var(--ease), background var(--dur-fast) var(--ease);
+  }
+  .dlss-refresh:hover { color: var(--accent); background: var(--accent-dim); }
+  .dlss-refresh:focus-visible { outline: none; box-shadow: var(--shadow-ring); }
   .dlss-warn {
     font-size: 12px;
     color: var(--warning, #d6a032);

--- a/frontend/src/components/DriverHistoryFlyout.svelte
+++ b/frontend/src/components/DriverHistoryFlyout.svelte
@@ -9,6 +9,8 @@
     showToast,
   } from "../lib/stores";
   import { installDriver, openUrl, type DriverReleaseDto, type GpuVendor } from "../lib/api";
+  import BrandMark from "./BrandMark.svelte";
+  import { BRANDS } from "../lib/brands";
 
   let {
     vendor,
@@ -22,12 +24,7 @@
     onClose: () => void;
   } = $props();
 
-  const VENDOR_LABEL: Record<GpuVendor, string> = {
-    nvidia: "NVIDIA",
-    amd: "AMD",
-    intel: "Intel",
-    other: "GPU",
-  };
+  let vendorName = $derived(vendor === "other" ? "GPU" : BRANDS[vendor].label);
 
   let query = $state("");
   let whqlOnly = $state(false);
@@ -117,23 +114,27 @@
   tabindex="-1"
 ></div>
 <div
-  class="flyout"
+  class="flyout glass-dialog"
   transition:fly={{ y: -8, duration: 160 }}
+  style:--edge-color={accent}
   role="dialog"
-  aria-label={`${VENDOR_LABEL[vendor]} driver history for ${model}`}
+  aria-label={`${vendorName} driver history for ${model}`}
   tabindex="-1"
   onkeydown={handleKey}
 >
-  <div class="vendor-stripe" style:background={accent}></div>
   <header class="flyout-head">
     <span class="vendor-pill" data-vendor={vendor} style:color={accent}>
-      {VENDOR_LABEL[vendor]}
+      {#if vendor === "other"}
+        {vendorName}
+      {:else}
+        <BrandMark key={vendor} tone="mono" size={12} />
+      {/if}
     </span>
     <div class="flyout-title">
       <span class="title-line">{model}</span>
       <span class="subtitle-line">Every driver version known compatible with this GPU</span>
     </div>
-    <button class="flyout-close" onclick={onClose} aria-label="Close">
+    <button class="dialog-close" onclick={onClose} aria-label="Close">
       <svg
         width="14"
         height="14"
@@ -242,27 +243,14 @@
     width: min(720px, 92vw);
     max-height: 84vh;
     z-index: 81;
-    background: var(--bg-card);
-    border: 1px solid var(--border);
-    border-radius: var(--radius-lg);
-    overflow: hidden;
     display: flex;
     flex-direction: column;
-    box-shadow: 0 30px 70px rgba(0, 0, 0, 0.5);
-  }
-  .vendor-stripe {
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    height: 2px;
-    opacity: 0.85;
   }
   .flyout-head {
     display: flex;
     align-items: center;
     gap: 12px;
-    padding: 16px 18px 14px;
+    padding: 16px 50px 14px 18px;
     border-bottom: 1px solid var(--border);
   }
   .vendor-pill {
@@ -277,16 +265,6 @@
   .flyout-title { display: flex; flex-direction: column; gap: 2px; min-width: 0; flex: 1; }
   .title-line { font-size: 15px; font-weight: 700; color: var(--text-primary); }
   .subtitle-line { font-size: 12px; color: var(--text-muted); }
-  .flyout-close {
-    width: 28px;
-    height: 28px;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    border-radius: var(--radius-sm);
-    color: var(--text-muted);
-  }
-  .flyout-close:hover { color: var(--text-primary); background: var(--bg-elevated); }
 
   .flyout-toolbar {
     display: flex;

--- a/frontend/src/components/GameCard.svelte
+++ b/frontend/src/components/GameCard.svelte
@@ -8,23 +8,25 @@
     featureIconId,
     featureVendor,
     FEATURE_ORDER,
-    VENDOR_ACCENTS,
-    GROUP_ACCENT,
+    vendorAccentVar,
+    GROUP_ACCENT_VAR,
     type UpdateStatus,
     type FeatureSlot,
   } from "../lib/labels";
   import { gameDlls, gameDllsLoading, gameStatuses, relationContext } from "../lib/stores";
   import { dllRelation } from "../lib/relation";
   import { launcherIcon } from "../lib/launcherIcons";
+  import { setActiveArt } from "../lib/artContext";
   import FeatureIcon from "./FeatureIcon.svelte";
 
-  let { game, hidden = false, onApply, onOpenFolder, onBlacklist, onClick }: {
+  let { game, hidden = false, onApply, onOpenFolder, onBlacklist, onClick, onContextMenu }: {
     game: DetectedGame;
     hidden?: boolean;
     onApply: (g: DetectedGame) => void;
     onOpenFolder: (g: DetectedGame) => void;
     onBlacklist: (g: DetectedGame) => void;
     onClick: (g: DetectedGame) => void;
+    onContextMenu?: (g: DetectedGame, e: MouseEvent) => void;
   } = $props();
 
   function handleCardKey(e: KeyboardEvent): void {
@@ -66,7 +68,7 @@
           outdated: out,
           count: 1,
           vendorAccent:
-            f === "advanced" ? GROUP_ACCENT.advanced : VENDOR_ACCENTS[featureVendor(f)] ?? GROUP_ACCENT.advanced,
+            f === "advanced" ? GROUP_ACCENT_VAR.advanced : vendorAccentVar(featureVendor(f)),
           short: f === "advanced" ? "Other" : featureShort(f),
           iconId: featureIconId(f),
         });
@@ -104,7 +106,10 @@
   role="button"
   tabindex="0"
   onclick={() => onClick(game)}
+  oncontextmenu={onContextMenu ? (e) => { e.preventDefault(); onContextMenu(game, e); } : undefined}
   onkeydown={handleCardKey}
+  onmouseenter={() => setActiveArt(game.image_url)}
+  onfocus={() => setActiveArt(game.image_url)}
 >
   <div class="art" style:--launcher-accent={accent}>
     {#if game.image_url && !imgErrored}
@@ -451,9 +456,9 @@
     font-size: 10.5px;
     font-weight: 600;
     border-radius: var(--radius-sm);
-    background: var(--bg-elevated);
+    background: color-mix(in oklab, var(--chip-accent, var(--accent)) 8%, var(--bg-elevated));
     color: var(--text-secondary);
-    border: 1px solid var(--border);
+    border: 1px solid color-mix(in oklab, var(--chip-accent, var(--accent)) 28%, var(--border));
     letter-spacing: 0.01em;
   }
   .feature-chip.outdated {

--- a/frontend/src/components/GameDetailDrawer.svelte
+++ b/frontend/src/components/GameDetailDrawer.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
-  import { fly, fade } from "svelte/transition";
-  import { cubicOut, backIn } from "svelte/easing";
+  import { onDestroy } from "svelte";
+  import { setActiveArt, clearActiveArt } from "../lib/artContext";
   import { EXTERNAL_URLS } from "../lib/ux";
   import {
     games,
     gameDlls,
+    gameDlssEnabler,
     gameDllsLoading,
     gameDllErrors,
     catalogLatestByKey,
@@ -12,11 +13,12 @@
     settings,
     persistSettings,
     showToast,
+    optimisticToggle,
     rescanGame,
     driverReports,
   } from "../lib/stores";
-  import { dllRelation, targetVersion } from "../lib/relation";
-  import { addBlacklistEntry, removeBlacklistEntry, findGameExecutable, detectAnticheat, type DllRecord, type AntiCheatReport } from "../lib/api";
+  import { dllRelation, targetVersion, recordUpdatable } from "../lib/relation";
+  import { addBlacklistEntry, removeBlacklistEntry, findGameExecutable, detectAnticheat, saveSettings, type AppSettings, type DllRecord, type AntiCheatReport } from "../lib/api";
   import { hasAntiCheat, statusNote, warningMessage, severity } from "../lib/anticheat";
   import DlssOverridePanel from "./DlssOverridePanel.svelte";
   import { dispatchApply, type ApplyTarget } from "../lib/applyController";
@@ -41,6 +43,7 @@
   } from "../lib/labels";
   import VersionPickerPopover from "./VersionPickerPopover.svelte";
   import FeatureIcon from "./FeatureIcon.svelte";
+  import ContextMenu, { type ContextMenuAction } from "./ContextMenu.svelte";
 
   let { gameId, onClose, onApplyStart }: {
     gameId: string;
@@ -49,7 +52,16 @@
   } = $props();
 
   let game = $derived($games.find((g) => g.id === gameId));
+  $effect(() => {
+    if (game?.image_url) setActiveArt(game.image_url);
+  });
+
+  onDestroy(() => {
+    clearActiveArt();
+  });
+
   let records: DllRecord[] = $derived($gameDlls[gameId] ?? []);
+  let dlssEnabler = $derived($gameDlssEnabler[gameId] ?? false);
   let loading = $derived($gameDllsLoading[gameId] ?? false);
   let scanError = $derived($gameDllErrors[gameId] ?? null);
   let imgErrored = $state(false);
@@ -128,6 +140,7 @@
   }
 
   function isOutdated(r: DllRecord): boolean {
+    if (!recordUpdatable(r, $settings?.update_prefs ?? null, dlssEnabler)) return false;
     return relation(r) === "outdated";
   }
 
@@ -147,18 +160,26 @@
 
   async function toggleFeatureDisabled(recs: DllRecord[]): Promise<void> {
     if (!$settings) return;
+    const before: AppSettings = $settings;
     const families: Set<string> = new Set(recs.map((r) => r.family));
-    const allDisabled = [...families].every((f) => disabledFamilies.includes(f));
-    const prefs = { ...$settings.game_preferences };
+    const wasAllDisabled = [...families].every((f) => disabledFamilies.includes(f));
+    const prefs = { ...before.game_preferences };
     const cur = prefs[gameId] ?? { disabled_families: [], pinned_versions: {} };
     let next = [...cur.disabled_families];
-    if (allDisabled) {
+    if (wasAllDisabled) {
       next = next.filter((f) => !families.has(f));
     } else {
       for (const f of families) if (!next.includes(f)) next.push(f);
     }
     prefs[gameId] = { ...cur, disabled_families: next };
-    await persistSettings({ ...$settings, game_preferences: prefs });
+    const after: AppSettings = { ...before, game_preferences: prefs };
+    const featureName = recs.length > 0 ? familyShort(recs[0].family) : "Feature";
+    await optimisticToggle({
+      applyOptimistic: () => settings.set(after),
+      revert: () => settings.set(before),
+      commit: () => saveSettings(after),
+      message: `${featureName} ${wasAllDisabled ? "enabled" : "disabled"} for ${game?.name ?? "this game"}`,
+    });
   }
 
   async function setPin(key: string, version: string | null): Promise<void> {
@@ -229,9 +250,10 @@
       const primary = pickPrimary(fid, recs);
       const anyOutdated = recs.some((r) => relation(r) === "outdated");
       const anyAhead = recs.some((r) => relation(r) === "ahead");
-      const allUpToDate = recs.length > 0 && recs.some((r) => relation(r) === "same");
+      const inCatalog = recs.filter((r) => relation(r) !== "no-target");
+      const allUpToDate = inCatalog.length > 0 && inCatalog.every((r) => relation(r) === "same");
       const allDisabled = recs.every((r) => disabledFamilies.includes(r.family));
-      let label = "No catalog";
+      let label = "Not in catalog";
       let tone: FeatureBucket["statusTone"] = "neutral";
       if (allDisabled) { label = "Disabled"; tone = "neutral"; }
       else if (anyOutdated) { label = recs.length > 1 ? "Updates ready" : "Update ready"; tone = "update"; }
@@ -349,6 +371,37 @@
     }
   }
 
+  let rowMenu = $state<{ x: number; y: number; primaryKey: string } | null>(null);
+  const rowMenuItems = [
+    { action: "open_folder" as ContextMenuAction, label: "Open folder" },
+    { action: "scan" as ContextMenuAction, label: "Rescan" },
+    { action: "pin" as ContextMenuAction, label: "Pin a version…" },
+    { action: "hide" as ContextMenuAction, label: "Hide game" },
+  ];
+
+  function openRowMenu(primaryKey: string, e: MouseEvent): void {
+    e.preventDefault();
+    rowMenu = { x: e.clientX, y: e.clientY, primaryKey };
+  }
+
+  async function onRowMenuSelect(action: ContextMenuAction): Promise<void> {
+    const key = rowMenu?.primaryKey ?? null;
+    switch (action) {
+      case "open_folder":
+        await openFolder();
+        break;
+      case "scan":
+        await doRescan();
+        break;
+      case "pin":
+        if (key) pickerOpenFor = key;
+        break;
+      case "hide":
+        await toggleHidden();
+        break;
+    }
+  }
+
   async function openFolder(): Promise<void> {
     if (!game) return;
     try {
@@ -402,9 +455,12 @@
 <svelte:window onkeydown={(e) => { if (game && e.key === "Escape") onClose(); }} />
 
 {#if game}
-  <div class="drawer-scrim" role="presentation" onclick={onClose} transition:fade={{ duration: 180 }}></div>
-  <aside class="drawer" in:fly={{ x: 480, duration: 220, easing: cubicOut }} out:fly={{ x: 480, duration: 280, easing: backIn }}>
-    <header class="drawer-head" style:--launcher-accent={accent}>
+  <div class="detail-view" style:--launcher-accent={accent} aria-label={game.name}>
+    <button class="detail-back" onclick={onClose} title="Back to Library (Esc)">
+      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><line x1="19" y1="12" x2="5" y2="12"/><polyline points="12 19 5 12 12 5"/></svg>
+      Back to Library
+    </button>
+    <header class="detail-hero">
       <div class="drawer-art">
         {#if game.image_url && !imgErrored}
           <img src={game.image_url} alt={game.name} onerror={() => (imgErrored = true)} />
@@ -413,9 +469,6 @@
         {/if}
         <div class="drawer-art-overlay"></div>
       </div>
-      <button class="drawer-close" onclick={onClose} title="Close (Esc)" aria-label="Close">
-        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
-      </button>
       <div class="drawer-meta">
         <span class="launcher-chip" style:background={accent}>{launcherLabel(game.launcher)}</span>
         <h2 class="drawer-title">{game.name}</h2>
@@ -451,7 +504,7 @@
 
     <div class="drawer-body">
       {#if acActive}
-        <div class="warning-banner" class:is-danger={acSeverity === "danger"} role="alert">
+        <div class="warning-banner edge-accent" class:is-warning={acSeverity !== "danger"} class:is-danger={acSeverity === "danger"} role="alert">
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
           <span>{warningMessage(acReport!)}{#if acStatus} {acStatus}{/if}</span>
           <button
@@ -464,6 +517,13 @@
               } catch (err) { showToast("warning", `Open link failed: ${String(err)}`); }
             }}
           >Learn more</button>
+        </div>
+      {/if}
+
+      {#if dlssEnabler}
+        <div class="warning-banner edge-accent is-warning" role="status">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+          <span>DLSS Enabler detected — it manages this game's NVIDIA Streamline set, so DLSSync leaves the <code>sl.*</code> plug-ins untouched. NGX DLLs still update normally.</span>
         </div>
       {/if}
 
@@ -534,7 +594,7 @@
               {@const primaryLatest = latestFor(b.primary)}
               {@const primaryPinned = pinnedVersions[primaryKey]}
               {@const primaryAside = primaryRel === "ahead" || (primaryRel === "same" && primaryTarget != null && primaryTarget !== (b.primary.current_version ?? ""))}
-              <li class="feature-row" class:is-update={b.anyOutdated && !b.allDisabled} class:disabled={b.allDisabled}>
+              <li class="feature-row" class:is-update={b.anyOutdated && !b.allDisabled} class:disabled={b.allDisabled} oncontextmenu={(e) => openRowMenu(primaryKey, e)}>
                 <label class="feature-check" title={selState === "all" ? "Deselect all in this feature" : "Select all updates in this feature"}>
                   <input
                     type="checkbox"
@@ -658,7 +718,7 @@
                           {:else if rel === "same"}
                             <span class="chip chip-success small-chip">Current</span>
                           {:else}
-                            <span class="chip chip-neutral small-chip">No catalog</span>
+                            <span class="chip chip-neutral small-chip">Not in catalog</span>
                           {/if}
                         </div>
                         {#if pickerOpenFor === k}
@@ -749,7 +809,7 @@
                       {:else if rel === "same"}
                         <span class="chip chip-success small-chip">Current</span>
                       {:else}
-                        <span class="chip chip-neutral small-chip">No catalog</span>
+                        <span class="chip chip-neutral small-chip">Not in catalog</span>
                       {/if}
                     </div>
                     {#if pickerOpenFor === k}
@@ -776,7 +836,7 @@
           <button type="button" class="advanced-head" onclick={toggleDlss} aria-expanded={dlssExpanded}>
             <span class="advanced-titles">
               <span class="advanced-name">
-                <span class="advanced-dot" style="background: #76b900;"></span>
+                <span class="advanced-dot" style="background: var(--vendor-nvidia);"></span>
                 DLSS Overrides
                 <span class="chip chip-neutral small-chip count">NVIDIA</span>
               </span>
@@ -825,58 +885,49 @@
         Apply selected ({selectedCount})
       </button>
     </footer>
-  </aside>
+  </div>
+  {#if rowMenu}
+    <ContextMenu
+      x={rowMenu.x}
+      y={rowMenu.y}
+      items={rowMenuItems}
+      onSelect={(a) => void onRowMenuSelect(a)}
+      onClose={() => (rowMenu = null)}
+    />
+  {/if}
 {/if}
 
 <style>
-  .drawer-scrim { display: none; }
-  @media (max-width: 1300px) {
-    .drawer-scrim {
-      display: block;
-      position: fixed;
-      inset: 0;
-      background:
-        radial-gradient(circle at 70% 30%, rgba(0, 0, 0, 0.55), rgba(0, 0, 0, 0.82) 75%);
-      z-index: 150;
-    }
-    @media (prefers-reduced-transparency: reduce) {
-      .drawer-scrim {
-        background: rgba(0, 0, 0, 0.82);
-      }
-    }
-  }
-  .drawer {
-    position: fixed;
-    right: 0;
-    top: 0;
-    bottom: 0;
-    width: var(--drawer-width);
-    background: var(--bg-card);
-    border-left: 1px solid var(--border-strong);
-    box-shadow: -12px 0 40px rgba(0, 0, 0, 0.45);
+  .detail-view {
     display: flex;
     flex-direction: column;
-    z-index: 151;
+  }
+  .detail-back {
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    align-self: flex-start;
+    margin-bottom: 14px;
+    padding: 7px 13px 7px 10px;
+    border-radius: var(--radius-full);
+    font-size: var(--fs-sm);
+    font-weight: 600;
+    color: var(--text-secondary);
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    cursor: pointer;
+    transition: color var(--dur-fast) var(--ease), background var(--dur-fast) var(--ease), border-color var(--dur-fast) var(--ease);
+  }
+  .detail-back:hover { color: var(--text-primary); background: var(--bg-card-hover); border-color: var(--border-hover); }
+  .detail-back:focus-visible { outline: none; box-shadow: var(--shadow-ring); }
+
+  .detail-hero {
+    position: relative;
+    border-radius: var(--radius-xl);
     overflow: hidden;
+    border: 1px solid var(--border);
   }
-  .drawer::before {
-    content: "";
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    height: 1px;
-    background: linear-gradient(
-      90deg,
-      transparent,
-      rgba(255, 255, 255, 0.4),
-      transparent
-    );
-    pointer-events: none;
-    z-index: 3;
-  }
-  .drawer-head { position: relative; }
-  .drawer-art { width: 100%; aspect-ratio: 16 / 9; overflow: hidden; position: relative; }
+  .drawer-art { width: 100%; height: clamp(180px, 26vh, 260px); overflow: hidden; position: relative; }
   .drawer-art::before {
     content: "";
     position: absolute;
@@ -907,22 +958,6 @@
     background: linear-gradient(180deg, rgba(0,0,0,0.30) 0%, rgba(0,0,0,0) 35%, rgba(0,0,0,0) 55%, rgba(0,0,0,0.95) 100%);
     pointer-events: none;
   }
-  .drawer-close {
-    position: absolute;
-    top: 14px;
-    right: 14px;
-    width: 32px;
-    height: 32px;
-    border-radius: 50%;
-    background: rgba(0, 0, 0, 0.6);
-    backdrop-filter: blur(8px);
-    color: #fff;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    z-index: 4;
-  }
-  .drawer-close:hover { background: rgba(0, 0, 0, 0.85); }
   .drawer-meta {
     position: absolute;
     bottom: 0;
@@ -954,16 +989,16 @@
   .drawer-path { font-size: 11px; color: rgba(255,255,255,0.78); }
 
   .drawer-body {
-    flex: 1;
-    overflow-y: auto;
-    padding: 18px 22px 24px;
+    padding: 18px 2px 24px;
   }
 
   .warning-banner {
+    position: relative;
+    overflow: hidden;
     display: flex;
     align-items: center;
     gap: 10px;
-    padding: 12px 14px;
+    padding: 12px 14px 12px 16px;
     border-radius: var(--radius-md);
     background: var(--warning-dim);
     border: 1px solid var(--warning);
@@ -1006,16 +1041,18 @@
     display: flex;
     align-items: center;
     gap: 8px;
-    padding: 8px 16px;
-    border-bottom: 1px solid var(--border);
+    margin-top: 14px;
+    padding: 10px 16px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
     font-size: var(--fs-sm);
     color: var(--text-secondary);
     background: var(--bg-elevated);
     font-variant-numeric: tabular-nums;
   }
-  .status-ribbon.is-update { color: var(--update); background: var(--update-dim); border-bottom-color: var(--update-glow); }
-  .status-ribbon.is-success { color: var(--success); background: var(--success-dim); border-bottom-color: var(--success-glow); }
-  .status-ribbon.is-danger { color: var(--danger); background: var(--danger-dim); border-bottom-color: var(--danger-glow); }
+  .status-ribbon.is-update { color: var(--update); background: var(--update-dim); border-color: var(--update-glow); }
+  .status-ribbon.is-success { color: var(--success); background: var(--success-dim); border-color: var(--success-glow); }
+  .status-ribbon.is-danger { color: var(--danger); background: var(--danger-dim); border-color: var(--danger-glow); }
   .status-ribbon.is-muted { color: var(--text-muted); }
   .ribbon-dot {
     width: 7px;
@@ -1332,14 +1369,20 @@
   .dlss-drawer-body { padding: 0 14px 14px; display: flex; flex-direction: column; gap: 10px; }
 
   .drawer-foot {
-    padding: 12px 22px;
-    border-top: 1px solid var(--border);
-    background: var(--bg-input);
+    position: sticky;
+    bottom: 16px;
+    margin-top: 20px;
+    padding: 12px 14px;
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius-lg);
+    background: var(--bg-elevated);
+    box-shadow: 0 12px 32px rgba(0, 0, 0, 0.45);
     display: flex;
     gap: 8px;
     align-items: center;
     flex-wrap: wrap;
     container-type: inline-size;
+    z-index: 4;
   }
   .foot-spacer { flex: 1 1 0; min-width: 0; }
   .ahead-chip { padding: 3px 8px; flex-shrink: 0; }

--- a/frontend/src/components/GameListRow.svelte
+++ b/frontend/src/components/GameListRow.svelte
@@ -15,13 +15,14 @@
   import { dllRelation, targetVersion } from "../lib/relation";
   import { launcherIcon } from "../lib/launcherIcons";
 
-  let { game, hidden = false, onApply, onOpenFolder, onBlacklist, onClick }: {
+  let { game, hidden = false, onApply, onOpenFolder, onBlacklist, onClick, onContextMenu }: {
     game: DetectedGame;
     hidden?: boolean;
     onApply: (g: DetectedGame) => void;
     onOpenFolder: (g: DetectedGame) => void;
     onBlacklist: (g: DetectedGame) => void;
     onClick: (g: DetectedGame) => void;
+    onContextMenu?: (g: DetectedGame, e: MouseEvent) => void;
   } = $props();
 
   let status: UpdateStatus = $derived(($gameStatuses[game.id] ?? "unknown") as UpdateStatus);
@@ -80,6 +81,7 @@
   tabindex="0"
   aria-label={`${game.name}, ${STATUS_LABELS[status] ?? status}`}
   onclick={() => onClick(game)}
+  oncontextmenu={onContextMenu ? (e) => { e.preventDefault(); onContextMenu(game, e); } : undefined}
   onkeydown={onKey}
 >
   <div class="cover" style:--launcher-accent={accent}>
@@ -222,9 +224,9 @@
     font-size: 10.5px;
     font-weight: 600;
     border-radius: var(--radius-sm);
-    background: var(--update-dim);
-    color: var(--update);
-    border: 1px solid rgba(34, 211, 238, 0.30);
+    background: color-mix(in oklab, var(--chip-accent, var(--update)) 12%, var(--bg-elevated));
+    color: var(--chip-accent, var(--update));
+    border: 1px solid color-mix(in oklab, var(--chip-accent, var(--update)) 32%, transparent);
     white-space: nowrap;
   }
   .feature-chip.overflow {

--- a/frontend/src/components/NotificationsBell.svelte
+++ b/frontend/src/components/NotificationsBell.svelte
@@ -11,6 +11,7 @@
   } from "../lib/notifications";
   import { currentView } from "../lib/stores";
   import { formatDurationSecs } from "../lib/formatHuman";
+  import { EXTERNAL_URLS } from "../lib/ux";
 
   let { open, onClose }: { open: boolean; onClose: () => void } = $props();
   let panelEl: HTMLDivElement | undefined = $state();
@@ -26,6 +27,7 @@
     const onClickOutside = (e: MouseEvent): void => {
       if (!open) return;
       const target = e.target as Node | null;
+      if (target instanceof Element && target.closest("[data-notifications-toggle]")) return;
       if (panelEl && target && !panelEl.contains(target)) {
         onClose();
       }
@@ -54,6 +56,39 @@
     } else if (entry.kind === "catalog_update_available") {
       currentView.set("catalog");
       onClose();
+    } else if (entry.kind === "driver_update_available" || entry.kind === "system_driver_update_available") {
+      currentView.set("drivers");
+      onClose();
+    } else if (entry.kind === "backup_restored") {
+      currentView.set("backups");
+      onClose();
+    }
+  }
+
+  function linkActions(entry: NotificationEntry): { label: string; url: string }[] {
+    const actions: { label: string; url: string }[] = [];
+    if (entry.link) {
+      const label =
+        entry.kind === "app_update_available"
+          ? "GitHub release"
+          : entry.kind === "driver_update_available" || entry.kind === "system_driver_update_available"
+            ? "Vendor page"
+            : "Open";
+      actions.push({ label, url: entry.link });
+    }
+    if (entry.kind === "app_update_available") {
+      actions.push({ label: "Nexus Mods", url: EXTERNAL_URLS.nexusMod });
+    }
+    return actions;
+  }
+
+  async function openExternal(url: string, ev: Event): Promise<void> {
+    ev.stopPropagation();
+    try {
+      const { open } = await import("@tauri-apps/plugin-shell");
+      await open(url);
+    } catch (err) {
+      console.warn("[dlssync] open external link failed:", err);
     }
   }
 
@@ -88,6 +123,9 @@
       case "apply_cancelled": return "↺";
       case "app_update_available": return "↑";
       case "catalog_update_available": return "★";
+      case "driver_update_available":
+      case "system_driver_update_available": return "⬇";
+      case "backup_restored": return "↺";
       case "scan_failed":
       case "catalog_refresh_failed": return "!";
       default: return "•";
@@ -101,6 +139,9 @@
       case "apply_cancelled": return "orange";
       case "app_update_available": return "blue";
       case "catalog_update_available": return "purple";
+      case "driver_update_available": return "green";
+      case "system_driver_update_available": return "purple";
+      case "backup_restored": return "green";
       case "scan_failed":
       case "catalog_refresh_failed": return "orange";
       default: return "blue";
@@ -114,6 +155,9 @@
       case "apply_cancelled": return "Update cancelled";
       case "app_update_available": return "App update available";
       case "catalog_update_available": return "New catalog version";
+      case "driver_update_available": return "GPU driver update";
+      case "system_driver_update_available": return "System driver update";
+      case "backup_restored": return "Backup restored";
       case "scan_failed": return "Library scan failed";
       case "catalog_refresh_failed": return "Catalog refresh failed";
       default: return "Notification";
@@ -122,7 +166,7 @@
 </script>
 
 {#if open}
-  <div class="bell-panel" role="dialog" aria-label="Notifications" bind:this={panelEl}>
+  <div class="bell-panel glass-dialog" role="dialog" aria-label="Notifications" bind:this={panelEl}>
     <header class="bell-panel-header">
       <span class="bell-panel-title">Notifications</span>
       <span class="bell-panel-count" aria-label="{entries.length} entries">{entries.length}</span>
@@ -140,32 +184,48 @@
             {#if entry.read_at == null}
               <span class="bell-unread-stripe" aria-hidden="true"></span>
             {/if}
-            <button
-              type="button"
-              class="bell-item-main"
-              onclick={() => handleItemClick(entry)}
-              aria-label="{kindLabel(entry.kind)}: {entry.title}"
-            >
-              <span class="aura-badge bell-item-badge" data-tint={tintForKind(entry.kind)} aria-hidden="true">
-                {kindIcon(entry.kind)}
-              </span>
-              <span class="bell-item-text">
-                <span class="bell-item-title">{entry.title}</span>
-                {#if entry.body}
-                  <span class="bell-item-body">{entry.body}</span>
-                {/if}
-                <span class="bell-item-time">{relativeTime(entry.created_at)}</span>
-              </span>
-            </button>
-            <button
-              type="button"
-              class="bell-item-dismiss"
-              title="Dismiss"
-              aria-label="Dismiss notification"
-              onclick={(ev) => handleDismiss(entry, ev)}
-            >
-              ×
-            </button>
+            <div class="bell-item-row">
+              <button
+                type="button"
+                class="bell-item-main"
+                onclick={() => handleItemClick(entry)}
+                aria-label="{kindLabel(entry.kind)}: {entry.title}"
+              >
+                <span class="aura-badge bell-item-badge" data-tint={tintForKind(entry.kind)} aria-hidden="true">
+                  {kindIcon(entry.kind)}
+                </span>
+                <span class="bell-item-text">
+                  <span class="bell-item-title">{entry.title}</span>
+                  {#if entry.body}
+                    <span class="bell-item-body">{entry.body}</span>
+                  {/if}
+                  <span class="bell-item-time">{relativeTime(entry.created_at)}</span>
+                </span>
+              </button>
+              <button
+                type="button"
+                class="bell-item-dismiss"
+                title="Dismiss"
+                aria-label="Dismiss notification"
+                onclick={(ev) => handleDismiss(entry, ev)}
+              >
+                ×
+              </button>
+            </div>
+            {#if linkActions(entry).length > 0}
+              <div class="bell-item-actions">
+                {#each linkActions(entry) as action}
+                  <button
+                    type="button"
+                    class="bell-item-link"
+                    onclick={(ev) => openExternal(action.url, ev)}
+                  >
+                    {action.label}
+                    <span class="bell-item-link-icon" aria-hidden="true">↗</span>
+                  </button>
+                {/each}
+              </div>
+            {/if}
           </div>
         {/each}
       {/if}
@@ -182,19 +242,23 @@
 
 <style>
   .bell-panel {
-    position: absolute;
-    top: calc(100% + 8px);
-    right: 0;
+    position: fixed;
+    top: calc(var(--topbar-height) + 6px);
+    right: 12px;
     width: 380px;
-    max-height: 480px;
+    max-width: calc(100vw - 24px);
+    max-height: min(480px, calc(100vh - var(--topbar-height) - 24px));
     display: flex;
     flex-direction: column;
-    background: var(--bg-card);
-    border: 1px solid var(--border);
     border-radius: var(--radius-2xl);
     box-shadow: var(--shadow-lg);
-    z-index: 60;
-    overflow: hidden;
+    z-index: 200;
+  }
+  @media (max-width: 460px) {
+    .bell-panel {
+      left: 12px;
+      width: auto;
+    }
   }
   .bell-panel-header {
     display: flex;
@@ -231,13 +295,17 @@
   .bell-item {
     position: relative;
     display: flex;
-    align-items: stretch;
-    gap: 2px;
+    flex-direction: column;
     border-radius: var(--radius-lg);
     transition: background var(--dur-fast) var(--ease);
   }
   .bell-item:hover {
     background: var(--bg-card-hover);
+  }
+  .bell-item-row {
+    display: flex;
+    align-items: stretch;
+    gap: 2px;
   }
   .bell-unread-stripe {
     position: absolute;
@@ -322,6 +390,38 @@
   .bell-item-dismiss:focus-visible {
     outline: none;
     box-shadow: var(--shadow-ring);
+  }
+  .bell-item-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    padding: 0 10px 10px 58px;
+  }
+  .bell-item-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 4px 10px;
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--accent);
+    background: var(--accent-dim);
+    border: 1px solid transparent;
+    border-radius: var(--radius-full);
+    cursor: pointer;
+    transition: background var(--dur-fast) var(--ease), color var(--dur-fast) var(--ease);
+  }
+  .bell-item-link:hover {
+    background: var(--accent);
+    color: var(--accent-fg);
+  }
+  .bell-item-link:focus-visible {
+    outline: none;
+    box-shadow: var(--shadow-ring);
+  }
+  .bell-item-link-icon {
+    font-size: 10px;
+    opacity: 0.8;
   }
   .bell-panel-footer {
     border-top: 1px solid var(--border);

--- a/frontend/src/components/Select.svelte
+++ b/frontend/src/components/Select.svelte
@@ -96,7 +96,7 @@
     <svg class="sel-chev" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9" /></svg>
   </button>
   {#if open}
-    <div class="sel-menu" role="listbox">
+    <div class="sel-menu glass-dialog" role="listbox">
       {#each options as o, i (String(o.value))}
         <button
           type="button"
@@ -186,13 +186,10 @@
     z-index: 240;
     list-style: none;
     margin: 0;
-    padding: 4px;
+    padding: 4px 4px 4px 6px;
     max-height: 280px;
     overflow-y: auto;
-    background: var(--bg-card);
-    border: 1px solid var(--border-strong, var(--border));
     border-radius: var(--radius-md, 8px);
-    box-shadow: var(--shadow-lg, 0 12px 32px rgba(0, 0, 0, 0.4));
   }
   .sel-opt {
     display: flex;

--- a/frontend/src/components/ShortcutOverlay.svelte
+++ b/frontend/src/components/ShortcutOverlay.svelte
@@ -120,7 +120,9 @@
     width: min(840px, 100%);
     max-height: 80vh;
     overflow-y: auto;
-    background: var(--bg-card);
+    background: var(--glass-strong);
+    backdrop-filter: var(--glass-blur);
+    -webkit-backdrop-filter: var(--glass-blur);
     border: 1px solid var(--border-strong);
     border-radius: var(--radius-lg);
     box-shadow: var(--shadow-lg);

--- a/frontend/src/components/Sidebar.svelte
+++ b/frontend/src/components/Sidebar.svelte
@@ -1,11 +1,24 @@
 <script lang="ts">
   import { onMount } from "svelte";
+  import { fly } from "svelte/transition";
   import {
     currentView,
     settings,
     persistSettings,
     sidebarCounts,
   } from "../lib/stores";
+
+  const STAGGER_STEP_MS = 28;
+  const prefersReducedMotion =
+    typeof window !== "undefined" &&
+    window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  function labelStagger(index: number): { x: number; duration: number; delay: number } {
+    return {
+      x: -8,
+      duration: prefersReducedMotion ? 0 : 180,
+      delay: prefersReducedMotion ? 0 : index * STAGGER_STEP_MS,
+    };
+  }
 
   let appVersion = $state("dev");
   onMount(async () => {
@@ -69,7 +82,7 @@
 
   <nav class="sidebar-nav">
     {#if !collapsed}<div class="nav-label">Library</div>{/if}
-    {#each librarySection as item}
+    {#each librarySection as item, i}
       {@const count = counterValue(item)}
       <button class="nav-pill" class:active={$currentView === item.id} title={item.title} onclick={() => switchView(item.id)}>
         {#if item.icon === "library"}
@@ -81,7 +94,7 @@
         {:else if item.icon === "drivers"}
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="4" width="16" height="16" rx="2"/><rect x="9" y="9" width="6" height="6"/><line x1="9" y1="1" x2="9" y2="4"/><line x1="15" y1="1" x2="15" y2="4"/><line x1="9" y1="20" x2="9" y2="23"/><line x1="15" y1="20" x2="15" y2="23"/><line x1="20" y1="9" x2="23" y2="9"/><line x1="20" y1="14" x2="23" y2="14"/><line x1="1" y1="9" x2="4" y2="9"/><line x1="1" y1="14" x2="4" y2="14"/></svg>
         {/if}
-        {#if !collapsed}<span class="nav-label-text">{item.title}</span>{/if}
+        {#if !collapsed}<span class="nav-label-text" in:fly={labelStagger(i)}>{item.title}</span>{/if}
         {#if count > 0}
           <span class="nav-counter" class:is-collapsed={collapsed} class:is-update={item.counterKey === "library"} aria-label={`${count} ${item.counterKey === "library" ? "outdated" : "restorable"}`}>
             {count > 99 ? "99+" : count}
@@ -91,14 +104,14 @@
     {/each}
 
     {#if !collapsed}<div class="nav-label">General</div>{/if}
-    {#each settingsSection as item}
+    {#each settingsSection as item, i}
       <button class="nav-pill" class:active={$currentView === item.id} title={item.title} onclick={() => switchView(item.id)}>
         {#if item.icon === "settings"}
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
         {:else}
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
         {/if}
-        {#if !collapsed}<span class="nav-label-text">{item.title}</span>{/if}
+        {#if !collapsed}<span class="nav-label-text" in:fly={labelStagger(librarySection.length + i)}>{item.title}</span>{/if}
       </button>
     {/each}
   </nav>
@@ -115,17 +128,22 @@
 
 <style>
   .sidebar {
-    position: fixed;
-    left: 0;
-    top: 0;
-    bottom: 0;
+    position: relative;
+    flex-shrink: 0;
     width: var(--sidebar-width);
-    background: var(--bg-sidebar);
+    height: 100%;
+    background: var(--glass-1);
+    backdrop-filter: var(--glass-blur);
+    -webkit-backdrop-filter: var(--glass-blur);
     border-right: 1px solid var(--border);
+    box-shadow: var(--glass-edge);
     display: flex;
     flex-direction: column;
-    z-index: 100;
+    z-index: 2;
     transition: width var(--dur-normal) var(--ease);
+  }
+  @supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
+    .sidebar { background: var(--glass-fallback); }
   }
   .sidebar.collapsed {
     width: var(--sidebar-width-collapsed);
@@ -186,11 +204,12 @@
     color: var(--text-secondary);
     font-size: 14px;
     font-weight: 500;
-    transition: background var(--dur-fast) var(--ease), color var(--dur-fast) var(--ease);
+    transition: background var(--dur-fast) var(--ease), color var(--dur-fast) var(--ease), transform var(--dur-fast) var(--spring);
   }
   .sidebar.collapsed .nav-pill { width: 44px; height: 44px; justify-content: center; padding: 0; }
   .nav-pill :global(svg) { width: 20px; height: 20px; flex-shrink: 0; }
-  .nav-pill:hover { background: var(--bg-card-hover); color: var(--text-primary); }
+  .nav-pill:hover { background: var(--bg-card-hover); color: var(--text-primary); transform: translateX(2px); }
+  .nav-pill:active { transform: translateX(2px) scale(0.99); }
   .nav-pill.active {
     background: var(--accent);
     color: var(--accent-fg);

--- a/frontend/src/components/Toast.svelte
+++ b/frontend/src/components/Toast.svelte
@@ -1,6 +1,19 @@
 <script lang="ts">
-  import { toasts, dismissToast } from "../lib/stores";
+  import { toasts, dismissToast, type Toast } from "../lib/stores";
   import { fly } from "svelte/transition";
+
+  function iconPaths(kind: Toast["kind"]): string {
+    switch (kind) {
+      case "success":
+        return "M22 11.08V12a10 10 0 1 1-5.93-9.14|M22 4 12 14.01 9 11.01";
+      case "warning":
+        return "M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z|M12 9v4|M12 17h.01";
+      case "danger":
+        return "M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z|M12 9v4|M12 17h.01";
+      default:
+        return "M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20z|M12 16v-4|M12 8h.01";
+    }
+  }
 </script>
 
 <div class="toast-container">
@@ -10,19 +23,67 @@
       in:fly={{ y: 16, duration: 200 }}
       out:fly={{ y: 16, duration: 150 }}
     >
+      <span class="toast-icon" data-kind={t.kind} aria-hidden="true">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round">
+          {#each iconPaths(t.kind).split("|") as d}
+            <path d={d} />
+          {/each}
+        </svg>
+      </span>
       <span class="toast-msg">{t.message}</span>
+      {#if t.action}
+        <button class="toast-action" onclick={() => t.action?.run()}>{t.action.label}</button>
+      {/if}
       <button class="toast-close" onclick={() => dismissToast(t.id)} aria-label="Dismiss">x</button>
+      <span class="toast-progress" data-kind={t.kind} style:--toast-ttl="{t.ttlMs}ms" aria-hidden="true"></span>
     </div>
   {/each}
 </div>
 
 <style>
   .toast-container { position: fixed; right: 16px; bottom: 16px; display: flex; flex-direction: column; gap: 8px; z-index: 200; pointer-events: none; }
-  .toast { pointer-events: auto; display: flex; align-items: center; gap: 12px; padding: 10px 14px; background: var(--bg-elevated); border: 1px solid var(--border); border-radius: var(--radius-md); box-shadow: var(--shadow-md); font-size: var(--fs-sm); }
+  .toast { position: relative; pointer-events: auto; display: flex; align-items: center; gap: 10px; padding: 10px 14px; background: var(--bg-elevated); border: 1px solid var(--border); border-radius: var(--radius-md); box-shadow: var(--shadow-md); font-size: var(--fs-sm); overflow: hidden; }
   .toast-success { border-color: var(--success); }
   .toast-warning { border-color: var(--warning); }
   .toast-danger { border-color: var(--danger); }
+  .toast-info { border-color: var(--info); }
+  .toast-icon { display: inline-flex; align-items: center; justify-content: center; flex-shrink: 0; }
+  .toast-icon[data-kind="success"] { color: var(--success); }
+  .toast-icon[data-kind="warning"] { color: var(--warning); }
+  .toast-icon[data-kind="danger"] { color: var(--danger); }
+  .toast-icon[data-kind="info"] { color: var(--info); }
   .toast-msg { color: var(--text-primary); }
+  .toast-action {
+    color: var(--accent);
+    font-size: var(--fs-xs);
+    font-weight: 600;
+    padding: 3px 8px;
+    border-radius: var(--radius-sm);
+    background: var(--accent-dim);
+    border: none;
+    cursor: pointer;
+    transition: background var(--dur-fast) var(--ease);
+  }
+  .toast-action:hover { background: var(--accent-glow, var(--accent-dim)); color: var(--accent-hover); }
+  .toast-action:focus-visible { outline: none; box-shadow: var(--shadow-ring); }
   .toast-close { color: var(--text-muted); font-size: 14px; line-height: 1; padding: 0 4px; cursor: pointer; background: none; border: none; }
   .toast-close:hover { color: var(--text-primary); }
+  .toast-progress {
+    position: absolute;
+    left: 0;
+    bottom: 0;
+    height: 2px;
+    width: 100%;
+    transform-origin: left center;
+    border-radius: var(--radius-full);
+    animation: toast-drain var(--toast-ttl, 4000ms) linear forwards;
+  }
+  .toast-progress[data-kind="success"] { background: var(--success); }
+  .toast-progress[data-kind="warning"] { background: var(--warning); }
+  .toast-progress[data-kind="danger"] { background: var(--danger); }
+  .toast-progress[data-kind="info"] { background: var(--info); }
+  @keyframes toast-drain { from { transform: scaleX(1); } to { transform: scaleX(0); } }
+  @media (prefers-reduced-motion: reduce) {
+    .toast-progress { animation: none; transform: scaleX(1); opacity: 0.5; }
+  }
 </style>

--- a/frontend/src/components/TopBar.svelte
+++ b/frontend/src/components/TopBar.svelte
@@ -4,13 +4,12 @@
     searchQuery,
     currentView,
     commandPaletteOpen,
+    notificationsOpen,
     notificationsUnreadCount,
   } from "../lib/stores";
   import { viewTitle } from "../lib/labels";
-  import NotificationsBell from "./NotificationsBell.svelte";
 
   let { onToggleTheme, theme }: { onToggleTheme: () => void; theme: string } = $props();
-  let notificationsOpen = $state(false);
 
   let searchInput: HTMLInputElement | undefined = $state();
 
@@ -88,9 +87,10 @@
       <button
         class="topbar-btn bell-btn"
         title="Notifications"
-        onclick={() => (notificationsOpen = !notificationsOpen)}
+        data-notifications-toggle
+        onclick={() => notificationsOpen.update((v) => !v)}
         aria-haspopup="dialog"
-        aria-expanded={notificationsOpen}
+        aria-expanded={$notificationsOpen}
         aria-label={unread > 0 ? `${unread} unread notifications` : "Notifications"}
       >
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -101,7 +101,6 @@
           <span class="bell-badge" aria-hidden="true">{unread > 9 ? "9+" : unread}</span>
         {/if}
       </button>
-      <NotificationsBell open={notificationsOpen} onClose={() => (notificationsOpen = false)} />
     </div>
 
     <button class="topbar-btn" title="Toggle theme" onclick={onToggleTheme} aria-label="Toggle theme">
@@ -133,19 +132,22 @@
     align-items: center;
     justify-content: space-between;
     padding: 0 12px 0 20px;
-    background: var(--bg-topbar);
-    backdrop-filter: blur(20px) saturate(160%);
-    -webkit-backdrop-filter: blur(20px) saturate(160%);
+    background: var(--glass-2);
+    backdrop-filter: var(--glass-blur-bar);
+    -webkit-backdrop-filter: var(--glass-blur-bar);
     border-bottom: 1px solid var(--border);
+    box-shadow: var(--glass-edge);
     gap: 16px;
     user-select: none;
     -webkit-app-region: drag;
-    position: sticky;
+    position: absolute;
     top: 0;
+    left: 0;
+    right: 0;
     z-index: 50;
   }
   @supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
-    .topbar { background: var(--bg-app); }
+    .topbar { background: var(--glass-fallback); }
   }
   .topbar-left { flex: 1; min-width: 0; display: flex; align-items: center; }
   .page-title { font-size: var(--fs-lg); font-weight: 600; color: var(--text-primary); letter-spacing: var(--letter-tighter); -webkit-app-region: no-drag; }

--- a/frontend/src/components/UpdateBanner.svelte
+++ b/frontend/src/components/UpdateBanner.svelte
@@ -8,6 +8,7 @@
     pushNotification,
     makeNotificationEntry,
   } from "../lib/notifications";
+  import { githubReleaseTagUrl } from "../lib/ux";
   import Download from "@lucide/svelte/icons/download";
   import X from "@lucide/svelte/icons/x";
   import ChevronDown from "@lucide/svelte/icons/chevron-down";
@@ -103,6 +104,19 @@
     return null;
   }
 
+  const NOTIFICATION_BODY_MAX = 160;
+
+  function notificationBody(notes: string | null): string {
+    const items = notes ? renderNotes(notes).flatMap((section) => section.items) : [];
+    if (items.length === 0) {
+      return firstChangelogHeading(notes) ?? "New version ready to install.";
+    }
+    const summary = items.slice(0, 2).join(" · ");
+    return summary.length > NOTIFICATION_BODY_MAX
+      ? `${summary.slice(0, NOTIFICATION_BODY_MAX - 1)}…`
+      : summary;
+  }
+
   function emitAppUpdateNotification(next: UpdateInfo): void {
     const existing = get(notifications).find(
       (n) => n.kind === "app_update_available" && (n.title.includes(next.version) || n.body?.includes(next.version)),
@@ -111,7 +125,8 @@
     const entry = makeNotificationEntry(
       "app_update_available",
       `DLSSync v${next.version} available`,
-      firstChangelogHeading(next.notes),
+      notificationBody(next.notes),
+      { link: githubReleaseTagUrl(next.version) },
     );
     pushNotification(entry).catch((err) => console.warn("[dlssync] push app-update notification failed:", err));
   }

--- a/frontend/src/components/VersionPickerPopover.svelte
+++ b/frontend/src/components/VersionPickerPopover.svelte
@@ -157,7 +157,7 @@
 </script>
 
 <div class="picker-backdrop" role="presentation" onclick={onClose} onkeydown={handleKey} tabindex="-1"></div>
-<div class="picker" transition:fly={{ y: -6, duration: 140 }} onkeydown={handleKey} role="dialog" aria-label="Pick version" tabindex="-1">
+<div class="picker glass-dialog" transition:fly={{ y: -6, duration: 140 }} onkeydown={handleKey} role="dialog" aria-label="Pick version" tabindex="-1">
   <header class="picker-head">
     <div class="picker-glyph" aria-hidden="true">
       <FeatureIcon id={icon} size={20} />
@@ -167,7 +167,7 @@
       <span class="subtitle-line">{subtitle}</span>
       <span class="file-line mono">{filename}</span>
     </div>
-    <button class="picker-close" onclick={onClose} aria-label="Close">
+    <button class="dialog-close" onclick={onClose} aria-label="Close">
       <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
     </button>
   </header>
@@ -373,20 +373,15 @@
     transform: translate(-50%, -50%);
     width: min(600px, 92vw);
     max-height: 84vh;
-    background: var(--bg-card);
-    border: 1px solid var(--border-strong);
-    border-radius: var(--radius-lg);
-    box-shadow: var(--shadow-lg);
     display: flex;
     flex-direction: column;
     z-index: 221;
-    overflow: hidden;
   }
   .picker-head {
-    padding: 16px 18px;
+    padding: 16px 48px 16px 18px;
     border-bottom: 1px solid var(--border);
     display: grid;
-    grid-template-columns: 40px 1fr auto;
+    grid-template-columns: 40px 1fr;
     gap: 12px;
     align-items: flex-start;
   }
@@ -404,17 +399,6 @@
   .title-line { font-size: 15px; font-weight: 700; color: var(--text-primary); letter-spacing: var(--letter-tight); }
   .subtitle-line { font-size: 11.5px; color: var(--text-secondary); line-height: 1.4; }
   .file-line { font-size: 10px; color: var(--text-muted); margin-top: 2px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-  .picker-close {
-    width: 28px;
-    height: 28px;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    color: var(--text-muted);
-    border-radius: var(--radius-sm);
-    flex-shrink: 0;
-  }
-  .picker-close:hover { background: var(--bg-elevated); color: var(--text-primary); }
 
   .rank {
     padding: 12px 18px;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -20,7 +20,13 @@ export interface DetectedGame {
   size_bytes: number | null;
 }
 
-export type UpdateStatus = "outdated" | "up_to_date" | "no_dlls" | "unknown" | "scanning";
+export type UpdateStatus =
+  | "outdated"
+  | "up_to_date"
+  | "no_dlls"
+  | "unknown"
+  | "scanning"
+  | "scan_failed";
 
 export type DllFamily =
   | "dlss_sr"
@@ -40,7 +46,9 @@ export type DllFamily =
   | "fsr_upscaler_vk"
   | "fsr_fg"
   | "fsr_loader"
-  | "direct_storage";
+  | "fsr_denoiser"
+  | "direct_storage"
+  | "direct_storage_core";
 
 export interface DllRecord {
   family: DllFamily;
@@ -79,6 +87,10 @@ export interface BackupEntry {
   created_at: string;
   restored_at: string | null;
   size_bytes: number | null;
+  backup_type: string;
+  device_class: string | null;
+  hardware_id: string | null;
+  driver_provider: string | null;
 }
 
 export interface DeleteOutcome {
@@ -426,6 +438,10 @@ export async function detectDlls(installDir: string): Promise<DllRecord[]> {
   return invoke("detect_dlls", { installDir });
 }
 
+export async function detectDlssEnabler(installDir: string): Promise<boolean> {
+  return invoke("detect_dlss_enabler", { installDir });
+}
+
 export async function refreshCatalog(): Promise<void> {
   return invoke("refresh_catalog");
 }
@@ -527,6 +543,120 @@ export async function installDriver(
   return invoke("install_driver", { vendor, downloadUrl });
 }
 
+
+export type SystemDeviceClass =
+  | "audio"
+  | "display"
+  | "monitor"
+  | "network"
+  | "bluetooth"
+  | "input"
+  | "storage"
+  | "printer"
+  | "camera"
+  | "sensor"
+  | "battery"
+  | "smart_card"
+  | "firmware"
+  | "chipset"
+  | "system"
+  | "usb"
+  | "other";
+
+export interface SystemDriverUpdate {
+  update_id: string;
+  title: string;
+  class: SystemDeviceClass;
+  provider: string;
+  driver_version: string | null;
+  driver_date: string | null;
+  hardware_id: string | null;
+  size_bytes: number;
+  target_device: string | null;
+  current_version: string | null;
+  /** DriverStore `oemNN.inf` of the matched installed device, for snapshot + version history. */
+  target_inf: string | null;
+  /** Hardware id of the matched installed device. */
+  target_hardware_id: string | null;
+  support_url: string | null;
+}
+
+export interface SystemDeviceGroup {
+  class: SystemDeviceClass;
+  label: string;
+  updates: SystemDriverUpdate[];
+}
+
+export type SystemInstallStage = "downloading" | "installing" | "completed" | "failed";
+
+export interface SystemDriverProgress {
+  stage: SystemInstallStage;
+  message: string;
+  fraction: number | null;
+}
+
+export interface SystemDriverOutcome {
+  success: boolean;
+  reboot_required: boolean;
+  result_code: number;
+  message: string;
+}
+
+export const SYSTEM_DRIVER_INSTALL_EVENT = "system_driver_install_progress";
+
+/** Installed-device context so the install snapshots the current driver before applying. */
+export interface DriverInstallContext {
+  infName: string | null;
+  hardwareId: string | null;
+  deviceClass: string | null;
+  provider: string | null;
+  currentVersion: string | null;
+}
+
+/** One DriverStore version (current or superseded) of a driver package. */
+export interface DriverStoreVersion {
+  publishedName: string;
+  version: string;
+  date: string | null;
+  provider: string;
+  current: boolean;
+}
+
+/** Build the snapshot context for a System & Components update from its matched device. */
+export function driverInstallContext(
+  update: SystemDriverUpdate,
+  deviceClass: string,
+): DriverInstallContext {
+  return {
+    infName: update.target_inf,
+    hardwareId: update.target_hardware_id,
+    deviceClass,
+    provider: update.provider,
+    currentVersion: update.current_version,
+  };
+}
+
+export async function scanSystemDrivers(): Promise<SystemDeviceGroup[]> {
+  return invoke("scan_system_drivers");
+}
+
+export async function installSystemDriver(
+  updateId: string,
+  context?: DriverInstallContext,
+): Promise<SystemDriverOutcome> {
+  return invoke("install_system_driver", { updateId, context: context ?? null });
+}
+
+/** Roll a System & Components driver back to a previously-snapshotted version. */
+export async function restoreSystemDriver(backupId: string): Promise<SystemDriverOutcome> {
+  return invoke("restore_system_driver", { backupId });
+}
+
+/** DriverStore versions (current + superseded) of a driver package, newest-first. */
+export async function systemDriverVersions(infName: string): Promise<DriverStoreVersion[]> {
+  return invoke("system_driver_versions", { infName });
+}
+
 export type DlssPreset =
   | "default"
   | "a"
@@ -537,10 +667,13 @@ export type DlssPreset =
   | "f"
   | "g"
   | "h"
+  | "i"
   | "j"
   | "k"
   | "l"
   | "m"
+  | "n"
+  | "o"
   | "recommended";
 
 export type FrameGenMode = "app_controlled" | "fixed" | "dynamic";
@@ -558,19 +691,27 @@ export interface DlssOverrideConfig {
 
 export type OverrideScope = { scope: "global" } | { scope: "per_game"; executable_path: string };
 
-export interface DlssSettingValue {
-  id: number;
-  value: number | null;
+export type DlssOverrideSource = "per_game" | "global" | "none";
+
+export interface DlssOverrideReadback {
+  config: DlssOverrideConfig;
+  source: DlssOverrideSource;
+  active_count: number;
 }
 
 export async function dlssOverridesSupported(): Promise<boolean> {
   return invoke("dlss_overrides_supported");
 }
 
+export interface DlssApplyOutcome {
+  needs_elevation: boolean;
+  denied_settings: number[];
+}
+
 export async function applyDlssOverride(
   scope: OverrideScope,
   config: DlssOverrideConfig,
-): Promise<void> {
+): Promise<DlssApplyOutcome> {
   return invoke("apply_dlss_override", { scope, config });
 }
 
@@ -578,8 +719,8 @@ export async function resetDlssOverride(scope: OverrideScope): Promise<void> {
   return invoke("reset_dlss_override", { scope });
 }
 
-export async function readDlssOverride(scope: OverrideScope): Promise<DlssSettingValue[]> {
-  return invoke("read_dlss_override", { scope });
+export async function readDlssOverrideConfig(scope: OverrideScope): Promise<DlssOverrideReadback> {
+  return invoke("read_dlss_override_config", { scope });
 }
 
 export async function findGameExecutable(installDir: string): Promise<string | null> {

--- a/frontend/src/lib/applyEvents.ts
+++ b/frontend/src/lib/applyEvents.ts
@@ -58,6 +58,7 @@ function buildTerminalEntry(
     apply_id: p.apply_id,
     game_id: tracker.game_id,
     error_class: p.error_class ?? null,
+    link: null,
   };
 }
 

--- a/frontend/src/lib/artContext.ts
+++ b/frontend/src/lib/artContext.ts
@@ -1,0 +1,11 @@
+import { writable } from "svelte/store";
+
+export const activeArt = writable<string | null>(null);
+
+export function setActiveArt(url: string | null | undefined): void {
+  activeArt.set(url && url.length > 0 ? url : null);
+}
+
+export function clearActiveArt(): void {
+  activeArt.set(null);
+}

--- a/frontend/src/lib/brands.ts
+++ b/frontend/src/lib/brands.ts
@@ -1,0 +1,137 @@
+import {
+  siAmd,
+  siAsus,
+  siBroadcom,
+  siDell,
+  siIntel,
+  siMediatek,
+  siMsi,
+  siNvidia,
+  siQualcomm,
+  siRazer,
+} from "simple-icons";
+
+export interface Brand {
+  label: string;
+  path: string;
+  viewBox: string;
+  accentVar: string;
+}
+
+const VENDOR_NVIDIA = "--vendor-nvidia";
+const VENDOR_AMD = "--vendor-amd";
+const VENDOR_INTEL = "--vendor-intel";
+const VENDOR_MICROSOFT = "--vendor-microsoft";
+const VENDOR_NEUTRAL = "--neutral";
+
+const SQUARE_24 = "0 0 24 24";
+
+const MICROSOFT_SQUARES = "M11.4 11.4H0V0h11.4zM24 11.4H12.6V0H24zM11.4 24H0V12.6h11.4zM24 24H12.6V12.6H24z";
+
+export const BRANDS = {
+  nvidia: { label: "NVIDIA", viewBox: SQUARE_24, accentVar: VENDOR_NVIDIA, path: siNvidia.path },
+  amd: { label: "AMD", viewBox: SQUARE_24, accentVar: VENDOR_AMD, path: siAmd.path },
+  intel: { label: "Intel", viewBox: SQUARE_24, accentVar: VENDOR_INTEL, path: siIntel.path },
+  microsoft: { label: "Microsoft", viewBox: SQUARE_24, accentVar: VENDOR_MICROSOFT, path: MICROSOFT_SQUARES },
+  dell: { label: "Dell", viewBox: SQUARE_24, accentVar: VENDOR_NEUTRAL, path: siDell.path },
+  msi: { label: "MSI", viewBox: SQUARE_24, accentVar: VENDOR_NEUTRAL, path: siMsi.path },
+  asus: { label: "ASUS", viewBox: SQUARE_24, accentVar: VENDOR_NEUTRAL, path: siAsus.path },
+  qualcomm: { label: "Qualcomm", viewBox: SQUARE_24, accentVar: VENDOR_NEUTRAL, path: siQualcomm.path },
+  razer: { label: "Razer", viewBox: SQUARE_24, accentVar: VENDOR_NEUTRAL, path: siRazer.path },
+  broadcom: { label: "Broadcom", viewBox: SQUARE_24, accentVar: VENDOR_NEUTRAL, path: siBroadcom.path },
+  mediatek: { label: "MediaTek", viewBox: SQUARE_24, accentVar: VENDOR_NEUTRAL, path: siMediatek.path },
+} as const satisfies Record<string, Brand>;
+
+export type BrandKey = keyof typeof BRANDS;
+
+const BRAND_KEY_MATCHERS: ReadonlyArray<readonly [RegExp, BrandKey]> = [
+  [/advanced micro devices|\bati\b|radeon|\bamd\b/, "amd"],
+  [/\bnvidia\b|geforce|\brtx\b|\bgtx\b/, "nvidia"],
+  [/\bintel\b/, "intel"],
+  [/microsoft|\bmsft\b/, "microsoft"],
+  [/\bdell\b|alienware/, "dell"],
+  [/micro-?star|\bmsi\b/, "msi"],
+  [/\basus\b|asustek|\brog\b/, "asus"],
+  [/qualcomm|atheros|\bqca\b|snapdragon/, "qualcomm"],
+  [/\brazer\b/, "razer"],
+  [/broadcom|\bbcm\b/, "broadcom"],
+  [/mediatek|\bmtk\b/, "mediatek"],
+];
+
+const BRAND_DOMAIN_MATCHERS: ReadonlyArray<readonly [RegExp, string]> = [
+  [/realtek|\brtk\b/, "realtek.com"],
+  [/a-?volute|nahimic/, "nahimic.com"],
+  [/synaptics/, "synaptics.com"],
+  [/gigabyte|gig-?a-?byte|\baorus\b/, "gigabyte.com"],
+  [/logitech|\blogi\b/, "logitech.com"],
+  [/sound ?blaster|creative (labs|technology|technologies)/, "creative.com"],
+  [/elan(tech| microelectronics)?/, "emc.com.tw"],
+  [/conexant/, "synaptics.com"],
+  [/hewlett-?packard|\bhp\b/, "hp.com"],
+  [/lenovo/, "lenovo.com"],
+  [/\bacer\b/, "acer.com"],
+  [/advanced micro devices|radeon|\bati\b|\bamd\b/, "amd.com"],
+  [/\bnvidia\b|geforce/, "nvidia.com"],
+  [/\bintel\b/, "intel.com"],
+  [/microsoft|\bmsft\b/, "microsoft.com"],
+  [/\bdell\b|alienware/, "dell.com"],
+  [/micro-?star|\bmsi\b/, "msi.com"],
+  [/\basus\b|asustek|\brog\b/, "asus.com"],
+  [/qualcomm|atheros|snapdragon/, "qualcomm.com"],
+  [/\brazer\b/, "razer.com"],
+  [/broadcom|\bbcm\b/, "broadcom.com"],
+  [/mediatek|\bmtk\b/, "mediatek.com"],
+];
+
+export function resolveBrandKey(raw: string | null | undefined): BrandKey | null {
+  if (!raw) return null;
+  const normalized = raw.toLowerCase();
+  if (normalized in BRANDS) return normalized as BrandKey;
+  for (const [matcher, key] of BRAND_KEY_MATCHERS) {
+    if (matcher.test(normalized)) return key;
+  }
+  return null;
+}
+
+export function resolveBrandDomain(raw: string | null | undefined): string | null {
+  if (!raw) return null;
+  const normalized = raw.toLowerCase();
+  for (const [matcher, domain] of BRAND_DOMAIN_MATCHERS) {
+    if (matcher.test(normalized)) return domain;
+  }
+  return null;
+}
+
+function brandfetchClientId(): string {
+  const env = import.meta.env as Record<string, string | undefined>;
+  return env?.VITE_BRANDFETCH_CLIENT_ID ?? "";
+}
+
+export function brandfetchConfigured(): boolean {
+  return brandfetchClientId().length > 0;
+}
+
+export interface BrandfetchOptions {
+  size?: number;
+  clientId?: string;
+}
+
+export function brandfetchLogoUrl(
+  domain: string | null | undefined,
+  options: BrandfetchOptions = {},
+): string | null {
+  const clientId = options.clientId ?? brandfetchClientId();
+  if (!domain || !clientId) return null;
+  const size = Math.max(16, Math.round(options.size ?? 64));
+  return `https://cdn.brandfetch.io/${domain}/w/${size}/h/${size}/icon?c=${clientId}`;
+}
+
+export function brandLabel(raw: string): string {
+  const key = resolveBrandKey(raw);
+  return key ? BRANDS[key].label : raw;
+}
+
+export function brandFor(raw: string | null | undefined): Brand | null {
+  const key = resolveBrandKey(raw);
+  return key ? BRANDS[key] : null;
+}

--- a/frontend/src/lib/dlss.ts
+++ b/frontend/src/lib/dlss.ts
@@ -86,6 +86,48 @@ export const SR_PRESET_OPTIONS: Option<DlssPreset>[] = [
       "Legacy CNN variant for slower-paced games — more temporally stable but more ghosting.",
     sourceUrl: SRC.presetTable,
   },
+  {
+    value: "n",
+    label: "Preset N — Transformer",
+    description: "DLSS transformer preset N. Shown so a profile set in the NVIDIA app or Profile Inspector is respected.",
+    sourceUrl: SRC.dlss45,
+  },
+  {
+    value: "o",
+    label: "Preset O — Transformer",
+    description: "DLSS transformer preset O. Shown so a profile set in the NVIDIA app or Profile Inspector is respected.",
+    sourceUrl: SRC.dlss45,
+  },
+  {
+    value: "a",
+    label: "Preset A — CNN (legacy)",
+    description: "Legacy CNN preset. Prefer a transformer preset on RTX unless a game misbehaves.",
+    sourceUrl: SRC.presetTable,
+  },
+  {
+    value: "b",
+    label: "Preset B — CNN (legacy)",
+    description: "Legacy CNN preset. Prefer a transformer preset on RTX unless a game misbehaves.",
+    sourceUrl: SRC.presetTable,
+  },
+  {
+    value: "g",
+    label: "Preset G — CNN (legacy)",
+    description: "Legacy CNN preset. Prefer a transformer preset on RTX unless a game misbehaves.",
+    sourceUrl: SRC.presetTable,
+  },
+  {
+    value: "h",
+    label: "Preset H — CNN (legacy)",
+    description: "Legacy CNN preset. Prefer a transformer preset on RTX unless a game misbehaves.",
+    sourceUrl: SRC.presetTable,
+  },
+  {
+    value: "i",
+    label: "Preset I — CNN (legacy)",
+    description: "Legacy CNN preset. Prefer a transformer preset on RTX unless a game misbehaves.",
+    sourceUrl: SRC.presetTable,
+  },
 ];
 
 export const FG_MODE_OPTIONS: Option<FrameGenMode>[] = [

--- a/frontend/src/lib/driverInstallEvents.ts
+++ b/frontend/src/lib/driverInstallEvents.ts
@@ -1,8 +1,14 @@
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
-import { DRIVER_INSTALL_EVENT, type DriverInstallProgress } from "./api";
-import { applyDriverInstallProgress } from "./stores";
+import {
+  DRIVER_INSTALL_EVENT,
+  SYSTEM_DRIVER_INSTALL_EVENT,
+  type DriverInstallProgress,
+  type SystemDriverProgress,
+} from "./api";
+import { applyDriverInstallProgress, applySystemDriverProgress } from "./stores";
 
 let unlisten: UnlistenFn | null = null;
+let unlistenSystem: UnlistenFn | null = null;
 
 /** Register the single app-level listener for driver-install progress. Mounted
  *  once in `App.svelte` so progress keeps flowing into the shared store even
@@ -21,4 +27,22 @@ export async function uninstallDriverInstallListener(): Promise<void> {
   } catch {
   }
   unlisten = null;
+}
+
+/** App-level listener for general PC-driver (System & Components) install
+ *  progress. Same lifetime rationale as the GPU listener above. */
+export async function installSystemDriverListener(): Promise<void> {
+  if (unlistenSystem) return;
+  unlistenSystem = await listen<SystemDriverProgress>(SYSTEM_DRIVER_INSTALL_EVENT, (event) => {
+    applySystemDriverProgress(event.payload);
+  });
+}
+
+export async function uninstallSystemDriverListener(): Promise<void> {
+  if (!unlistenSystem) return;
+  try {
+    unlistenSystem();
+  } catch {
+  }
+  unlistenSystem = null;
 }

--- a/frontend/src/lib/labels.ts
+++ b/frontend/src/lib/labels.ts
@@ -21,6 +21,19 @@ export function vendorAccent(key: string): string {
   return VENDOR_ACCENTS[key] ?? DEFAULT_VENDOR_ACCENT;
 }
 
+export const VENDOR_ACCENT_VARS: Record<string, string> = {
+  nvidia: "var(--vendor-nvidia)",
+  amd: "var(--vendor-amd)",
+  intel: "var(--vendor-intel)",
+  microsoft: "var(--vendor-microsoft)",
+};
+
+export const DEFAULT_VENDOR_ACCENT_VAR = "var(--neutral)";
+
+export function vendorAccentVar(key: string): string {
+  return VENDOR_ACCENT_VARS[key] ?? DEFAULT_VENDOR_ACCENT_VAR;
+}
+
 export interface VendorPortal {
   label: string;
   url: string;
@@ -59,7 +72,9 @@ export const FAMILY_LABELS: Record<string, string> = {
   fsr_upscaler_vk: "FSR Vulkan",
   fsr_fg: "FSR Frame Generation",
   fsr_loader: "FSR Loader",
+  fsr_denoiser: "FSR Denoiser",
   direct_storage: "DirectStorage",
+  direct_storage_core: "DirectStorage Core",
 };
 
 export const FAMILY_SHORT: Record<string, string> = {
@@ -80,7 +95,9 @@ export const FAMILY_SHORT: Record<string, string> = {
   fsr_upscaler_vk: "FSR VK",
   fsr_fg: "FSR FG",
   fsr_loader: "FSR Loader",
+  fsr_denoiser: "FSR Denoiser",
   direct_storage: "DirectStorage",
+  direct_storage_core: "DS Core",
 };
 
 export const FAMILY_TO_VENDOR: Record<string, string> = {
@@ -101,7 +118,9 @@ export const FAMILY_TO_VENDOR: Record<string, string> = {
   fsr_upscaler_vk: "amd",
   fsr_fg: "amd",
   fsr_loader: "amd",
+  fsr_denoiser: "amd",
   direct_storage: "microsoft",
+  direct_storage_core: "microsoft",
 };
 
 export const FAMILY_TO_CATALOG_KEY: Record<string, string> = {
@@ -122,7 +141,9 @@ export const FAMILY_TO_CATALOG_KEY: Record<string, string> = {
   fsr_upscaler_vk: "fsr_upscaler",
   fsr_loader: "fsr_upscaler",
   fsr_fg: "fsr_fg",
+  fsr_denoiser: "fsr_denoiser",
   direct_storage: "direct_storage",
+  direct_storage_core: "direct_storage_core",
 };
 
 export const LAUNCHER_LABELS: Record<LauncherKind, string> = {
@@ -205,6 +226,13 @@ export const GROUP_ACCENT: Record<FamilyGroup, string> = {
   advanced: "#94a3b8",
 };
 
+export const GROUP_ACCENT_VAR: Record<FamilyGroup, string> = {
+  dlss: "var(--vendor-nvidia)",
+  fsr: "var(--vendor-amd)",
+  xess: "var(--vendor-intel)",
+  advanced: "var(--neutral)",
+};
+
 export const FAMILY_TO_GROUP: Record<string, FamilyGroup> = {
   dlss_sr: "dlss",
   dlss_fg: "dlss",
@@ -213,6 +241,7 @@ export const FAMILY_TO_GROUP: Record<string, FamilyGroup> = {
   fsr_upscaler_vk: "fsr",
   fsr_fg: "fsr",
   fsr_loader: "fsr",
+  fsr_denoiser: "fsr",
   xess_sr: "xess",
   xess_sr_dx11: "xess",
   xess_fg: "xess",

--- a/frontend/src/lib/notifications.ts
+++ b/frontend/src/lib/notifications.ts
@@ -10,6 +10,9 @@ export type NotificationKind =
   | "apply_cancelled"
   | "app_update_available"
   | "catalog_update_available"
+  | "driver_update_available"
+  | "system_driver_update_available"
+  | "backup_restored"
   | "scan_failed"
   | "catalog_refresh_failed";
 
@@ -17,7 +20,7 @@ export function makeNotificationEntry(
   kind: NotificationKind,
   title: string,
   body: string | null = null,
-  extras?: Partial<Pick<NotificationEntry, "apply_id" | "game_id" | "error_class">>,
+  extras?: Partial<Pick<NotificationEntry, "apply_id" | "game_id" | "error_class" | "link">>,
 ): NotificationEntry {
   return {
     id: crypto.randomUUID(),
@@ -30,6 +33,7 @@ export function makeNotificationEntry(
     apply_id: extras?.apply_id ?? null,
     game_id: extras?.game_id ?? null,
     error_class: extras?.error_class ?? null,
+    link: extras?.link ?? null,
   };
 }
 
@@ -44,6 +48,7 @@ export interface NotificationEntry {
   apply_id: string | null;
   game_id: string | null;
   error_class: string | null;
+  link: string | null;
 }
 
 export interface ListFilter {

--- a/frontend/src/lib/relation.ts
+++ b/frontend/src/lib/relation.ts
@@ -1,5 +1,54 @@
-import type { DllRecord } from "./api";
+import type { DllRecord, UpdatePreferences } from "./api";
 import { familyVendor, familyCatalogKey, filenameFromPath, type UpdateStatus } from "./labels";
+
+const FAMILY_PREF: Record<string, keyof UpdatePreferences> = {
+  dlss_sr: "update_dlss",
+  dlss_fg: "update_dlss_fg",
+  dlss_rr: "update_dlss_rr",
+  streamline: "update_streamline",
+  streamline_common: "update_streamline",
+  streamline_pcl: "update_streamline",
+  streamline_nis: "update_streamline",
+  streamline_direct_sr: "update_streamline",
+  reflex: "update_reflex",
+  xess_sr: "update_xess",
+  xess_sr_dx11: "update_xess",
+  xess_fg: "update_xess",
+  xell: "update_xess",
+  fsr_upscaler: "update_fsr",
+  fsr_upscaler_vk: "update_fsr",
+  fsr_fg: "update_fsr",
+  fsr_loader: "update_fsr",
+  fsr_denoiser: "update_fsr",
+  direct_storage: "update_direct_storage",
+  direct_storage_core: "update_direct_storage",
+};
+
+/** An NVIDIA Streamline plugin/interposer DLL (`sl.*.dll`) — a version-locked set
+ * that must not be swapped piecemeal (mirrors the backend `is_streamline_plugin`). */
+export function isStreamlinePlugin(filename: string): boolean {
+  const lower = filename.toLowerCase();
+  return lower.startsWith("sl.") && lower.endsWith(".dll");
+}
+
+/** Whether a DLL may be offered/applied given the user's per-feature preferences.
+ * `sl.*` Streamline plugins additionally require the Streamline master switch and
+ * are never offered when DLSS Enabler manages the Streamline set in this game —
+ * swapping them out of lockstep crashes the game (kFeatureReflex). `prefs === null`
+ * keeps the legacy permissive behaviour. */
+export function recordUpdatable(
+  r: DllRecord,
+  prefs: UpdatePreferences | null = null,
+  dlssEnablerPresent = false,
+): boolean {
+  const streamlinePlugin = isStreamlinePlugin(filenameFromPath(r.path));
+  if (streamlinePlugin && dlssEnablerPresent) return false;
+  if (!prefs) return true;
+  const prefKey = FAMILY_PREF[r.family];
+  if (prefKey && !prefs[prefKey]) return false;
+  if (streamlinePlugin && !prefs.update_streamline) return false;
+  return true;
+}
 
 export type DllRelation = "outdated" | "same" | "ahead" | "no-target";
 
@@ -73,12 +122,15 @@ export function gameStatusFromRecords(
   ctx: RelationContext,
   disabledFamilies: string[] = [],
   scanError: string | null = null,
+  prefs: UpdatePreferences | null = null,
+  dlssEnablerPresent = false,
 ): UpdateStatus {
   if (scanError) return "scan_failed";
   if (!records) return "unknown";
   if (records.length === 0) return "no_dlls";
   for (const r of records) {
     if (disabledFamilies.includes(r.family)) continue;
+    if (!recordUpdatable(r, prefs, dlssEnablerPresent)) continue;
     if (dllRelation(r, ctx) === "outdated") return "outdated";
   }
   return "up_to_date";

--- a/frontend/src/lib/stores.ts
+++ b/frontend/src/lib/stores.ts
@@ -8,11 +8,15 @@ import {
   getSettings,
   saveSettings,
   detectDlls,
+  detectDlssEnabler,
   enrichGameArt,
   fetchSteamArt,
   checkDriverUpdates,
   listDriverHistory,
   installDriver,
+  scanSystemDrivers,
+  installSystemDriver,
+  driverInstallContext,
   type DetectedGame,
   type BackupEntry,
   type AppSettings,
@@ -23,8 +27,11 @@ import {
   type DriverInstallProgress,
   type InstallStage,
   type GpuVendor,
+  type SystemDeviceGroup,
+  type SystemDriverUpdate,
+  type SystemDriverProgress,
 } from "./api";
-import { sortDriverReports } from "./drivers";
+import { sortDriverReports, hasDriverUpdate, driverPageUrl } from "./drivers";
 import { vendorLabel, familyLabel, familyShort, type UpdateStatus } from "./labels";
 import { buildShasByVendor, gameStatusFromRecords, type CatalogShasByVendor, type RelationContext } from "./relation";
 import {
@@ -92,6 +99,44 @@ function emitCatalogUpdateNotifications(
   }
 }
 
+const DRIVER_UPDATE_NOTIFICATION_CAP = 4;
+
+function emitDriverUpdateNotifications(reports: DriverStatusReport[]): void {
+  const fresh = reports
+    .filter(hasDriverUpdate)
+    .filter(
+      (r) => !alreadyEmitted("driver_update_available", `${r.device.model} ${r.latest?.version.display ?? ""}`),
+    );
+  for (const report of fresh.slice(0, DRIVER_UPDATE_NOTIFICATION_CAP)) {
+    const version = report.latest?.version.display ?? "latest";
+    const entry = makeNotificationEntry(
+      "driver_update_available",
+      `GPU driver ${version} — ${report.device.model}`,
+      `New ${vendorLabel(report.device.vendor)} driver available`,
+      { link: driverPageUrl(report) },
+    );
+    pushNotification(entry).catch((err) =>
+      console.warn("[dlssync] push driver-update notification failed:", err),
+    );
+  }
+}
+
+function emitSystemDriverUpdateNotification(groups: SystemDeviceGroup[]): void {
+  const count = groups.reduce((total, group) => total + group.updates.length, 0);
+  if (count === 0) return;
+  const noun = `${count} system driver update${count === 1 ? "" : "s"}`;
+  if (alreadyEmitted("system_driver_update_available", noun)) return;
+  const categories = groups.filter((group) => group.updates.length > 0).length;
+  const entry = makeNotificationEntry(
+    "system_driver_update_available",
+    `${noun} available`,
+    `Across ${categories} hardware categor${categories === 1 ? "y" : "ies"}`,
+  );
+  pushNotification(entry).catch((err) =>
+    console.warn("[dlssync] push system-driver notification failed:", err),
+  );
+}
+
 export const currentView: Writable<string> = writable("library");
 
 export const games: Writable<DetectedGame[]> = writable([]);
@@ -125,23 +170,80 @@ export const settings: Writable<AppSettings | null> = writable(null);
 export const gameDlls: Writable<Record<string, DllRecord[]>> = writable({});
 export const gameDllsLoading: Writable<Record<string, boolean>> = writable({});
 export const gameDllErrors: Writable<Record<string, string | null>> = writable({});
+export const gameDlssEnabler: Writable<Record<string, boolean>> = writable({});
 
+export interface ToastAction {
+  label: string;
+  run: () => void;
+}
 export interface Toast {
   id: number;
   kind: "success" | "warning" | "danger" | "info";
   message: string;
+  action?: ToastAction;
+  ttlMs: number;
 }
 export const toasts: Writable<Toast[]> = writable([]);
 let toastSeq = 0;
 
 export function showToast(kind: Toast["kind"], message: string, ttlMs = 4000): void {
   const id = ++toastSeq;
-  toasts.update((arr) => [...arr, { id, kind, message }]);
+  toasts.update((arr) => [...arr, { id, kind, message, ttlMs }]);
   setTimeout(() => dismissToast(id), ttlMs);
+}
+
+/** A quiet toast carrying a single inline action (e.g. Undo). Returns the id so
+ *  the caller can dismiss it early once the action is no longer reversible. */
+export function showActionToast(
+  kind: Toast["kind"],
+  message: string,
+  action: ToastAction,
+  ttlMs = 6000,
+): number {
+  const id = ++toastSeq;
+  toasts.update((arr) => [...arr, { id, kind, message, action, ttlMs }]);
+  setTimeout(() => dismissToast(id), ttlMs);
+  return id;
 }
 
 export function dismissToast(id: number): void {
   toasts.update((arr) => arr.filter((t) => t.id !== id));
+}
+
+/** Run a reversible toggle optimistically: flip UI state now, fire the backend
+ *  call, and surface a quiet Undo toast. The optimistic state is reverted if the
+ *  backend rejects OR the user clicks Undo; on success the toast lingers briefly
+ *  with the Undo affordance, then auto-clears. */
+export async function optimisticToggle(opts: {
+  applyOptimistic: () => void;
+  revert: () => void;
+  commit: () => Promise<void>;
+  message: string;
+  undoLabel?: string;
+}): Promise<void> {
+  opts.applyOptimistic();
+  let reverted = false;
+  const undo = (): void => {
+    if (reverted) return;
+    reverted = true;
+    opts.revert();
+  };
+  const toastId = showActionToast("info", opts.message, {
+    label: opts.undoLabel ?? "Undo",
+    run: () => {
+      undo();
+      dismissToast(toastId);
+    },
+  });
+  try {
+    await opts.commit();
+  } catch (err: unknown) {
+    if (!reverted) {
+      undo();
+      dismissToast(toastId);
+      showToast("danger", `Could not save: ${formatError(err)}`);
+    }
+  }
 }
 
 export const searchQuery: Writable<string> = writable("");
@@ -202,12 +304,20 @@ export const relationContext: Readable<RelationContext> = derived(
 );
 
 export const gameStatuses: Readable<GameStatusMap> = derived(
-  [games, gameDlls, gameDllErrors, relationContext, settings],
-  ([$games, $dlls, $errs, $ctx, $settings]) => {
+  [games, gameDlls, gameDllErrors, relationContext, settings, gameDlssEnabler],
+  ([$games, $dlls, $errs, $ctx, $settings, $enabler]) => {
     const out: GameStatusMap = {};
+    const prefs = $settings?.update_prefs ?? null;
     for (const g of $games) {
       const disabled = $settings?.game_preferences[g.id]?.disabled_families ?? [];
-      out[g.id] = gameStatusFromRecords($dlls[g.id], $ctx, disabled, $errs[g.id] ?? null);
+      out[g.id] = gameStatusFromRecords(
+        $dlls[g.id],
+        $ctx,
+        disabled,
+        $errs[g.id] ?? null,
+        prefs,
+        $enabler[g.id] ?? false,
+      );
     }
     return out;
   },
@@ -286,6 +396,7 @@ export const sidebarCounts: Readable<SidebarCounts> = derived(
 );
 
 export const commandPaletteOpen: Writable<boolean> = writable(false);
+export const notificationsOpen: Writable<boolean> = writable(false);
 export const shortcutOverlayOpen: Writable<boolean> = writable(false);
 export const notificationsUnreadCount: Readable<number> = derived(
   notifications,
@@ -362,6 +473,9 @@ async function scanOne(g: DetectedGame): Promise<void> {
       gameDlls.update((m) => ({ ...m, [g.id]: records }));
       gameDllErrors.update((m) => ({ ...m, [g.id]: null }));
       gameDllsLoading.update((m) => ({ ...m, [g.id]: false }));
+      void detectDlssEnabler(g.install_dir)
+        .then((flag) => gameDlssEnabler.update((m) => ({ ...m, [g.id]: flag })))
+        .catch(() => {});
       return;
     } catch (err) {
       lastErr = err;
@@ -488,6 +602,7 @@ export async function loadDriverUpdates(): Promise<void> {
   try {
     const reports = await checkDriverUpdates();
     driverReports.set(sortDriverReports(reports));
+    emitDriverUpdateNotifications(reports);
   } catch (err: unknown) {
     const message = formatError(err);
     driverCheckError.set(message);
@@ -572,6 +687,161 @@ export async function loadDriverHistory(
     driverHistoryLoading.update((m) => ({ ...m, [model]: false }));
   }
 }
+
+
+export const systemDriverGroups: Writable<SystemDeviceGroup[]> = writable([]);
+export const systemScanInProgress: Writable<boolean> = writable(false);
+export const systemScanError: Writable<string | null> = writable(null);
+export const systemScanRan: Writable<boolean> = writable(false);
+
+export async function loadSystemDrivers(): Promise<void> {
+  systemScanInProgress.set(true);
+  systemScanError.set(null);
+  try {
+    const groups = await scanSystemDrivers();
+    systemDriverGroups.set(groups);
+    systemScanRan.set(true);
+    emitSystemDriverUpdateNotification(groups);
+  } catch (err: unknown) {
+    const message = formatError(err);
+    systemScanError.set(message);
+    showToast("danger", `System driver scan failed: ${message}`);
+  } finally {
+    systemScanInProgress.set(false);
+  }
+}
+
+/** Shared, app-level install state for a single system-driver update. Keyed by
+ *  the WUA `update_id` so the card that launched it shows progress regardless of
+ *  which view is mounted (the app-level listener keeps writing here). */
+export interface SystemDriverInstallState {
+  updateId: string | null;
+  stage: SystemDriverProgress["stage"] | null;
+  message: string;
+  fraction: number | null;
+}
+
+const SYSTEM_DRIVER_IDLE: SystemDriverInstallState = {
+  updateId: null,
+  stage: null,
+  message: "",
+  fraction: null,
+};
+
+/** Human label per install stage (the backend enum is machine-cased). */
+export const DRIVER_INSTALL_STAGE_LABEL: Record<string, string> = {
+  downloading: "Downloading",
+  installing: "Installing",
+  completed: "Done",
+  failed: "Failed",
+};
+
+export const systemDriverInstall: Writable<SystemDriverInstallState> = writable({
+  ...SYSTEM_DRIVER_IDLE,
+});
+
+/** Fold a backend progress event into the shared state. Ignored when no install
+ *  is active so a late event cannot resurrect a cleared card. */
+export function applySystemDriverProgress(p: SystemDriverProgress): void {
+  systemDriverInstall.update((s) =>
+    s.updateId === null ? s : { ...s, stage: p.stage, message: p.message, fraction: p.fraction },
+  );
+}
+
+/** Drive a system-driver install end-to-end. One at a time; on success the
+ *  scan is refreshed so the freshly-installed driver drops off the list. */
+export async function startSystemDriverInstall(
+  update: SystemDriverUpdate,
+  deviceClassLabel?: string,
+): Promise<void> {
+  if (get(systemDriverInstall).updateId) return;
+  systemDriverInstall.set({
+    updateId: update.update_id,
+    stage: "downloading",
+    message: "Starting…",
+    fraction: null,
+  });
+  try {
+    const outcome = await installSystemDriver(
+      update.update_id,
+      driverInstallContext(update, deviceClassLabel ?? update.class),
+    );
+    if (outcome.success) {
+      const reboot = outcome.reboot_required ? " A restart is required to finish." : "";
+      showToast("success", `${update.title} installed.${reboot}`);
+      systemDriverInstall.set({ ...SYSTEM_DRIVER_IDLE });
+      await loadSystemDrivers();
+    } else {
+      showToast("danger", outcome.message);
+      failSystemDriverInstall(update.update_id, outcome.message);
+    }
+  } catch (err: unknown) {
+    const message = `Install failed: ${formatError(err)}`;
+    showToast("danger", message);
+    failSystemDriverInstall(update.update_id, message);
+  }
+}
+
+/** Park the card in a VISIBLE terminal 'failed' state (instead of silently
+ *  snapping back to idle), then auto-clear after a grace period. */
+function failSystemDriverInstall(id: string, message: string): void {
+  systemDriverInstall.set({ updateId: id, stage: "failed", message, fraction: 1 });
+  setTimeout(() => {
+    const s = get(systemDriverInstall);
+    if (s.updateId === id && s.stage === "failed") {
+      systemDriverInstall.set({ ...SYSTEM_DRIVER_IDLE });
+    }
+  }, 8000);
+}
+
+/** Manually clear a finished/failed install card. */
+export function dismissSystemDriverInstall(): void {
+  systemDriverInstall.set({ ...SYSTEM_DRIVER_IDLE });
+}
+
+export interface DockItem {
+  id: string;
+  kind: "apply" | "gpu_driver" | "system_driver";
+  label: string;
+  stage: string;
+  fraction: number | null;
+}
+
+export const dockItems: Readable<DockItem[]> = derived(
+  [activeApplies, driverInstall, systemDriverInstall],
+  ([$applies, $gpu, $sys]) => {
+    const items: DockItem[] = [];
+    for (const a of Object.values($applies)) {
+      if (a.ended_at !== null) continue;
+      items.push({
+        id: a.apply_id,
+        kind: "apply",
+        label: a.game_label ?? a.game_id,
+        stage: a.stage,
+        fraction: a.progress,
+      });
+    }
+    if ($gpu.vendor !== null) {
+      items.push({
+        id: `gpu:${$gpu.vendor}`,
+        kind: "gpu_driver",
+        label: `${$gpu.vendor.toUpperCase()} driver`,
+        stage: $gpu.stage ?? "",
+        fraction: $gpu.fraction,
+      });
+    }
+    if ($sys.updateId !== null) {
+      items.push({
+        id: `sys:${$sys.updateId}`,
+        kind: "system_driver",
+        label: "Component driver",
+        stage: $sys.stage ?? "",
+        fraction: $sys.fraction,
+      });
+    }
+    return items;
+  },
+);
 
 export async function loadSettings(): Promise<void> {
   try {

--- a/frontend/src/lib/ux.ts
+++ b/frontend/src/lib/ux.ts
@@ -95,33 +95,37 @@ export interface PaletteCommand {
   title: string;
   aliases: readonly string[];
   category: CommandCategory;
+  /** Lucide icon key (kebab-case file name) resolved to a component in the palette. */
+  icon: string;
+  /** Key sequence shown as a chip, e.g. ["g","l"]. Display-only — the global handlers own the bindings. */
+  shortcut?: readonly string[];
   hint?: string;
 }
 
 export const COMMANDS: readonly PaletteCommand[] = [
-  { id: "nav.library", title: "Go to Library", aliases: ["library", "games"], category: "navigate" },
-  { id: "nav.catalog", title: "Go to Catalog", aliases: ["catalog", "versions", "manifest"], category: "navigate" },
-  { id: "nav.backups", title: "Go to Backups", aliases: ["backups", "snapshots", "restore"], category: "navigate" },
-  { id: "nav.settings", title: "Go to Settings", aliases: ["settings", "prefs", "preferences", "options"], category: "navigate" },
-  { id: "nav.about", title: "Go to About", aliases: ["about", "info", "version", "system"], category: "navigate" },
+  { id: "nav.library", title: "Go to Library", aliases: ["library", "games"], category: "navigate", icon: "layout-grid", shortcut: ["g", "l"], hint: "Your installed games and pending updates" },
+  { id: "nav.catalog", title: "Go to Catalog", aliases: ["catalog", "versions", "manifest"], category: "navigate", icon: "layers", shortcut: ["g", "c"], hint: "Every DLL version in the manifest" },
+  { id: "nav.backups", title: "Go to Backups", aliases: ["backups", "snapshots", "restore"], category: "navigate", icon: "archive", shortcut: ["g", "b"], hint: "Saved snapshots you can restore" },
+  { id: "nav.settings", title: "Go to Settings", aliases: ["settings", "prefs", "preferences", "options"], category: "navigate", icon: "settings", shortcut: ["g", "s"] },
+  { id: "nav.about", title: "Go to About", aliases: ["about", "info", "version", "system"], category: "navigate", icon: "info", shortcut: ["g", "a"] },
 
-  { id: "action.apply_all_outdated", title: "Apply all outdated updates", aliases: ["apply", "update all", "run updates"], category: "action" },
-  { id: "action.rescan", title: "Rescan installed games", aliases: ["rescan", "refresh games"], category: "action" },
-  { id: "action.refresh_manifest", title: "Refresh DLL manifest", aliases: ["refresh manifest", "catalog refresh"], category: "action" },
-  { id: "action.check_updates", title: "Check for app updates", aliases: ["check updates", "upgrade"], category: "action" },
-  { id: "action.restore_recent", title: "Restore most recent backup", aliases: ["restore", "undo", "revert"], category: "action" },
-  { id: "action.open_data_folder", title: "Open DLSSync data folder", aliases: ["open data", "reveal data folder"], category: "action" },
-  { id: "action.open_backups_folder", title: "Open backups folder", aliases: ["open backups", "reveal backups"], category: "action" },
-  { id: "action.open_logs_folder", title: "Open logs folder", aliases: ["open logs", "reveal logs"], category: "action" },
-  { id: "action.toggle_theme", title: "Toggle dark / light theme", aliases: ["toggle theme", "dark mode", "light mode"], category: "action" },
-  { id: "action.toggle_view_mode", title: "Toggle Library view (Grid / List)", aliases: ["toggle view", "grid", "list"], category: "action" },
-  { id: "action.toggle_density", title: "Toggle Library density (Compact / Comfy)", aliases: ["toggle density", "compact", "comfy"], category: "action" },
+  { id: "action.apply_all_outdated", title: "Apply all outdated updates", aliases: ["apply", "update all", "run updates"], category: "action", icon: "download-cloud", shortcut: ["a"] },
+  { id: "action.rescan", title: "Rescan installed games", aliases: ["rescan", "refresh games"], category: "action", icon: "refresh-cw", shortcut: ["r"] },
+  { id: "action.refresh_manifest", title: "Refresh DLL manifest", aliases: ["refresh manifest", "catalog refresh"], category: "action", icon: "rotate-cw" },
+  { id: "action.check_updates", title: "Check for app updates", aliases: ["check updates", "upgrade"], category: "action", icon: "arrow-up-circle" },
+  { id: "action.restore_recent", title: "Restore most recent backup", aliases: ["restore", "undo", "revert"], category: "action", icon: "undo-2" },
+  { id: "action.open_data_folder", title: "Open DLSSync data folder", aliases: ["open data", "reveal data folder"], category: "action", icon: "folder" },
+  { id: "action.open_backups_folder", title: "Open backups folder", aliases: ["open backups", "reveal backups"], category: "action", icon: "folder-archive" },
+  { id: "action.open_logs_folder", title: "Open logs folder", aliases: ["open logs", "reveal logs"], category: "action", icon: "scroll-text" },
+  { id: "action.toggle_theme", title: "Toggle dark / light theme", aliases: ["toggle theme", "dark mode", "light mode"], category: "action", icon: "sun-moon" },
+  { id: "action.toggle_view_mode", title: "Toggle Library view (Grid / List)", aliases: ["toggle view", "grid", "list"], category: "action", icon: "layout-list", shortcut: ["v"] },
+  { id: "action.toggle_density", title: "Toggle Library density (Compact / Comfy)", aliases: ["toggle density", "compact", "comfy"], category: "action", icon: "rows-3", shortcut: ["d"] },
 
-  { id: "settings.general", title: "Settings · General", aliases: ["general", "startup"], category: "settings" },
-  { id: "settings.updates", title: "Settings · Update preferences", aliases: ["update preferences", "vendor toggles"], category: "settings" },
-  { id: "settings.detection", title: "Settings · Detection", aliases: ["detection", "scanners", "launchers"], category: "settings" },
-  { id: "settings.art", title: "Settings · Art", aliases: ["art", "covers", "steamgriddb"], category: "settings" },
-  { id: "settings.advanced", title: "Settings · Advanced", aliases: ["advanced", "retries", "concurrency", "allow unsigned"], category: "settings" },
+  { id: "settings.general", title: "Settings · General", aliases: ["general", "startup"], category: "settings", icon: "sliders-horizontal" },
+  { id: "settings.updates", title: "Settings · Update preferences", aliases: ["update preferences", "vendor toggles"], category: "settings", icon: "download-cloud" },
+  { id: "settings.detection", title: "Settings · Detection", aliases: ["detection", "scanners", "launchers"], category: "settings", icon: "radar" },
+  { id: "settings.art", title: "Settings · Art", aliases: ["art", "covers", "steamgriddb"], category: "settings", icon: "image" },
+  { id: "settings.advanced", title: "Settings · Advanced", aliases: ["advanced", "retries", "concurrency", "allow unsigned"], category: "settings", icon: "wrench" },
 ];
 
 export const COMMAND_CATEGORY_LABELS: Record<CommandCategory | "all", string> = {
@@ -152,6 +156,53 @@ export function matchCommands(query: string, commands: readonly PaletteCommand[]
   return out;
 }
 
+/** Indices in `text` that the query matched, for fuzzy-character highlighting.
+ *  Prefers a contiguous substring span; falls back to subsequence positions;
+ *  returns [] when the query is not a subsequence of `text` (e.g. it matched an alias). */
+export function matchedIndices(query: string, text: string): number[] {
+  const q = query.toLowerCase().trim();
+  if (!q) return [];
+  const t = text.toLowerCase();
+  const span = t.indexOf(q);
+  if (span >= 0) {
+    return Array.from({ length: q.length }, (_, k) => span + k);
+  }
+  const out: number[] = [];
+  let i = 0;
+  for (let pos = 0; pos < t.length && i < q.length; pos++) {
+    if (t[pos] === q[i]) {
+      out.push(pos);
+      i += 1;
+    }
+  }
+  return i === q.length ? out : [];
+}
+
+export interface HighlightSegment {
+  text: string;
+  hit: boolean;
+}
+
+/** Split `text` into consecutive hit / non-hit segments from matched indices. */
+export function highlightSegments(text: string, indices: readonly number[]): HighlightSegment[] {
+  if (indices.length === 0) return [{ text, hit: false }];
+  const flags = new Set(indices);
+  const segments: HighlightSegment[] = [];
+  let buffer = "";
+  let bufferHit = flags.has(0);
+  for (let i = 0; i < text.length; i++) {
+    const hit = flags.has(i);
+    if (hit !== bufferHit) {
+      if (buffer) segments.push({ text: buffer, hit: bufferHit });
+      buffer = "";
+      bufferHit = hit;
+    }
+    buffer += text[i];
+  }
+  if (buffer) segments.push({ text: buffer, hit: bufferHit });
+  return segments;
+}
+
 function subsequenceScore(needle: string, haystack: string): number | null {
   if (haystack.includes(needle)) return haystack.length - needle.length;
   let i = 0;
@@ -167,9 +218,21 @@ export const EXTERNAL_URLS = {
   anticheatFaq: "https://www.pcgamingwiki.com/wiki/Glossary:Anti-cheat",
   homepage: "https://github.com/xt0n1-t3ch/DLSSync",
   releases: "https://github.com/xt0n1-t3ch/DLSSync/releases",
+  releasesLatest: "https://github.com/xt0n1-t3ch/DLSSync/releases/latest",
+  nexusMod: "https://www.nexusmods.com/site/mods/1922",
   sponsor: "https://github.com/sponsors/xt0n1-t3ch",
   kofi: "https://ko-fi.com/xt0n1",
 } as const;
+
+export function githubReleaseTagUrl(version: string): string {
+  const tag = version.trim().replace(/^v/i, "");
+  return `${EXTERNAL_URLS.homepage}/releases/tag/v${tag}`;
+}
+
+/** Why a driver install asks for Administrator — shown wherever a per-machine
+ *  install can trigger a UAC prompt (System & Components, GPU drivers). */
+export const ADMIN_ELEVATION_NOTE =
+  "Windows installs per-machine drivers only with Administrator rights, so Update shows a UAC prompt. DLSSync stays unelevated and runs a signed helper with your approval — it snapshots the current driver and sets a System Restore point first, so you can roll back.";
 
 export const VENDOR_TOKEN_BY_FAMILY: Record<string, string> = {
   dlss_sr: "var(--vendor-nvidia)",

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -11,9 +11,9 @@
   --bg-app: #000000;
   --bg-sidebar: #000000;
   --bg-topbar: rgba(0, 0, 0, 0.72);
-  --bg-card: #0a0a0a;
-  --bg-card-hover: #171717;
-  --bg-elevated: #141414;
+  --bg-card: #101014;
+  --bg-card-hover: #1c1c22;
+  --bg-elevated: #17171c;
   --bg-input: #0a0a0a;
   --bg-overlay: rgba(0, 0, 0, 0.92);
   --bg-art-fallback: linear-gradient(135deg, #141414 0%, #000000 100%);
@@ -102,6 +102,16 @@
   --radius-3xl: 28px;
   --radius-full: 9999px;
 
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 24px;
+  --space-6: 32px;
+  --space-7: 48px;
+  --space-8: 64px;
+  --density: 1;
+
   --shadow-xs: 0 1px 2px rgba(0, 0, 0, 0.6);
   --shadow-sm: 0 2px 6px rgba(0, 0, 0, 0.6);
   --shadow-md: 0 4px 14px rgba(0, 0, 0, 0.7);
@@ -149,10 +159,34 @@
 
   --sidebar-width: 232px;
   --sidebar-width-collapsed: 64px;
+  --shell-gap: 12px;
   --topbar-height: 52px;
   --content-max: 1600px;
   --drawer-width: clamp(440px, 38vw, 600px);
   --card-art-aspect: 2 / 1;
+
+  --glass-1: rgba(22, 24, 34, 0.44);
+  --glass-2: rgba(16, 18, 28, 0.38);
+  --glass-3: rgba(12, 14, 22, 0.55);
+  --glass-strong: rgba(18, 20, 30, 0.60);
+  --glass-blur: blur(28px) saturate(180%) brightness(1.08);
+  --glass-blur-bar: blur(20px) saturate(180%) brightness(1.08);
+  --glass-edge: inset 0 1px 0 rgba(255, 255, 255, 0.16), inset 0 -1px 0 rgba(0, 0, 0, 0.18);
+  --dock-height: 64px;
+  --accent-progress: #00d4d4;
+
+  --glass-fallback: var(--bg-elevated);
+  --art-blur: 80px;
+  --art-dim: 0.50;
+  --art-opacity: 0.42;
+  --art-sat: 1.25;
+  --art-edge-left: 23.8%;
+  --art-edge-left-fade: 32.3%;
+  --art-edge-top: 16.9%;
+  --art-edge-top-fade: 25.4%;
+  --ambient-glow-1: hsla(211, 95%, 50%, 0.42);
+  --ambient-glow-2: hsla(174, 80%, 45%, 0.30);
+  --ambient-glow-3: hsla(270, 85%, 60%, 0.32);
 
   font-family: var(--font-sans);
   font-size: var(--fs-base);
@@ -168,13 +202,13 @@
 
 [data-theme="light"] {
   color-scheme: light;
-  --bg-base: #ffffff;
-  --bg-app: #ffffff;
+  --bg-base: #f2f3f5;
+  --bg-app: #f2f3f5;
   --bg-sidebar: #ffffff;
   --bg-topbar: rgba(255, 255, 255, 0.72);
   --bg-card: #ffffff;
-  --bg-card-hover: #f2f4f8;
-  --bg-elevated: #f7f8fb;
+  --bg-card-hover: #f0f2f6;
+  --bg-elevated: #eaedf2;
   --bg-input: #ffffff;
   --bg-overlay: rgba(255, 255, 255, 0.94);
   --bg-art-fallback: linear-gradient(135deg, #e1e5ec 0%, #f4f6f9 100%);
@@ -253,6 +287,25 @@
   --shadow-md: 0 4px 14px rgba(15, 23, 42, 0.06);
   --shadow-lg: 0 16px 40px rgba(15, 23, 42, 0.08);
   --shadow-card-hover: 0 8px 24px rgba(15, 23, 42, 0.08), 0 0 0 1px var(--accent-dim);
+
+  --glass-1: rgba(255, 255, 255, 0.55);
+  --glass-2: rgba(255, 255, 255, 0.48);
+  --glass-3: rgba(255, 255, 255, 0.66);
+  --glass-strong: rgba(252, 253, 255, 0.70);
+  --glass-edge: inset 0 1px 0 rgba(255, 255, 255, 0.7);
+  --accent-progress: #0aa2a2;
+
+  --art-blur: 90px;
+  --art-dim: 0.82;
+  --art-opacity: 0.30;
+  --art-sat: 1.15;
+  --art-edge-left: 23.8%;
+  --art-edge-left-fade: 32.3%;
+  --art-edge-top: 16.9%;
+  --art-edge-top-fade: 25.4%;
+  --ambient-glow-1: hsla(211, 100%, 62%, 0.26);
+  --ambient-glow-2: hsla(168, 72%, 52%, 0.20);
+  --ambient-glow-3: hsla(266, 85%, 66%, 0.20);
 }
 
 *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
@@ -623,7 +676,6 @@ input::placeholder, textarea::placeholder { color: var(--text-placeholder); }
   background: var(--bg-card);
   border-radius: var(--radius-2xl);
   padding: 22px 24px;
-  box-shadow: var(--shadow-md);
   border: 1px solid var(--border);
   transition: box-shadow var(--dur-normal) var(--ease), border-color var(--dur-normal) var(--ease), transform var(--dur-normal) var(--ease);
 }
@@ -687,6 +739,215 @@ input::placeholder, textarea::placeholder { color: var(--text-placeholder); }
 
 .aura-stack { display: flex; flex-direction: column; gap: 12px; min-width: 0; }
 .aura-stack.aura-stack-tight { gap: 6px; }
+
+/* ── Tidal-grade glass + section + media-card utilities ─────────────────────
+   Frosted-glass chrome (NOT the GameDetailDrawer scrim — that stays blur-free).
+   Falls back to a solid surface where backdrop-filter is unsupported. */
+.glass-panel {
+  background: var(--glass-1);
+  backdrop-filter: var(--glass-blur);
+  -webkit-backdrop-filter: var(--glass-blur);
+  border: 1px solid var(--border);
+  box-shadow: var(--glass-edge);
+}
+@supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
+  .glass-panel { background: var(--bg-elevated); }
+}
+
+/* The single floating-dialog material: one blur level, lg shadow, a 3px accent
+   leading stripe and a 32px close affordance. Every modal/flyout/popover shares
+   this — do NOT hand-roll per-component glass surfaces. */
+.glass-dialog {
+  position: relative;
+  overflow: hidden;
+  background: var(--glass-strong);
+  backdrop-filter: var(--glass-blur);
+  -webkit-backdrop-filter: var(--glass-blur);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-lg), var(--glass-edge);
+}
+.glass-dialog::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 3px;
+  background: linear-gradient(
+    to bottom,
+    var(--edge-color, var(--accent)),
+    color-mix(in oklab, var(--edge-color, var(--accent)) 30%, transparent)
+  );
+  pointer-events: none;
+  z-index: 1;
+}
+@supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
+  .glass-dialog { background: var(--glass-fallback); }
+}
+.dialog-close {
+  position: absolute;
+  top: var(--space-3);
+  right: var(--space-3);
+  z-index: 2;
+  width: 32px;
+  height: 32px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-md);
+  color: var(--text-muted);
+  background: transparent;
+  transition: background var(--dur-fast) var(--ease), color var(--dur-fast) var(--ease);
+}
+.dialog-close:hover { background: var(--bg-elevated); color: var(--text-primary); }
+.dialog-close:focus-visible { outline: none; box-shadow: var(--shadow-ring); }
+
+.section-head {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  margin: 4px 0 14px;
+}
+.section-head .section-title {
+  font-size: var(--fs-lg);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: var(--letter-wide);
+  color: var(--text-primary);
+}
+.section-head .section-count {
+  font-family: var(--font-mono);
+  font-size: var(--fs-2xs);
+  font-weight: 700;
+  padding: 1px 7px;
+  border-radius: var(--radius-full);
+  background: var(--bg-elevated);
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+}
+.section-head .section-viewall {
+  margin-left: auto;
+  font-size: var(--fs-xs);
+  font-weight: 600;
+  color: var(--text-secondary);
+  background: none;
+  border: none;
+  padding: 4px 6px;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: color var(--dur-fast) var(--ease), background var(--dur-fast) var(--ease);
+}
+.section-head .section-viewall:hover { color: var(--accent); background: var(--accent-dim); }
+
+.tidal-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(clamp(200px, 22vw, 280px), 1fr));
+  gap: clamp(12px, 1.4vw, 20px);
+}
+
+/* Media-card hover doctrine: the hovered card lifts + scales; its siblings dim.
+   Apply `.media-deck` to the grid and `.media-card` to each card. */
+.media-deck:hover .media-card { opacity: 0.86; }
+.media-card {
+  transition: opacity var(--dur-normal) var(--ease), transform var(--dur-normal) var(--spring);
+  will-change: transform;
+}
+.media-deck .media-card:hover,
+.media-deck .media-card:focus-visible,
+.media-deck .media-card.is-active {
+  opacity: 1;
+  transform: translateY(-3px) scale(1.018);
+}
+
+/* Tactile micro-interaction language — one shared lift + press. Compose these;
+   do NOT redefine hover/active transforms per component. */
+.hover-lift {
+  transition: transform var(--dur-normal) var(--ease-out), box-shadow var(--dur-normal) var(--ease-out);
+  will-change: transform;
+}
+.hover-lift:hover { transform: translateY(-2px) scale(1.02); }
+.press { transition: transform var(--dur-instant) var(--ease); }
+.press:active { transform: scale(0.98); }
+
+/* ── Design-system coherence layer ──────────────────────────────────────────
+   Shared control + signature primitives, centralized so every view reads as
+   one app. Views must NOT redefine these locally — extend with modifiers. */
+
+/* Accent-edge signature: a 3px leading-edge bar marking a feature/active panel
+   (hero, GPU card, KPI strip…). The host must be position:relative with
+   overflow:hidden + a border-radius so the bar clips to the corner. Override
+   the hue per-instance with --edge-color (defaults to the celeste accent). */
+.edge-accent { position: relative; }
+.edge-accent::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 3px;
+  background: linear-gradient(
+    to bottom,
+    var(--edge-color, var(--accent)),
+    color-mix(in oklab, var(--edge-color, var(--accent)) 30%, transparent)
+  );
+  pointer-events: none;
+  z-index: 1;
+}
+.edge-accent.is-success { --edge-color: var(--success); }
+.edge-accent.is-warning { --edge-color: var(--warning); }
+.edge-accent.is-danger  { --edge-color: var(--danger); }
+.edge-accent.is-info    { --edge-color: var(--info); }
+
+.pills { display: flex; flex-wrap: wrap; gap: 4px; }
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 32px;
+  padding: 0 13px;
+  border-radius: var(--radius-full);
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  color: var(--text-secondary);
+  font-size: var(--fs-sm);
+  font-weight: 500;
+  white-space: nowrap;
+  transition: background var(--dur-fast) var(--ease), border-color var(--dur-fast) var(--ease), color var(--dur-fast) var(--ease);
+}
+.pill:hover { background: var(--bg-elevated); border-color: var(--border-hover); color: var(--text-primary); }
+.pill.active { background: var(--accent-dim); border-color: var(--accent); color: var(--accent); }
+.pill:focus-visible { outline: none; box-shadow: var(--shadow-ring); }
+.pill-count {
+  font-size: var(--fs-2xs);
+  font-weight: 600;
+  background: var(--bg-elevated);
+  color: var(--text-muted);
+  padding: 1px 6px;
+  border-radius: var(--radius-full);
+  font-variant-numeric: tabular-nums;
+}
+.pill.active .pill-count { background: var(--accent-glow); color: var(--accent); }
+
+.seg {
+  display: inline-flex;
+  height: 32px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: 2px;
+  gap: 2px;
+}
+.seg-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 0 11px;
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  font-size: var(--fs-xs);
+  font-weight: 600;
+  transition: background var(--dur-fast) var(--ease), color var(--dur-fast) var(--ease);
+}
+.seg-btn:hover { color: var(--text-primary); background: var(--bg-elevated); }
+.seg-btn.active { background: var(--accent-dim); color: var(--accent); }
+.seg-btn:focus-visible { outline: none; box-shadow: var(--shadow-ring); }
 
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after {

--- a/frontend/src/views/About.svelte
+++ b/frontend/src/views/About.svelte
@@ -36,6 +36,7 @@
   import FileText from "@lucide/svelte/icons/file-text";
   import ExternalLink from "@lucide/svelte/icons/external-link";
   import Database from "@lucide/svelte/icons/database";
+  import BrandMark from "../components/BrandMark.svelte";
 
   let version = $state("dev");
   let appPaths = $state<AppPathsDto | null>(null);
@@ -259,7 +260,7 @@
   </div>
 </header>
 
-<section class="brand-row" in:fly={{ y: 6, duration: 240 }}>
+<section class="brand-row edge-accent" in:fly={{ y: 6, duration: 240 }}>
   <div class="brand-mark" aria-hidden="true">
     <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round">
       <path d="M3 12a9 9 0 1 0 3-6.7"/>
@@ -447,7 +448,13 @@
         <div class="system-row">
           <span class="system-label"><HardDrive size={13} /> {systemInfo.gpus.length > 1 ? `GPU ${idx + 1}` : "GPU"}</span>
           <span class="system-value">
-            <span class="chip chip-neutral">{vendorLabel(gpu.vendor)}</span>
+            <span class="chip chip-neutral">
+              {#if gpu.vendor === "other"}
+                {vendorLabel(gpu.vendor)}
+              {:else}
+                <BrandMark key={gpu.vendor} tone="mono" size={12} />
+              {/if}
+            </span>
             {gpu.model}
             {#if gpu.driver_version && gpu.driver_version !== "Unknown"}
               <span class="system-muted mono">driver {gpu.driver_version}</span>
@@ -483,7 +490,7 @@
         in:fly={{ y: 4, duration: 220, delay: 240 + i * 30 }}
       >
         <span class="source-stripe"></span>
-        <span class="source-vendor">{s.vendor}</span>
+        <span class="source-vendor"><BrandMark key={s.vendor} tone="mono" size={12} /></span>
         <span class="source-label">{s.label}</span>
         <ExternalLink size={11} />
       </button>
@@ -685,9 +692,9 @@
     background: var(--bg-input);
     color: var(--text-secondary);
   }
-  .update-banner.is-success { color: var(--success); border-color: rgba(52,211,153,0.4); background: var(--success-dim); }
-  .update-banner.is-warning { color: var(--warning); border-color: rgba(245,185,80,0.4); background: var(--warning-dim); }
-  .update-banner.is-danger { color: var(--danger); border-color: rgba(239,68,68,0.4); background: var(--danger-dim); }
+  .update-banner.is-success { color: var(--success); border-color: color-mix(in oklab, var(--success) 40%, transparent); background: var(--success-dim); }
+  .update-banner.is-warning { color: var(--warning); border-color: color-mix(in oklab, var(--warning) 40%, transparent); background: var(--warning-dim); }
+  .update-banner.is-danger { color: var(--danger); border-color: color-mix(in oklab, var(--danger) 40%, transparent); background: var(--danger-dim); }
   .update-banner.is-info { color: var(--accent); border-color: var(--accent-ring); background: var(--accent-soft); }
 
   .info-grid {
@@ -846,9 +853,10 @@
   .sources-section { margin-bottom: 16px; }
   .section-head-row { margin-bottom: 12px; }
   .section-heading-h {
-    font-size: var(--fs-md);
-    font-weight: 600;
-    letter-spacing: var(--letter-tight);
+    font-size: var(--fs-lg);
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: var(--letter-wide);
     color: var(--text-primary);
     margin-bottom: 3px;
   }

--- a/frontend/src/views/Backups.svelte
+++ b/frontend/src/views/Backups.svelte
@@ -2,7 +2,8 @@
   import { onMount } from "svelte";
   import { fly } from "svelte/transition";
   import { backups, loadBackups, games, showToast, settings, persistSettings } from "../lib/stores";
-  import { restoreBackup, deleteBackup, openPath, type BackupEntry, type DetectedGame, type BackupsGroupBy } from "../lib/api";
+  import { pushNotification, makeNotificationEntry } from "../lib/notifications";
+  import { restoreBackup, restoreSystemDriver, deleteBackup, openPath, type BackupEntry, type DetectedGame, type BackupsGroupBy } from "../lib/api";
   import { BACKUPS_GROUP_BYS, BACKUPS_GROUP_BY_DEFAULT } from "../lib/ux";
   import { confirm } from "@tauri-apps/plugin-dialog";
   import {
@@ -93,9 +94,81 @@
     return d.toLocaleDateString(undefined, { weekday: "short", year: "numeric", month: "short", day: "numeric" });
   }
 
+  let dllBackups = $derived($backups.filter((b) => b.backup_type !== "driver_package"));
+  let driverBackups = $derived($backups.filter((b) => b.backup_type === "driver_package"));
+
+  let driverQuery = $state("");
+  let driverClassFilter = $state<string>("all");
+  let restoringDriverId = $state<string | null>(null);
+
+  type DriverClassGroup = { deviceClass: string; entries: BackupEntry[] };
+
+  let driverClasses = $derived.by<string[]>(() => {
+    const set = new Set<string>();
+    for (const b of driverBackups) set.add(b.device_class ?? "Driver");
+    return Array.from(set).sort((a, b) => a.localeCompare(b));
+  });
+
+  let driverGroups = $derived.by<DriverClassGroup[]>(() => {
+    const q = driverQuery.trim().toLowerCase();
+    const m = new Map<string, BackupEntry[]>();
+    for (const b of driverBackups) {
+      const cls = b.device_class ?? "Driver";
+      if (driverClassFilter !== "all" && cls !== driverClassFilter) continue;
+      if (
+        q &&
+        !(
+          cls.toLowerCase().includes(q) ||
+          (b.driver_provider ?? "").toLowerCase().includes(q) ||
+          b.dll_filename.toLowerCase().includes(q) ||
+          (b.hardware_id ?? "").toLowerCase().includes(q) ||
+          (b.previous_version ?? "").toLowerCase().includes(q)
+        )
+      )
+        continue;
+      (m.get(cls) ?? m.set(cls, []).get(cls)!).push(b);
+    }
+    return Array.from(m.entries())
+      .map(([deviceClass, entries]) => ({
+        deviceClass,
+        entries: entries.sort((a, b) => b.created_at.localeCompare(a.created_at)),
+      }))
+      .sort((a, b) => a.deviceClass.localeCompare(b.deviceClass));
+  });
+
+  async function doDriverRestore(b: BackupEntry): Promise<void> {
+    if (restoringDriverId) return;
+    const ok = await confirm(
+      `Roll ${b.driver_provider ?? "this"} ${(b.device_class ?? "driver").toLowerCase()} driver back to v${b.previous_version ?? "?"}?\n\nDLSSync re-installs the snapshot it took before the update. Windows will ask for Administrator approval, and a reboot may be needed.`,
+      { title: "Roll back driver", kind: "warning", okLabel: "Roll back", cancelLabel: "Cancel" },
+    );
+    if (!ok) return;
+    restoringDriverId = b.id;
+    try {
+      const outcome = await restoreSystemDriver(b.id);
+      if (outcome.success) {
+        showToast("success", `Rolled back ${b.dll_filename}${outcome.reboot_required ? " — reboot to finish" : ""}`);
+        void pushNotification(
+          makeNotificationEntry(
+            "backup_restored",
+            `Rolled back ${b.device_class ?? "driver"} driver`,
+            `${b.driver_provider ?? ""} ${b.dll_filename}`.trim(),
+          ),
+        ).catch((err) => console.warn("[dlssync] push driver-rollback notification failed:", err));
+        await loadBackups();
+      } else {
+        showToast("danger", outcome.message);
+      }
+    } catch (err: unknown) {
+      showToast("danger", `Rollback failed: ${String(err)}`);
+    } finally {
+      restoringDriverId = null;
+    }
+  }
+
   let grouped = $derived.by<GroupedBackup[]>(() => {
     const m = new Map<string, GroupedBackup>();
-    for (const b of $backups) {
+    for (const b of dllBackups) {
       const key = groupBy === "date" ? b.created_at.slice(0, 10) : b.game_id;
       let g = m.get(key);
       if (!g) {
@@ -146,18 +219,18 @@
       .filter((g) => g.entries.length > 0);
   });
 
-  let totalRestorable = $derived($backups.filter((b) => !b.restored_at && !isMissing(b)).length);
-  let totalRestored = $derived($backups.filter((b) => b.restored_at).length);
-  let totalMissing = $derived($backups.filter((b) => isMissing(b)).length);
-  let uniqueGames = $derived(new Set($backups.map((b) => b.game_id)).size);
-  let totalBytes = $derived($backups.reduce((n, b) => n + (b.size_bytes ?? 0), 0));
+  let totalRestorable = $derived(dllBackups.filter((b) => !b.restored_at && !isMissing(b)).length);
+  let totalRestored = $derived(dllBackups.filter((b) => b.restored_at).length);
+  let totalMissing = $derived(dllBackups.filter((b) => isMissing(b)).length);
+  let uniqueGames = $derived(new Set(dllBackups.map((b) => b.game_id)).size);
+  let totalBytes = $derived(dllBackups.reduce((n, b) => n + (b.size_bytes ?? 0), 0));
   let oldestDate = $derived.by<string | null>(() => {
-    if ($backups.length === 0) return null;
-    return $backups.reduce((acc, b) => (b.created_at < acc ? b.created_at : acc), $backups[0].created_at);
+    if (dllBackups.length === 0) return null;
+    return dllBackups.reduce((acc, b) => (b.created_at < acc ? b.created_at : acc), dllBackups[0].created_at);
   });
   let newestDate = $derived.by<string | null>(() => {
-    if ($backups.length === 0) return null;
-    return $backups.reduce((acc, b) => (b.created_at > acc ? b.created_at : acc), $backups[0].created_at);
+    if (dllBackups.length === 0) return null;
+    return dllBackups.reduce((acc, b) => (b.created_at > acc ? b.created_at : acc), dllBackups[0].created_at);
   });
 
   async function doRestore(b: BackupEntry): Promise<void> {
@@ -166,6 +239,14 @@
     try {
       await restoreBackup(b.id);
       showToast("success", `Restored ${b.dll_filename}`);
+      void pushNotification(
+        makeNotificationEntry(
+          "backup_restored",
+          `Restored ${b.dll_filename}`,
+          gameById.get(b.game_id)?.name ?? b.game_id,
+          { game_id: b.game_id },
+        ),
+      ).catch((err) => console.warn("[dlssync] push backup-restored notification failed:", err));
       await loadBackups();
     } catch (err: unknown) {
       showToast("danger", `Restore failed: ${String(err)}`);
@@ -174,7 +255,7 @@
     }
   }
 
-  let selectedEntries = $derived.by<BackupEntry[]>(() => $backups.filter((b) => selectedIds.has(b.id)));
+  let selectedEntries = $derived.by<BackupEntry[]>(() => dllBackups.filter((b) => selectedIds.has(b.id)));
   let selectedActiveCount = $derived(selectedEntries.filter((e) => !e.restored_at && !isMissing(e)).length);
   let selectedTotalBytes = $derived(selectedEntries.reduce((n, e) => n + (e.size_bytes ?? 0), 0));
 
@@ -199,6 +280,15 @@
     bulkRunning = null;
     selectedIds = new Set();
     await loadBackups();
+    if (ok > 0) {
+      void pushNotification(
+        makeNotificationEntry(
+          "backup_restored",
+          `Restored ${ok} snapshot${ok === 1 ? "" : "s"}`,
+          fail > 0 ? `${fail} failed to restore` : "All selected snapshots restored",
+        ),
+      ).catch((err) => console.warn("[dlssync] push backup-restored notification failed:", err));
+    }
     if (fail === 0) showToast("success", `Restored ${ok} snapshot${ok === 1 ? "" : "s"}`);
     else if (ok === 0) showToast("danger", `Restore failed for all ${fail} snapshots`);
     else showToast("warning", `Restored ${ok}, ${fail} failed`);
@@ -334,17 +424,18 @@
   <div class="empty">
     <svg width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="21 8 21 21 3 21 3 8"/><rect x="1" y="3" width="22" height="5" rx="0.5"/><line x1="10" y1="12" x2="14" y2="12"/></svg>
     <h3 class="empty-title">No backups yet</h3>
-    <p class="section-sub">Backups are created automatically when you apply a DLL update. Open any game from the Library, pick DLLs, and click Apply selected.</p>
+    <p class="section-sub">Backups are created automatically when you apply a DLL update or a System &amp; Components driver. Open any game from the Library, pick DLLs, and click Apply selected.</p>
   </div>
 {:else}
-  <section class="backup-hero aura-card" in:fly={{ y: 6, duration: 220 }}>
+  {#if dllBackups.length > 0}
+  <section class="backup-hero aura-card edge-accent" in:fly={{ y: 6, duration: 220 }}>
     <div class="hero-stats">
       <div class="bk-stat">
         <span class="bk-stat-badge aura-badge" data-tint="blue" aria-hidden="true">
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="21 8 21 21 3 21 3 8"/><rect x="1" y="3" width="22" height="5" rx="0.5"/><line x1="10" y1="12" x2="14" y2="12"/></svg>
         </span>
         <div class="bk-stat-text">
-          <span class="bk-stat-num">{$backups.length.toLocaleString()}</span>
+          <span class="bk-stat-num">{dllBackups.length.toLocaleString()}</span>
           <span class="bk-stat-lbl">Total backups</span>
         </div>
       </div>
@@ -452,7 +543,7 @@
       <button class="seg-btn" class:active={groupBy === "date"} onclick={() => void setGroupBy("date")} aria-pressed={groupBy === "date"}>Date</button>
     </div>
     <span class="toolbar-summary">
-      {filtered.reduce((a, g) => a + g.entries.length, 0)} of {$backups.length} backup{$backups.length === 1 ? "" : "s"}{filtered.length !== grouped.length ? ` · ${filtered.length} ${groupBy === "date" ? "day" : "game"}${filtered.length === 1 ? "" : "s"}` : ""}
+      {filtered.reduce((a, g) => a + g.entries.length, 0)} of {dllBackups.length} backup{dllBackups.length === 1 ? "" : "s"}{filtered.length !== grouped.length ? ` · ${filtered.length} ${groupBy === "date" ? "day" : "game"}${filtered.length === 1 ? "" : "s"}` : ""}
     </span>
   </div>
 
@@ -637,6 +728,114 @@
       {/each}
     </div>
   {/if}
+  {/if}
+
+  {#if driverBackups.length > 0}
+    <section class="driver-section" in:fly={{ y: 6, duration: 220 }}>
+      <div class="section-head driver-head">
+        <h2 class="section-title">System Drivers</h2>
+        <span class="section-count">{driverBackups.length}</span>
+      </div>
+      <p class="section-sub driver-sub">
+        Pre-update snapshots of your audio, network, Bluetooth, chipset, and other
+        component drivers. Roll any one back if an update misbehaves — Windows asks
+        for Administrator approval, and a reboot may be needed.
+      </p>
+
+      <div class="driver-toolbar">
+        <div class="backup-search">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="search-icon"><circle cx="11" cy="11" r="7"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+          <input type="search" placeholder="Search by component, vendor, INF, or hardware id…" bind:value={driverQuery} />
+          {#if driverQuery}
+            <button class="search-clear" onclick={() => (driverQuery = "")} aria-label="Clear search">
+              <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+            </button>
+          {/if}
+        </div>
+        {#if driverClasses.length > 1}
+          <div class="pills" role="group" aria-label="Filter drivers by component">
+            <button class="pill" class:active={driverClassFilter === "all"} onclick={() => (driverClassFilter = "all")}>All</button>
+            {#each driverClasses as c (c)}
+              <button class="pill" class:active={driverClassFilter === c} onclick={() => (driverClassFilter = c)}>{c}</button>
+            {/each}
+          </div>
+        {/if}
+      </div>
+
+      {#if driverGroups.length === 0}
+        <div class="empty small">
+          <p class="section-sub">No driver backups match your filter.</p>
+        </div>
+      {:else}
+        <div class="groups">
+          {#each driverGroups as dg (dg.deviceClass)}
+            <section class="group">
+              <div class="driver-group-head">
+                <span class="driver-class">{dg.deviceClass}</span>
+                <span class="driver-class-count">{dg.entries.length}</span>
+              </div>
+              <ul class="entries">
+                {#each dg.entries as b (b.id)}
+                  <li class="entry driver-entry" class:restored={b.restored_at}>
+                    <div class="entry-glyph" aria-hidden="true">
+                      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="4" width="16" height="16" rx="2"/><rect x="9" y="9" width="6" height="6"/><line x1="9" y1="1" x2="9" y2="4"/><line x1="15" y1="1" x2="15" y2="4"/><line x1="9" y1="20" x2="9" y2="23"/><line x1="15" y1="20" x2="15" y2="23"/><line x1="20" y1="9" x2="23" y2="9"/><line x1="20" y1="14" x2="23" y2="14"/><line x1="1" y1="9" x2="4" y2="9"/><line x1="1" y1="14" x2="4" y2="14"/></svg>
+                    </div>
+                    <div class="entry-main">
+                      <div class="entry-head">
+                        <span class="entry-title">{b.driver_provider ?? "Driver"}</span>
+                        {#if b.restored_at}
+                          <span class="chip chip-success small-chip" title={`Rolled back ${fmtDate(b.restored_at)}`}>Rolled back</span>
+                        {:else}
+                          <span class="chip chip-update small-chip" title="The driver in place before the update is snapshotted and ready to roll back.">Snapshot</span>
+                        {/if}
+                      </div>
+                      <div class="entry-meta mono">
+                        <span class="file">{b.dll_filename}</span>
+                        <span class="sep">·</span>
+                        <span>v{b.previous_version ?? "?"}</span>
+                        <span class="sep">·</span>
+                        <span class="truncate hwid" title={b.hardware_id ?? ""}>{b.hardware_id ?? "—"}</span>
+                        <span class="sep">·</span>
+                        <span title={b.created_at}>{fmtDate(b.created_at)}</span>
+                      </div>
+                    </div>
+                    <div class="entry-actions">
+                      <button
+                        class="btn btn-sm btn-ghost"
+                        onclick={() => revealBackup(b)}
+                        title="Open the snapshot folder in Explorer"
+                        disabled={openingPath === b.id}
+                      >
+                        {#if openingPath === b.id}
+                          <span class="spin"></span>
+                        {:else}
+                          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
+                        {/if}
+                      </button>
+                      <button
+                        class="btn btn-sm btn-accent"
+                        disabled={restoringDriverId === b.id}
+                        onclick={() => doDriverRestore(b)}
+                        title="Re-install the driver that was in place before the update (Administrator approval required)"
+                      >
+                        {#if restoringDriverId === b.id}
+                          <span class="spin"></span>
+                          Rolling back
+                        {:else}
+                          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12a9 9 0 1 0 9-9c-2.52 0-4.85.93-6.63 2.46"/><polyline points="3 4 3 9 8 9"/></svg>
+                          Roll back
+                        {/if}
+                      </button>
+                    </div>
+                  </li>
+                {/each}
+              </ul>
+            </section>
+          {/each}
+        </div>
+      {/if}
+    </section>
+  {/if}
 {/if}
 
 <style>
@@ -664,7 +863,7 @@
   .empty-title { font-size: var(--fs-lg); font-weight: 600; color: var(--text-primary); }
   .empty .section-sub { max-width: 460px; }
 
-  .backup-hero { margin-bottom: 16px; }
+  .backup-hero { margin-bottom: 16px; overflow: hidden; }
   .hero-stats {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
@@ -935,6 +1134,13 @@
     border-radius: var(--radius-lg);
     box-shadow: 0 4px 14px rgba(0,0,0,0.25);
     backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+  }
+  @supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
+    .bulk-bar { background: var(--bg-elevated); }
+  }
+  @media (prefers-reduced-transparency: reduce) {
+    .bulk-bar { background: var(--bg-elevated); }
   }
   .bulk-count {
     font-size: var(--fs-sm);
@@ -973,4 +1179,43 @@
 
   .spin { width: 11px; height: 11px; border: 2px solid currentColor; border-top-color: transparent; border-radius: 50%; animation: spin 0.7s linear infinite; display: inline-block; }
   @keyframes spin { to { transform: rotate(360deg); } }
+
+  .driver-section { margin-top: 28px; }
+  .driver-head { margin-bottom: 4px; }
+  .driver-sub { max-width: 640px; margin-bottom: 14px; }
+  .driver-toolbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 14px;
+    flex-wrap: wrap;
+  }
+  .driver-group-head {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 16px;
+    border-bottom: 1px solid var(--border);
+    background: var(--bg-input);
+  }
+  .driver-class {
+    font-size: var(--fs-xs);
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: var(--letter-wider);
+    color: var(--text-secondary);
+  }
+  .driver-class-count {
+    font-size: var(--fs-2xs);
+    font-weight: 600;
+    color: var(--text-muted);
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-full);
+    padding: 0 7px;
+    font-variant-numeric: tabular-nums;
+  }
+  .entry-meta .hwid { max-width: 320px; display: inline-block; vertical-align: bottom; }
+  .entry.driver-entry { grid-template-columns: 32px 1fr auto; }
 </style>

--- a/frontend/src/views/Catalog.svelte
+++ b/frontend/src/views/Catalog.svelte
@@ -24,6 +24,7 @@
   } from "../lib/labels";
   import FeatureIcon from "./../components/FeatureIcon.svelte";
   import CatalogVersionsFlyout from "./../components/CatalogVersionsFlyout.svelte";
+  import BrandMark from "./../components/BrandMark.svelte";
 
   let refreshing = $state(false);
   let flyoutTarget = $state<{
@@ -221,7 +222,7 @@
   </button>
 </header>
 
-<section class="info-bar" in:fade={{ duration: 200 }}>
+<section class="info-bar edge-accent" in:fade={{ duration: 200 }}>
   <div class="info-item">
     <span class="info-item-label">Versions</span>
     <span class="info-item-value">{totals.releases.toLocaleString()}</span>
@@ -252,7 +253,13 @@
       {#each $driverReports as report (report.device.model)}
         {@const tone = driverStatusTone(report.status)}
         <li class="driver-cat-row">
-          <span class="driver-cat-vendor" data-vendor={report.device.vendor}>{report.device.vendor.toUpperCase()}</span>
+          <span class="driver-cat-vendor" data-vendor={report.device.vendor}>
+            {#if report.device.vendor === "other"}
+              GPU
+            {:else}
+              <BrandMark key={report.device.vendor} tone="mono" size={11} />
+            {/if}
+          </span>
           <span class="driver-cat-model">{report.device.model}</span>
           <span class="driver-cat-ver mono">
             {report.installed.display}
@@ -300,7 +307,7 @@
         <div class="vendor-stripe" style:background={v.accent}></div>
         <header class="vendor-head">
           <div class="vendor-dot" style:background={v.accent} style:box-shadow="0 0 14px {v.accent}80"></div>
-          <h3 class="vendor-name">{v.label}</h3>
+          <h3 class="vendor-name"><BrandMark key={v.vendor} label={v.label} size={16} /></h3>
           <span class="chip chip-neutral vendor-pill">{v.totalReleases} versions</span>
           {#if portal}
             <button class="vendor-portal" onclick={() => openExternal(portal.url)} title={portal.label} aria-label={`Open ${portal.label}`}>
@@ -411,17 +418,17 @@
     border-radius: var(--radius-md);
   }
   .driver-cat-vendor { font-size: 10px; font-weight: 700; letter-spacing: 0.04em; color: var(--text-secondary); }
-  .driver-cat-vendor[data-vendor="nvidia"] { color: #76b900; }
-  .driver-cat-vendor[data-vendor="amd"] { color: #ed1c24; }
-  .driver-cat-vendor[data-vendor="intel"] { color: #2f9be6; }
+  .driver-cat-vendor[data-vendor="nvidia"] { color: var(--vendor-nvidia); }
+  .driver-cat-vendor[data-vendor="amd"] { color: var(--vendor-amd); }
+  .driver-cat-vendor[data-vendor="intel"] { color: var(--vendor-intel); }
   .driver-cat-model { font-size: var(--fs-sm); font-weight: 600; color: var(--text-primary); min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   .driver-cat-ver { font-size: var(--fs-xs); color: var(--text-muted); font-variant-numeric: tabular-nums; white-space: nowrap; }
   .driver-cat-arrow { margin: 0 5px; color: var(--text-muted); }
   .driver-cat-next { color: var(--accent); font-weight: 600; }
   .driver-cat-badge { font-size: 10.5px; font-weight: 600; padding: 3px 9px; border-radius: var(--radius-full); background: var(--bg-card); color: var(--text-muted); white-space: nowrap; }
-  .driver-cat-badge[data-tone="success"] { background: var(--success-dim, rgba(70,180,110,0.14)); color: var(--success, #46b46e); }
-  .driver-cat-badge[data-tone="accent"] { background: var(--update-dim, var(--accent-dim)); color: var(--update, var(--accent)); }
-  .driver-cat-badge[data-tone="warning"] { background: var(--warning-dim, rgba(220,160,50,0.14)); color: var(--warning, #d6a032); }
+  .driver-cat-badge[data-tone="success"] { background: var(--success-dim); color: var(--success); }
+  .driver-cat-badge[data-tone="accent"] { background: var(--update-dim); color: var(--update); }
+  .driver-cat-badge[data-tone="warning"] { background: var(--warning-dim); color: var(--warning); }
 
 
   .catalog-toolbar {
@@ -466,10 +473,11 @@
     padding-top: 4px;
   }
   .section-title {
-    font-size: 15px;
+    font-size: var(--fs-lg);
     font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: var(--letter-wide);
     color: var(--text-primary);
-    letter-spacing: var(--letter-tight);
   }
   .section-sub {
     font-size: var(--fs-xs);

--- a/frontend/src/views/Drivers.svelte
+++ b/frontend/src/views/Drivers.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import { onMount } from "svelte";
-  import { openUrl, type DriverStatusReport, type GpuVendor } from "../lib/api";
+  import { slide } from "svelte/transition";
+  import { openUrl, systemDriverVersions, type DriverStatusReport, type GpuVendor } from "../lib/api";
+  import { ADMIN_ELEVATION_NOTE } from "../lib/ux";
   import {
     driverStatusLabel,
     driverStatusTone,
@@ -18,25 +20,30 @@
     startDriverInstall,
     driverInstall,
     showToast,
+    systemDriverGroups,
+    systemScanInProgress,
+    systemScanError,
+    systemScanRan,
+    loadSystemDrivers,
+    startSystemDriverInstall,
+    systemDriverInstall,
+    DRIVER_INSTALL_STAGE_LABEL,
   } from "../lib/stores";
+  import type { SystemDriverUpdate, SystemDeviceClass, DriverStoreVersion } from "../lib/api";
+  import { formatBytes } from "../lib/formatHuman";
   import DlssOverridePanel from "../components/DlssOverridePanel.svelte";
   import DriverHistoryFlyout from "../components/DriverHistoryFlyout.svelte";
+  import BrandMark from "../components/BrandMark.svelte";
+  import { BRANDS } from "../lib/brands";
 
   let expandedModel = $state<string | null>(null);
   let historyTarget = $state<{ vendor: GpuVendor; model: string; accent: string } | null>(null);
 
   const VENDOR_ACCENT: Record<GpuVendor, string> = {
-    nvidia: "#76b900",
-    amd: "#ed1c24",
-    intel: "#2f9be6",
-    other: "#94a3b8",
-  };
-
-  const VENDOR_LABEL: Record<GpuVendor, string> = {
-    nvidia: "NVIDIA",
-    amd: "AMD",
-    intel: "Intel",
-    other: "GPU",
+    nvidia: "var(--vendor-nvidia)",
+    amd: "var(--vendor-amd)",
+    intel: "var(--vendor-intel)",
+    other: "var(--neutral)",
   };
 
   let reports = $derived(sortDriverReports($driverReports));
@@ -52,7 +59,7 @@
   );
 
   function vendorLabel(vendor: GpuVendor): string {
-    return VENDOR_LABEL[vendor] ?? "GPU";
+    return vendor === "other" ? "GPU" : BRANDS[vendor].label;
   }
 
   function sizeLabel(bytes: number): string {
@@ -79,23 +86,101 @@
     expandedModel = expandedModel === model ? null : model;
   }
 
+  let systemUpdateCount = $derived(
+    $systemDriverGroups.reduce((n, g) => n + g.updates.length, 0),
+  );
+  let systemBusy = $derived(
+    $systemDriverInstall.updateId !== null && $systemDriverInstall.stage !== "failed",
+  );
+
+  function isInstalling(update: SystemDriverUpdate): boolean {
+    return $systemDriverInstall.updateId === update.update_id;
+  }
+
+  // DriverStore version history (current + superseded), lazily loaded per card.
+  type VersionState = DriverStoreVersion[] | "loading" | "error";
+  let versionsByUpdate = $state<Record<string, VersionState>>({});
+
+  async function toggleVersions(update: SystemDriverUpdate): Promise<void> {
+    const id = update.update_id;
+    if (versionsByUpdate[id]) {
+      const next = { ...versionsByUpdate };
+      delete next[id];
+      versionsByUpdate = next;
+      return;
+    }
+    if (!update.target_inf) return;
+    versionsByUpdate = { ...versionsByUpdate, [id]: "loading" };
+    try {
+      const list = await systemDriverVersions(update.target_inf);
+      versionsByUpdate = { ...versionsByUpdate, [id]: list };
+    } catch {
+      versionsByUpdate = { ...versionsByUpdate, [id]: "error" };
+    }
+  }
+
+  // Per-class icon (24x24 stroke paths) for the System & Components section headers.
+  const CLASS_ICON: Record<SystemDeviceClass, string> = {
+    audio: "M11 5 6 9H2v6h4l5 4zM15.54 8.46a5 5 0 0 1 0 7.07M19.07 4.93a10 10 0 0 1 0 14.14",
+    display: "M2 4h20v12H2zM8 20h8M12 16v4",
+    monitor: "M2 3h20v14H2zM8 21h8M12 17v4",
+    network: "M5 12.55a11 11 0 0 1 14 0M1.42 9a16 16 0 0 1 21.16 0M8.53 16.11a6 6 0 0 1 6.95 0M12 20h.01",
+    bluetooth: "m7 7 10 10-5 5V2l5 5L7 17",
+    input: "M6 8h.01M10 8h.01M14 8h.01M18 8h.01M8 12h.01M12 12h.01M16 12h.01M7 16h10M2 5h20v14H2z",
+    storage: "M22 12H2M5.45 5.11 2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11zM6 16h.01M10 16h.01",
+    printer: "M6 9V2h12v7M6 18H4a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-2M6 14h12v8H6z",
+    camera: "M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2zM12 17a4 4 0 1 0 0-8 4 4 0 0 0 0 8z",
+    sensor: "M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20zM12 6a6 6 0 1 0 0 12 6 6 0 0 0 0-12zM12 10a2 2 0 1 0 0 4 2 2 0 0 0 0-4z",
+    battery: "M3 7h16v10H3zM19 10h2v4h-2M7 10v4M11 10v4",
+    smart_card: "M2 5h20v14H2zM2 9h20M6 14h6",
+    firmware: "M9 2v3M15 2v3M9 19v3M15 19v3M2 9h3M2 15h3M19 9h3M19 15h3M5 5h14v14H5zM9 9h6v6H9z",
+    chipset: "M6 6h12v12H6zM9 2v2M15 2v2M9 20v2M15 20v2M2 9h2M2 15h2M20 9h2M20 15h2M10 10h4v4h-4z",
+    system: "M4 4h16v16H4zM9 9h6v6H9zM9 1v3M15 1v3M9 20v3M15 20v3M20 9h3M20 14h3M1 9h3M1 14h3",
+    usb: "M12 2v16M12 18a3 3 0 1 0 0 6 3 3 0 0 0 0-6zM8 8l4-4 4 4M7 12l-3 3 3 3M5 15h7",
+    other: "M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20zM12 16v-4M12 8h.01",
+  };
+
+  // Strip the redundant " Driver Update (x.x.x)" / "(x.x.x.x)" tail WUA appends.
+  function cleanTitle(title: string): string {
+    return title
+      .replace(/\s*Driver Update\s*\([^)]*\)\s*$/i, "")
+      .replace(/\s*\(\d+(\.\d+){1,3}\)\s*$/, "")
+      .replace(/\s*-\s*\d{1,2}\/\d{1,2}\/\d{4}.*$/i, "")
+      .trim();
+  }
+
+  function deviceName(update: SystemDriverUpdate): string {
+    return update.target_device ?? cleanTitle(update.title);
+  }
+
+  // WUA's SupportUrl is often a generic 404 hub; the backend already filters
+  // that out, so when there's no real vendor URL we link to the exact package
+  // in the Microsoft Update Catalog (always resolves).
+  const UPDATE_CATALOG_SEARCH = "https://www.catalog.update.microsoft.com/Search.aspx?q=";
+  function vendorLink(update: SystemDriverUpdate): string {
+    return update.support_url ?? `${UPDATE_CATALOG_SEARCH}${encodeURIComponent(update.title)}`;
+  }
+
   onMount(() => {
     void loadDriverUpdates();
+    void loadSystemDrivers();
   });
 </script>
 
 <section class="drivers-view">
-  <header class="view-head">
+  <header class="view-header">
     <div>
-      <h1>Drivers</h1>
-      <p class="sub">
+      <h1 class="view-title">Drivers</h1>
+      <p class="view-subtitle">
         Latest GPU driver for each detected adapter, checked live against the vendor — plus DLSS preset
         and frame-generation controls.
       </p>
     </div>
-    <button class="check-btn" onclick={() => loadDriverUpdates()} disabled={$driverCheckInProgress}>
-      {$driverCheckInProgress ? "Checking…" : "Check for updates"}
-    </button>
+    <div class="header-actions">
+      <button class="check-btn" onclick={() => loadDriverUpdates()} disabled={$driverCheckInProgress}>
+        {$driverCheckInProgress ? "Checking…" : "Check for updates"}
+      </button>
+    </div>
   </header>
 
   {#if $driverCheckError}
@@ -118,7 +203,11 @@
         <div class="card-row">
           <div class="card-main">
             <span class="vendor-pill" data-vendor={report.device.vendor}>
-              {vendorLabel(report.device.vendor)}
+              {#if report.device.vendor === "other"}
+                {vendorLabel(report.device.vendor)}
+              {:else}
+                <BrandMark key={report.device.vendor} tone="mono" size={12} />
+              {/if}
             </span>
             <div class="model-block">
               <span class="model">{report.device.model}</span>
@@ -215,10 +304,151 @@
     {/each}
   </ul>
 
+  <section class="feature-block system-block edge-accent">
+    <div class="section-head feature-section-head">
+      <span class="section-title">System &amp; Components</span>
+      <span class="beta-tag" title="This feature is still in beta">Beta</span>
+      {#if systemUpdateCount > 0}
+        <span class="section-count">{systemUpdateCount}</span>
+      {/if}
+      <button class="check-btn ghost" onclick={() => loadSystemDrivers()} disabled={$systemScanInProgress}>
+        {$systemScanInProgress ? "Scanning…" : "Rescan"}
+      </button>
+    </div>
+    <p class="feature-sub">
+      Driver updates for the rest of your PC: audio, network, Bluetooth, chipset, input, and storage. They
+      come from Windows Update and the Microsoft Update Catalog, stay vendor-signed, and we never offer one
+      older than the driver you already have.
+    </p>
+    <p class="beta-note">
+      Detection can miss or misread some hardware, so check each update before you apply it. If one causes
+      trouble, the auto-backup rolls it back.
+    </p>
+    <p class="admin-note">
+      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
+      <span>{ADMIN_ELEVATION_NOTE}</span>
+    </p>
+
+    {#if $systemScanError}
+      <p class="error-banner edge-accent is-danger">{$systemScanError}</p>
+    {/if}
+
+    {#if $systemScanInProgress && systemUpdateCount === 0}
+      <p class="empty">Scanning Windows Update for component drivers…</p>
+    {:else if $systemScanRan && systemUpdateCount === 0 && !$systemScanError}
+      <p class="empty">Every component is up to date — Windows Update has no newer driver.</p>
+    {/if}
+
+    <div class="sys-groups">
+      {#each $systemDriverGroups as group (group.class)}
+        <section class="sys-group">
+          <header class="sys-group-head">
+            <span class="sys-group-icon" aria-hidden="true">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d={CLASS_ICON[group.class]} /></svg>
+            </span>
+            <span class="sys-group-label">{group.label}</span>
+            <span class="sys-group-count">{group.updates.length}</span>
+          </header>
+          <ul class="sys-list">
+            {#each group.updates as update (update.update_id)}
+              {@const installing = isInstalling(update)}
+              {@const versions = versionsByUpdate[update.update_id]}
+              <li class="sys-card" class:is-installing={installing}>
+                <div class="sys-row">
+                <div class="sys-main">
+                  <span class="sys-name" title={update.title}>{deviceName(update)}</span>
+                  <span class="sys-meta">
+                    <span class="sys-provider"><BrandMark key={update.provider} size={12} /></span>
+                    <span class="sys-versions mono">
+                      {#if update.current_version}<span class="sys-cur">{update.current_version}</span><span class="sys-arrow">→</span>{/if}
+                      <span class="sys-new">{update.driver_version ?? "latest"}</span>
+                    </span>
+                    {#if update.driver_date}<span class="sys-dot">·</span><span class="sys-date mono">{update.driver_date}</span>{/if}
+                  </span>
+                </div>
+                <div class="sys-side">
+                  {#if installing}
+                    {@const failed = $systemDriverInstall.stage === "failed"}
+                    <div class="install-live" class:is-failed={failed} role="status" aria-live="polite">
+                      <span class="install-stage">{DRIVER_INSTALL_STAGE_LABEL[$systemDriverInstall.stage ?? ""] ?? "Working"}</span>
+                      <div class="install-bar" class:indeterminate={$systemDriverInstall.fraction === null && !failed}>
+                        <div
+                          class="install-fill"
+                          style:width={failed
+                            ? "100%"
+                            : $systemDriverInstall.fraction === null
+                              ? undefined
+                              : `${Math.round($systemDriverInstall.fraction * 100)}%`}
+                        ></div>
+                      </div>
+                      <span class="install-msg">{$systemDriverInstall.message}</span>
+                    </div>
+                  {:else}
+                    {#if update.target_inf}
+                      <button
+                        class="driver-icon"
+                        class:is-on={versions !== undefined}
+                        onclick={() => toggleVersions(update)}
+                        title="Show installed and previously-installed versions of this driver"
+                        aria-label="Version history"
+                        aria-expanded={versions !== undefined}
+                      >
+                        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3v5h5"/><path d="M3.05 13A9 9 0 1 0 6 5.3L3 8"/><path d="M12 7v5l4 2"/></svg>
+                      </button>
+                    {/if}
+                    <button
+                      class="driver-icon"
+                      data-href={vendorLink(update)}
+                      onclick={() => open(vendorLink(update))}
+                      title={update.support_url ? "Open the vendor's information page for this driver" : "Find this driver in the Microsoft Update Catalog"}
+                      aria-label="Driver info"
+                    >
+                      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
+                    </button>
+                    <button class="driver-update" onclick={() => startSystemDriverInstall(update, group.label)} disabled={systemBusy}>
+                      <span class="driver-update-label">Update</span>
+                      {#if update.size_bytes > 0}<span class="driver-update-size mono">{formatBytes(update.size_bytes)}</span>{/if}
+                    </button>
+                  {/if}
+                </div>
+                </div>
+                {#if versions !== undefined}
+                  <div class="sys-versions-panel" transition:slide={{ duration: 160 }}>
+                    {#if versions === "loading"}
+                      <span class="sys-versions-msg">Reading the local driver store…</span>
+                    {:else if versions === "error"}
+                      <span class="sys-versions-msg is-error">Couldn't read driver versions.</span>
+                    {:else if versions.length === 0}
+                      <span class="sys-versions-msg">No earlier versions are cached on this PC. Latest available: <strong>{update.driver_version ?? "—"}</strong>.</span>
+                    {:else}
+                      <span class="sys-versions-head">On this PC</span>
+                      <ul class="ver-list">
+                        {#each versions as v (v.publishedName)}
+                          <li class="ver-row" class:current={v.current}>
+                            <span class="ver-num mono">{v.version}</span>
+                            {#if v.current}<span class="chip chip-success small-chip">Installed</span>{/if}
+                            {#if v.date}<span class="ver-date mono">{v.date}</span>{/if}
+                            <span class="ver-name mono">{v.publishedName}</span>
+                          </li>
+                        {/each}
+                      </ul>
+                      <span class="sys-versions-head">Latest available</span>
+                      <span class="ver-latest mono">{update.driver_version ?? "—"}{update.driver_date ? ` · ${update.driver_date}` : ""}</span>
+                    {/if}
+                  </div>
+                {/if}
+              </li>
+            {/each}
+          </ul>
+        </section>
+      {/each}
+    </div>
+  </section>
+
   {#if hasNvidia}
     <section class="feature-block">
-      <div class="feature-head">
-        <h2>DLSS Overrides</h2>
+      <div class="section-head feature-section-head">
+        <span class="section-title">DLSS Overrides</span>
         <span class="vendor-pill" data-vendor="nvidia">NVIDIA</span>
       </div>
       <p class="feature-sub">
@@ -241,8 +471,8 @@
 
   {#if nonNvidia.length > 0}
     <section class="feature-block muted-block">
-      <div class="feature-head">
-        <h2>Upscaling on {nonNvidia.includes("amd") ? "AMD" : ""}{nonNvidia.includes("amd") && nonNvidia.includes("intel") ? " / " : ""}{nonNvidia.includes("intel") ? "Intel" : ""}</h2>
+      <div class="section-head feature-section-head">
+        <span class="section-title">Upscaling on {nonNvidia.includes("amd") ? "AMD" : ""}{nonNvidia.includes("amd") && nonNvidia.includes("intel") ? " / " : ""}{nonNvidia.includes("intel") ? "Intel" : ""}</span>
       </div>
       <p class="feature-sub">
         Driver-profile preset overrides are NVIDIA-only (NVAPI). On AMD and Intel, FSR and XeSS are
@@ -255,9 +485,7 @@
 
 <style>
   .drivers-view { display: flex; flex-direction: column; gap: 20px; }
-  .view-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; }
-  .view-head h1 { font-size: 22px; font-weight: 700; letter-spacing: -0.01em; color: var(--text-primary); }
-  .sub { font-size: 13px; color: var(--text-muted); margin-top: 4px; max-width: 60ch; }
+  .drivers-view :global(.view-header) { margin-bottom: 0; }
   .check-btn {
     height: 38px;
     padding: 0 16px;
@@ -272,11 +500,14 @@
   .check-btn:hover:not(:disabled) { background: var(--accent-hover); }
   .check-btn:disabled { opacity: 0.6; cursor: default; }
   .error-banner {
-    padding: 10px 14px;
+    position: relative;
+    overflow: hidden;
+    padding: 10px 14px 10px 16px;
     border-radius: var(--radius-lg);
-    background: var(--danger-dim, rgba(220, 60, 60, 0.12));
-    color: var(--danger, #e05b5b);
+    background: var(--danger-dim);
+    color: var(--danger);
     font-size: 13px;
+    font-variant-numeric: tabular-nums;
   }
   .empty { color: var(--text-muted); font-size: 14px; padding: 24px 0; }
   .driver-list { display: flex; flex-direction: column; gap: 10px; list-style: none; padding: 0; margin: 0; }
@@ -298,17 +529,17 @@
     color: var(--text-secondary);
     flex-shrink: 0;
   }
-  .vendor-pill[data-vendor="nvidia"] { color: #76b900; }
-  .vendor-pill[data-vendor="amd"] { color: #ed1c24; }
-  .vendor-pill[data-vendor="intel"] { color: #2f9be6; }
+  .vendor-pill[data-vendor="nvidia"] { color: var(--vendor-nvidia); }
+  .vendor-pill[data-vendor="amd"] { color: var(--vendor-amd); }
+  .vendor-pill[data-vendor="intel"] { color: var(--vendor-intel); }
   .model-block { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
   .model { font-size: 14px; font-weight: 600; color: var(--text-primary); }
   .versions { font-size: 12px; color: var(--text-muted); font-variant-numeric: tabular-nums; display: inline-flex; align-items: center; gap: 6px; }
   .arrow { color: var(--text-muted); }
   .next { color: var(--accent); font-weight: 600; }
   .chan-chip { font-size: 9px; font-weight: 700; padding: 1px 6px; border-radius: var(--radius-full); letter-spacing: 0.04em; }
-  .chan-chip.whql { background: var(--success-dim, rgba(70,180,110,0.14)); color: var(--success, #46b46e); }
-  .chan-chip.beta { background: var(--warning-dim, rgba(214,160,50,0.14)); color: var(--warning, #d6a032); }
+  .chan-chip.whql { background: var(--success-dim); color: var(--success); }
+  .chan-chip.beta { background: var(--warning-dim); color: var(--warning); }
   .card-side { display: flex; align-items: center; gap: 8px; flex-shrink: 0; }
   .driver-update {
     display: inline-flex;
@@ -344,9 +575,9 @@
     background: var(--bg-elevated);
     color: var(--text-muted);
   }
-  .driver-state[data-tone="success"] { background: var(--success-dim, rgba(70, 180, 110, 0.14)); color: var(--success, #46b46e); }
-  .driver-state[data-tone="accent"] { background: var(--update-dim, var(--accent-dim)); color: var(--update, var(--accent)); }
-  .driver-state[data-tone="warning"] { background: var(--warning-dim, rgba(220, 160, 50, 0.14)); color: var(--warning, #d6a032); }
+  .driver-state[data-tone="success"] { background: var(--success-dim); color: var(--success); }
+  .driver-state[data-tone="accent"] { background: var(--update-dim); color: var(--update); }
+  .driver-state[data-tone="warning"] { background: var(--warning-dim); color: var(--warning); }
   .driver-secondary { display: inline-flex; align-items: center; gap: 4px; }
   .driver-icon {
     width: 34px;
@@ -409,14 +640,51 @@
     gap: 12px;
   }
   .feature-block.muted-block { background: transparent; }
-  .feature-head { display: flex; align-items: center; gap: 10px; }
-  .feature-head h2 { font-size: 16px; font-weight: 700; color: var(--text-primary); }
+  .feature-block.system-block { overflow: hidden; }
+  .feature-section-head { margin: 0; }
   .feature-sub { font-size: 12.5px; color: var(--text-muted); line-height: 1.55; max-width: 70ch; margin: 0; }
+  .beta-tag {
+    font-size: 10px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: var(--letter-wider);
+    padding: 2px 7px;
+    border-radius: var(--radius-full);
+    color: var(--warning);
+    background: var(--warning-dim);
+    border: 1px solid color-mix(in oklab, var(--warning) 35%, transparent);
+  }
+  .beta-note {
+    font-size: 12px;
+    color: var(--warning);
+    line-height: 1.5;
+    max-width: 70ch;
+    margin: 6px 0 0;
+  }
   .install-live { display: flex; flex-direction: column; align-items: flex-end; gap: 4px; min-width: 180px; }
-  .install-stage { font-size: 11px; font-weight: 600; text-transform: capitalize; color: var(--accent); }
-  .install-bar { width: 180px; height: 6px; border-radius: var(--radius-full); background: var(--bg-elevated); overflow: hidden; }
-  .install-fill { height: 100%; background: var(--accent); transition: width 0.2s var(--ease); }
+  .install-stage { font-size: 11px; font-weight: 600; text-transform: capitalize; color: var(--accent-progress); }
+  .install-bar {
+    position: relative;
+    width: 180px;
+    height: 6px;
+    border-radius: var(--radius-full);
+    background: var(--bg-elevated);
+    overflow: hidden;
+    box-shadow: inset 0 0 0 1px var(--border);
+  }
+  .install-fill {
+    height: 100%;
+    border-radius: inherit;
+    background: linear-gradient(90deg, var(--accent-progress), color-mix(in oklab, var(--accent-progress) 60%, #ffffff));
+    box-shadow: 0 0 8px color-mix(in oklab, var(--accent-progress) 55%, transparent);
+    transition: width 0.25s var(--ease);
+  }
+  .install-bar.indeterminate .install-fill { width: 40%; animation: installSlide 1.2s var(--ease) infinite; }
+  @keyframes installSlide { 0% { transform: translateX(-130%); } 100% { transform: translateX(330%); } }
+  .install-live.is-failed .install-stage { color: var(--danger); }
+  .install-live.is-failed .install-fill { background: var(--danger); box-shadow: none; animation: none; }
   .install-msg { font-size: 10px; color: var(--text-muted); max-width: 220px; text-align: right; }
+  .install-live.is-failed .install-msg { color: var(--danger); }
 
   .driver-update.open-page { background: var(--bg-elevated); color: var(--text-primary); border: 1px solid var(--border-strong); box-shadow: none; }
   .driver-update.open-page:hover:not(:disabled) { background: var(--bg-card); border-color: var(--accent); }
@@ -434,4 +702,136 @@
   @media (prefers-reduced-motion: reduce) {
     .install-fill { transition: none; }
   }
+
+  /* System & Components */
+  .check-btn.ghost {
+    background: transparent;
+    color: var(--text-secondary);
+    border: 1px solid var(--border-strong);
+    height: 32px;
+    padding: 0 12px;
+    font-size: 12px;
+    margin-left: auto;
+  }
+  .check-btn.ghost:hover:not(:disabled) { background: var(--bg-elevated); color: var(--text-primary); }
+
+  .sys-groups { display: flex; flex-direction: column; gap: 22px; margin-top: 4px; }
+  .sys-group { display: flex; flex-direction: column; gap: 10px; }
+  .sys-group-head {
+    display: flex;
+    align-items: center;
+    gap: 9px;
+    padding-bottom: 9px;
+    border-bottom: 1px solid var(--border);
+  }
+  .sys-group-icon {
+    width: 28px;
+    height: 28px;
+    border-radius: var(--radius-md);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--accent-dim);
+    color: var(--accent);
+    flex-shrink: 0;
+  }
+  .sys-group-label {
+    font-size: 13.5px;
+    font-weight: 700;
+    letter-spacing: var(--letter-tight);
+    color: var(--text-primary);
+  }
+  .sys-group-count {
+    font-family: var(--font-mono);
+    font-size: var(--fs-2xs);
+    font-weight: 700;
+    padding: 1px 7px;
+    border-radius: var(--radius-full);
+    background: var(--bg-elevated);
+    color: var(--text-muted);
+    margin-left: 2px;
+  }
+  .sys-list { display: flex; flex-direction: column; gap: 8px; list-style: none; padding: 0; margin: 0; }
+  .sys-card {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding: 12px 16px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    background: var(--bg-elevated);
+    transition: border-color var(--dur-fast) var(--ease), background var(--dur-fast) var(--ease);
+  }
+  .sys-row { display: flex; align-items: center; justify-content: space-between; gap: 16px; }
+  .sys-card:hover { border-color: var(--border-hover); background: var(--bg-card-hover); }
+  .sys-card.is-installing { border-color: var(--accent-ring); }
+  .sys-main { display: flex; flex-direction: column; gap: 4px; min-width: 0; }
+  .sys-name {
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--text-primary);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    letter-spacing: var(--letter-tight);
+  }
+  .sys-meta { font-size: 11.5px; color: var(--text-muted); display: inline-flex; align-items: center; gap: 7px; flex-wrap: wrap; }
+  .sys-provider { color: var(--text-secondary); font-weight: 500; }
+  .sys-versions { display: inline-flex; align-items: center; gap: 6px; font-variant-numeric: tabular-nums; }
+  .sys-cur { color: var(--text-muted); }
+  .sys-arrow { color: var(--text-placeholder); }
+  .sys-new { color: var(--accent); font-weight: 600; }
+  .sys-date { color: var(--text-muted); }
+  .sys-dot { opacity: 0.45; }
+  .sys-side { flex-shrink: 0; display: inline-flex; align-items: center; gap: 8px; }
+  .driver-icon.is-on { background: var(--accent-dim); color: var(--accent); border-color: var(--accent-ring); }
+
+  .admin-note {
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+    margin: 4px 0 12px;
+    padding: 9px 12px;
+    border-radius: var(--radius-md);
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    font-size: 12px;
+    line-height: 1.45;
+    color: var(--text-muted);
+  }
+  .admin-note svg { flex-shrink: 0; margin-top: 2px; color: var(--text-secondary); }
+
+  .sys-versions-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 10px 12px;
+    border-radius: var(--radius-md);
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+  }
+  .sys-versions-msg { font-size: 12px; color: var(--text-muted); }
+  .sys-versions-msg.is-error { color: var(--danger); }
+  .sys-versions-head {
+    font-size: var(--fs-2xs);
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: var(--letter-wider);
+    color: var(--text-muted);
+  }
+  .ver-list { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 4px; }
+  .ver-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 12px;
+    color: var(--text-secondary);
+    flex-wrap: wrap;
+  }
+  .ver-row.current .ver-num { color: var(--accent); font-weight: 700; }
+  .ver-num { font-variant-numeric: tabular-nums; }
+  .ver-date { color: var(--text-muted); }
+  .ver-name { color: var(--text-placeholder); margin-left: auto; }
+  .ver-latest { font-size: 12px; color: var(--accent); font-weight: 600; font-variant-numeric: tabular-nums; }
+  .small-chip { padding: 1px 7px; font-size: var(--fs-2xs); letter-spacing: 0.04em; }
 </style>

--- a/frontend/src/views/Library.svelte
+++ b/frontend/src/views/Library.svelte
@@ -14,6 +14,7 @@
     settings,
     persistSettings,
     gameDlls,
+    gameDlssEnabler,
     gameStatuses,
     relationContext,
     activeApplies,
@@ -24,7 +25,7 @@
     requestApplyAllOutdated,
     type StatusFilter,
   } from "../lib/stores";
-  import { dllRelation, targetVersion } from "../lib/relation";
+  import { dllRelation, targetVersion, recordUpdatable } from "../lib/relation";
   import { addBlacklistEntry, removeBlacklistEntry, type DllRecord } from "../lib/api";
   import type { DetectedGame, LibraryViewMode, LibraryDensity, LibrarySort } from "../lib/api";
   import {
@@ -38,7 +39,7 @@
   import { STATUS_LABELS, launcherLabel, familyGroup, GROUP_LABELS, type FamilyGroup } from "../lib/labels";
   import GameCard from "../components/GameCard.svelte";
   import GameListRow from "../components/GameListRow.svelte";
-  import GameDetailDrawer from "../components/GameDetailDrawer.svelte";
+  import ContextMenu, { type ContextMenuAction, type ContextMenuItem } from "../components/ContextMenu.svelte";
   import { dispatchApply, type ApplyTarget } from "../lib/applyController";
   import { listen, type UnlistenFn } from "@tauri-apps/api/event";
   import { TRAY_SHOW_PROGRESS_EVENT } from "../lib/api";
@@ -51,8 +52,10 @@
       const records = $gameDlls[game.id] ?? [];
       const disabled = $settings?.game_preferences[game.id]?.disabled_families ?? [];
       const pinned = $settings?.game_preferences[game.id]?.pinned_versions ?? {};
+      const enabler = $gameDlssEnabler[game.id] ?? false;
       for (const r of records) {
         if (disabled.includes(r.family)) continue;
+        if (!recordUpdatable(r, $settings?.update_prefs ?? null, enabler)) continue;
         const pin = pinned[`${r.family}|${r.path}`] ?? null;
         if (dllRelation(r, $relationContext, pin) !== "outdated") continue;
         const target = targetVersion(r, $relationContext, pin);
@@ -160,6 +163,42 @@
     }
   }
 
+  let contextMenu = $state<{ game: DetectedGame; x: number; y: number } | null>(null);
+  let contextMenuItems = $derived.by<ContextMenuItem[]>(() => {
+    if (!contextMenu) return [];
+    const isHidden = $hiddenIds.has(contextMenu.game.id);
+    return [
+      { action: "open_folder", label: "Open folder" },
+      { action: "scan", label: "Scan" },
+      { action: "pin", label: "Pin a version…" },
+      { action: "hide", label: isHidden ? "Unhide" : "Hide" },
+    ];
+  });
+
+  function openContextMenu(game: DetectedGame, e: MouseEvent): void {
+    contextMenu = { game, x: e.clientX, y: e.clientY };
+  }
+
+  async function onContextSelect(action: ContextMenuAction): Promise<void> {
+    const game = contextMenu?.game;
+    if (!game) return;
+    switch (action) {
+      case "open_folder":
+        await onOpenFolder(game);
+        break;
+      case "scan":
+        await rescanGame(game.id);
+        showToast("info", `Rescanning ${game.name}`);
+        break;
+      case "pin":
+        drawerGameId.set(game.id);
+        break;
+      case "hide":
+        await onHideToggle(game);
+        break;
+    }
+  }
+
   async function addCustomFolder(): Promise<void> {
     if (!$settings) return;
     try {
@@ -242,6 +281,10 @@
     return set.size;
   });
 
+  // Tidal-style sections: split the actionable list into "Needs update" vs the rest.
+  let needsUpdate = $derived(sortedActionable.filter((g) => $gameStatuses[g.id] === "outdated"));
+  let upToDate = $derived(sortedActionable.filter((g) => $gameStatuses[g.id] !== "outdated"));
+
   let noDllsRevealed = $state(false);
   function toggleNoDllsZone(): void { noDllsRevealed = !noDllsRevealed; }
 
@@ -285,8 +328,7 @@
 
 {#if outdatedTotal > 0}
   <div class="updates-hero-shell">
-    <aside class="updates-hero" role="status" aria-label="Pending updates">
-      <span class="updates-hero-edge" aria-hidden="true"></span>
+    <aside class="updates-hero edge-accent" role="status" aria-label="Pending updates">
       <div class="updates-hero-body">
         <p class="updates-hero-headline">
           <strong>{outdatedTotal}</strong>
@@ -431,39 +473,56 @@
     <button class="btn btn-accent" onclick={() => { searchQuery.set(""); launcherFilter.set("all"); statusFilter.set("all"); }}>Reset filters</button>
   </div>
 {:else}
-  {#if sortedActionable.length > 0}
-    {#if viewMode === "grid"}
-      <div class="grid" data-density={density}>
-        {#each sortedActionable as g, i (g.id)}
-          <div class="grid-cell" style:--stagger="{Math.min(i, 20) * 24}ms">
-            <GameCard
-              game={g}
-              hidden={$hiddenIds.has(g.id)}
-              {onApply}
-              {onOpenFolder}
-              onBlacklist={onHideToggle}
-              onClick={onCardClick}
-            />
+  {#snippet gameSection(title: string, list: DetectedGame[], viewAll: StatusFilter)}
+    {#if list.length > 0}
+      <section class="lib-section">
+        <div class="section-head">
+          <span class="section-title">{title}</span>
+          <span class="section-count">{list.length}</span>
+          {#if $statusFilter === "all"}
+            <button class="section-viewall" onclick={() => statusFilter.set(viewAll)}>View all →</button>
+          {/if}
+        </div>
+        {#if viewMode === "grid"}
+          <div class="grid media-deck" data-density={density}>
+            {#each list as g, i (g.id)}
+              <div class="grid-cell media-card" style:--stagger="{Math.min(i, 20) * 24}ms">
+                <GameCard
+                  game={g}
+                  hidden={$hiddenIds.has(g.id)}
+                  {onApply}
+                  {onOpenFolder}
+                  onBlacklist={onHideToggle}
+                  onClick={onCardClick}
+                  onContextMenu={openContextMenu}
+                />
+              </div>
+            {/each}
           </div>
-        {/each}
-      </div>
-    {:else}
-      <div class="list">
-        {#each sortedActionable as g, i (g.id)}
-          <div class="list-cell" style:--stagger="{Math.min(i, 20) * 12}ms">
-            <GameListRow
-              game={g}
-              hidden={$hiddenIds.has(g.id)}
-              {onApply}
-              {onOpenFolder}
-              onBlacklist={onHideToggle}
-              onClick={onCardClick}
-            />
+        {:else}
+          <div class="list">
+            {#each list as g, i (g.id)}
+              <div class="list-cell" style:--stagger="{Math.min(i, 20) * 12}ms">
+                <GameListRow
+                  game={g}
+                  hidden={$hiddenIds.has(g.id)}
+                  {onApply}
+                  {onOpenFolder}
+                  onBlacklist={onHideToggle}
+                  onClick={onCardClick}
+                  onContextMenu={openContextMenu}
+                />
+              </div>
+            {/each}
           </div>
-        {/each}
-      </div>
+        {/if}
+      </section>
     {/if}
-  {/if}
+  {/snippet}
+
+  {@render gameSection("Needs update", needsUpdate, "outdated")}
+  {@render gameSection("Up to date", upToDate, "up_to_date")}
+
   {#if $libraryZones.noDlls.length > 0}
     <div class="zone-no-dlls">
       <button
@@ -489,6 +548,7 @@
                 {onOpenFolder}
                 onBlacklist={onHideToggle}
                 onClick={onCardClick}
+                onContextMenu={openContextMenu}
               />
             </div>
           {/each}
@@ -498,11 +558,13 @@
   {/if}
 {/if}
 
-{#if $drawerGameId}
-  <GameDetailDrawer
-    gameId={$drawerGameId}
-    onClose={() => drawerGameId.set(null)}
-    onApplyStart={() => applyModalOpen.set(true)}
+{#if contextMenu}
+  <ContextMenu
+    x={contextMenu.x}
+    y={contextMenu.y}
+    items={contextMenuItems}
+    onSelect={(a) => void onContextSelect(a)}
+    onClose={() => (contextMenu = null)}
   />
 {/if}
 
@@ -554,35 +616,9 @@
     letter-spacing: var(--letter-wider);
     color: var(--text-muted);
   }
-  .pills { display: flex; flex-wrap: wrap; gap: 4px; }
-  .pill {
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-    height: 32px;
-    padding: 0 13px;
-    border-radius: var(--radius-full);
-    background: var(--bg-card);
-    border: 1px solid var(--border);
-    color: var(--text-secondary);
-    font-size: 12.5px;
-    font-weight: 500;
-    transition: background 0.15s var(--ease), border-color 0.15s var(--ease), color 0.15s var(--ease);
-  }
-  .pill:hover { background: var(--bg-elevated); border-color: var(--border-hover); color: var(--text-primary); }
-  .pill.active { background: var(--accent-dim); border-color: var(--accent); color: var(--accent); }
   .pill.is-hidden { color: var(--text-muted); }
-  .pill.is-hidden.active { background: rgba(239, 68, 68, 0.10); border-color: var(--danger); color: var(--danger); }
-  .pill-count {
-    font-size: 10px;
-    font-weight: 600;
-    background: var(--bg-elevated);
-    color: var(--text-muted);
-    padding: 1px 6px;
-    border-radius: var(--radius-full);
-  }
-  .pill.active .pill-count { background: var(--accent-glow); color: var(--accent); }
-  .pill.is-hidden.active .pill-count { background: rgba(239, 68, 68, 0.18); color: var(--danger); }
+  .pill.is-hidden.active { background: var(--danger-dim); border-color: var(--danger); color: var(--danger); }
+  .pill.is-hidden.active .pill-count { background: var(--danger-glow); color: var(--danger); }
 
   .updates-hero-shell { container-type: inline-size; margin-bottom: 20px; }
   .updates-hero {
@@ -598,16 +634,6 @@
       linear-gradient(120deg, color-mix(in oklab, var(--accent) 7%, transparent), transparent 48%),
       var(--bg-card);
     overflow: hidden;
-  }
-  .updates-hero-edge {
-    position: absolute;
-    inset: 0 auto 0 0;
-    width: 3px;
-    background: linear-gradient(
-      to bottom,
-      var(--accent),
-      color-mix(in oklab, var(--accent) 30%, transparent)
-    );
   }
   .updates-hero-body { display: flex; flex-direction: column; gap: 9px; min-width: 0; }
   .updates-hero-headline {
@@ -713,36 +739,15 @@
   }
   .sort-select:hover { border-color: var(--border-hover); }
   .sort-select:focus-visible { outline: none; border-color: var(--accent); box-shadow: var(--shadow-ring); }
-  .seg {
-    display: inline-flex;
-    height: 32px;
-    background: var(--bg-card);
-    border: 1px solid var(--border);
-    border-radius: var(--radius-md);
-    padding: 2px;
-    gap: 2px;
-  }
-  .seg-btn {
-    display: inline-flex;
-    align-items: center;
-    gap: 5px;
-    padding: 0 11px;
-    border-radius: var(--radius-sm);
-    color: var(--text-secondary);
-    font-size: var(--fs-xs);
-    font-weight: 600;
-    transition: background var(--dur-fast) var(--ease), color var(--dur-fast) var(--ease);
-  }
-  .seg-btn:hover { color: var(--text-primary); background: var(--bg-elevated); }
-  .seg-btn.active { background: var(--accent-dim); color: var(--accent); }
-  .seg-btn:focus-visible { outline: none; box-shadow: var(--shadow-ring); }
-
+  .lib-section { margin-bottom: 30px; }
+  .lib-section:last-of-type { margin-bottom: 8px; }
   .grid {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(248px, 1fr));
     gap: 16px;
     padding-bottom: 32px;
   }
+  .lib-section .grid { padding-bottom: 4px; }
   .grid[data-density="compact"] {
     grid-template-columns: repeat(auto-fill, minmax(184px, 1fr));
     gap: 10px;

--- a/frontend/src/views/Settings.svelte
+++ b/frontend/src/views/Settings.svelte
@@ -21,6 +21,7 @@
   } from "../lib/api";
   import type { AppSettings, UpdatePreferences, LauncherOverrides, AdvancedConfig, NetworkConfig, SgdbConfig, AppPathsDto } from "../lib/api";
   import { LAUNCHER_BRANDS, LAUNCHER_BRAND_ORDER, type LauncherBrandKey } from "../lib/launcherLogos";
+  import BrandMark from "../components/BrandMark.svelte";
 
   let { onToggleTheme, currentTheme }: { onToggleTheme: () => void; currentTheme: string } = $props();
   let dlssOverlayLive = $state(false);
@@ -289,7 +290,7 @@
     { key: "update_dlss", label: "DLSS Super Resolution", sub: "Sharper image at higher FPS — NVIDIA AI upscaling.", files: "nvngx_dlss.dll · sl.dlss.dll" },
     { key: "update_dlss_fg", label: "DLSS Frame Generation", sub: "Extra interpolated frames for smoother motion on RTX 40+ GPUs.", files: "nvngx_dlssg.dll · sl.dlss_g.dll" },
     { key: "update_dlss_rr", label: "DLSS Ray Reconstruction", sub: "Cleaner ray-traced reflections, shadows and global illumination.", files: "nvngx_dlssd.dll · sl.dlss_d.dll" },
-    { key: "update_streamline", label: "NVIDIA Streamline runtime", sub: "Shared NVIDIA loader required by DLSS, Reflex and DirectSR.", files: "sl.interposer.dll · sl.common.dll · sl.pcl.dll · sl.nis.dll · sl.directsr.dll" },
+    { key: "update_streamline", label: "NVIDIA Streamline plug-ins (advanced)", sub: "Master switch for every sl.* Streamline DLL. Off by default — they are a version-locked set, so swapping them can crash games (especially with DLSS Enabler). NGX DLLs are unaffected.", files: "sl.interposer.dll · sl.common.dll · sl.dlss.dll · sl.dlss_g.dll · sl.reflex.dll · sl.pcl.dll · sl.directsr.dll" },
     { key: "update_reflex", label: "NVIDIA Reflex", sub: "Lower input latency in supported titles.", files: "sl.reflex.dll" },
     { key: "update_xess", label: "Intel XeSS", sub: "Intel AI upscaling — best on Arc GPUs, works elsewhere.", files: "libxess.dll · libxess_fg.dll · libxell.dll" },
     { key: "update_fsr", label: "AMD FSR", sub: "AMD upscaling and frame generation — runs on any GPU.", files: "amd_fidelityfx_*.dll · ffx_*.dll" },
@@ -812,7 +813,7 @@
 
         <div class="settings-card" style="margin-top: 18px;">
           <header class="card-head">
-            <h3>DLSS Overrides <span class="chip chip-update small-pill">NVIDIA</span></h3>
+            <h3>DLSS Overrides <span class="chip chip-update small-pill"><BrandMark key="nvidia" tone="mono" size={11} /></span></h3>
             <p class="card-sub">DLSS preset and frame-generation overrides moved to the <strong>Drivers</strong> tab, alongside your GPU driver updates. Per-game overrides stay in each game's detail drawer.</p>
           </header>
           <button class="btn btn-primary" style="margin-top: 14px;" onclick={() => currentView.set("drivers")}>Open the Drivers tab</button>
@@ -904,10 +905,11 @@
   .tab-panels { max-width: 920px; min-width: 0; }
   .section-head { margin-bottom: 10px; }
   .section-title-h {
-    font-size: var(--fs-md);
-    font-weight: 600;
+    font-size: var(--fs-lg);
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: var(--letter-wide);
     color: var(--text-primary);
-    letter-spacing: var(--letter-tight);
     margin-bottom: 3px;
     display: flex;
     align-items: center;

--- a/manifest/manifest.json
+++ b/manifest/manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 2,
-  "generated_at": "2026-05-20T11:46:43.651879500Z",
+  "generated_at": "2026-05-29T13:08:24.502347200Z",
   "vendors": {
     "amd": {
       "fsr_fg": {
@@ -20,7 +20,8 @@
             "signature_subject": "Advanced Micro Devices, Inc.",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           }
         ]
       },
@@ -41,13 +42,167 @@
             "signature_subject": "Advanced Micro Devices, Inc.",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           }
         ]
       },
       "fsr_upscaler": {
         "latest": "2.0.0",
         "releases": [
+          {
+            "version": "1.0.0.36208",
+            "version_packed": 281474976746864,
+            "filename": "amd_fidelityfx_dx12.dll",
+            "sha256": "cfcd38f47665ddff195b80c62e3b57e2",
+            "size_bytes": 6470360,
+            "signed": true,
+            "released_at": "2026-05-29T13:04:54.606337400Z",
+            "source": "F1 2024",
+            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/fsr_31_dx12/fsr_31_dx12_v1.0.0.36208_CFCD38F47665DDFF195B80C62E3B57E2.zip",
+            "release_notes": "3.1.0",
+            "signature_subject": "Advanced Micro Devices, Inc.",
+            "channel": "stable",
+            "is_dev": false,
+            "min_driver": null,
+            "hash_algorithm": "md5"
+          },
+          {
+            "version": "1.0.0.36604",
+            "version_packed": 281474976747260,
+            "filename": "amd_fidelityfx_dx12.dll",
+            "sha256": "071eb42e3cbd0989a12465e0e529bcac",
+            "size_bytes": 6475480,
+            "signed": true,
+            "released_at": "2026-05-29T13:04:54.606346300Z",
+            "source": "FidelityFX-SDK-1.1.zip",
+            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/fsr_31_dx12/fsr_31_dx12_v1.0.0.36604_071EB42E3CBD0989A12465E0E529BCAC.zip",
+            "release_notes": "3.1.0",
+            "signature_subject": "Advanced Micro Devices, Inc.",
+            "channel": "stable",
+            "is_dev": false,
+            "min_driver": null,
+            "hash_algorithm": "md5"
+          },
+          {
+            "version": "1.0.0.36752",
+            "version_packed": 281474976747408,
+            "filename": "amd_fidelityfx_dx12.dll",
+            "sha256": "46f7049b30404d8c4ef685a13ef0bc43",
+            "size_bytes": 6475992,
+            "signed": true,
+            "released_at": "2026-05-29T13:04:54.606352500Z",
+            "source": "Horizon Zero Dawn Remastered",
+            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/fsr_31_dx12/fsr_31_dx12_v1.0.0.36752_46F7049B30404D8C4EF685A13EF0BC43.zip",
+            "release_notes": "3.1.0",
+            "signature_subject": "Advanced Micro Devices, Inc.",
+            "channel": "stable",
+            "is_dev": false,
+            "min_driver": null,
+            "hash_algorithm": "md5"
+          },
+          {
+            "version": "1.0.1.37507",
+            "version_packed": 281474976813699,
+            "filename": "amd_fidelityfx_dx12.dll",
+            "sha256": "2fcbe69a137dba1ff45071a9b64c9581",
+            "size_bytes": 6609624,
+            "signed": true,
+            "released_at": "2026-05-29T13:04:54.606358600Z",
+            "source": "FidelityFX-SDK-v1.1.1.zip",
+            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/fsr_31_dx12/fsr_31_dx12_v1.0.1.37507_2FCBE69A137DBA1FF45071A9B64C9581.zip",
+            "release_notes": "3.1.1",
+            "signature_subject": "Advanced Micro Devices, Inc.",
+            "channel": "stable",
+            "is_dev": false,
+            "min_driver": null,
+            "hash_algorithm": "md5"
+          },
+          {
+            "version": "1.0.1.38338",
+            "version_packed": 281474976814530,
+            "filename": "amd_fidelityfx_dx12.dll",
+            "sha256": "2dc40d2f183920624be396b624466157",
+            "size_bytes": 6634192,
+            "signed": true,
+            "released_at": "2026-05-29T13:04:54.606364500Z",
+            "source": "FidelityFX-SDK-v1.1.2.zip",
+            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/fsr_31_dx12/fsr_31_dx12_v1.0.1.38338_2DC40D2F183920624BE396B624466157.zip",
+            "release_notes": "3.1.2",
+            "signature_subject": "Advanced Micro Devices, Inc.",
+            "channel": "stable",
+            "is_dev": false,
+            "min_driver": null,
+            "hash_algorithm": "md5"
+          },
+          {
+            "version": "1.0.1.39157",
+            "version_packed": 281474976815349,
+            "filename": "amd_fidelityfx_dx12.dll",
+            "sha256": "3ef374f8f7eb44d211bcc0c063a520d9",
+            "size_bytes": 6647504,
+            "signed": true,
+            "released_at": "2026-05-29T13:04:54.606370500Z",
+            "source": "FidelityFX-SDK-v1.1.3.zip",
+            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/fsr_31_dx12/fsr_31_dx12_v1.0.1.39157_3EF374F8F7EB44D211BCC0C063A520D9.zip",
+            "release_notes": "3.1.3",
+            "signature_subject": "Advanced Micro Devices, Inc.",
+            "channel": "stable",
+            "is_dev": false,
+            "min_driver": null,
+            "hash_algorithm": "md5"
+          },
+          {
+            "version": "1.0.1.40157",
+            "version_packed": 281474976816349,
+            "filename": "amd_fidelityfx_dx12.dll",
+            "sha256": "6deffa8d3e83449c961558e26781687b",
+            "size_bytes": 6647504,
+            "signed": true,
+            "released_at": "2025-02-27T11:30:58Z",
+            "source": "beeradmoore/dlss-swapper",
+            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/fsr_31_dx12/fsr_31_dx12_v1.0.1.40157_6DEFFA8D3E83449C961558E26781687B.zip",
+            "release_notes": "3.1.3",
+            "signature_subject": "Advanced Micro Devices, Inc.",
+            "channel": "stable",
+            "is_dev": false,
+            "min_driver": null,
+            "hash_algorithm": "md5"
+          },
+          {
+            "version": "1.0.1.41314",
+            "version_packed": 281474976817506,
+            "filename": "amd_fidelityfx_dx12.dll",
+            "sha256": "49230ad94ed6169933cd0457501d9cb4",
+            "size_bytes": 6675664,
+            "signed": true,
+            "released_at": "2025-05-07T13:17:26Z",
+            "source": "FidelityFX-SDK-v1.1.4.zip",
+            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/fsr_31_dx12/fsr_31_dx12_v1.0.1.41314_49230AD94ED6169933CD0457501D9CB4.zip",
+            "release_notes": "3.1.4",
+            "signature_subject": "Advanced Micro Devices, Inc.",
+            "channel": "stable",
+            "is_dev": false,
+            "min_driver": null,
+            "hash_algorithm": "md5"
+          },
+          {
+            "version": "1.0.2.38022",
+            "version_packed": 281474976879750,
+            "filename": "amd_fidelityfx_dx12.dll",
+            "sha256": "ab23d0e0887e0866578ef142eeb6eec6",
+            "size_bytes": 6621392,
+            "signed": true,
+            "released_at": "2024-10-10T09:40:39Z",
+            "source": "beeradmoore/dlss-swapper",
+            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/fsr_31_dx12/fsr_31_dx12_v1.0.2.38022_AB23D0E0887E0866578EF142EEB6EEC6.zip",
+            "release_notes": "3.1.2",
+            "signature_subject": "Advanced Micro Devices, Inc.",
+            "channel": "stable",
+            "is_dev": false,
+            "min_driver": null,
+            "hash_algorithm": "md5"
+          },
           {
             "version": "2.0.0",
             "version_packed": 562949953421312,
@@ -62,7 +217,132 @@
             "signature_subject": "Advanced Micro Devices, Inc.",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
+          }
+        ]
+      },
+      "fsr_upscaler_vk": {
+        "latest": "1.0.1.42386",
+        "releases": [
+          {
+            "version": "1.0.0.36604",
+            "version_packed": 281474976747260,
+            "filename": "amd_fidelityfx_vk.dll",
+            "sha256": "a2bc75bc5455e870d71890c774541da9",
+            "size_bytes": 9200344,
+            "signed": true,
+            "released_at": "2026-05-29T13:04:54.606405200Z",
+            "source": "FidelityFX-SDK-1.1.zip",
+            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/fsr_31_vk/fsr_31_vk_v1.0.0.36604_A2BC75BC5455E870D71890C774541DA9.zip",
+            "release_notes": "3.1.0",
+            "signature_subject": "Advanced Micro Devices, Inc.",
+            "channel": "stable",
+            "is_dev": false,
+            "min_driver": null,
+            "hash_algorithm": "md5"
+          },
+          {
+            "version": "1.0.1.37507",
+            "version_packed": 281474976813699,
+            "filename": "amd_fidelityfx_vk.dll",
+            "sha256": "1fc735751d2632e926016206398b8654",
+            "size_bytes": 9262808,
+            "signed": true,
+            "released_at": "2026-05-29T13:04:54.606412100Z",
+            "source": "FidelityFX-SDK-v1.1.1.zip",
+            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/fsr_31_vk/fsr_31_vk_v1.0.1.37507_1FC735751D2632E926016206398B8654.zip",
+            "release_notes": "3.1.1",
+            "signature_subject": "Advanced Micro Devices, Inc.",
+            "channel": "stable",
+            "is_dev": false,
+            "min_driver": null,
+            "hash_algorithm": "md5"
+          },
+          {
+            "version": "1.0.1.38338",
+            "version_packed": 281474976814530,
+            "filename": "amd_fidelityfx_vk.dll",
+            "sha256": "0d0cdc8d5865027d100daa35b605793f",
+            "size_bytes": 9277136,
+            "signed": true,
+            "released_at": "2026-05-29T13:04:54.606418600Z",
+            "source": "FidelityFX-SDK-v1.1.2.zip",
+            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/fsr_31_vk/fsr_31_vk_v1.0.1.38338_0D0CDC8D5865027D100DAA35B605793F.zip",
+            "release_notes": "3.1.2",
+            "signature_subject": "Advanced Micro Devices, Inc.",
+            "channel": "stable",
+            "is_dev": false,
+            "min_driver": null,
+            "hash_algorithm": "md5"
+          },
+          {
+            "version": "1.0.1.39157",
+            "version_packed": 281474976815349,
+            "filename": "amd_fidelityfx_vk.dll",
+            "sha256": "23a87c10a859d5756edbe5a6d7f692b5",
+            "size_bytes": 9284304,
+            "signed": true,
+            "released_at": "2026-05-29T13:04:54.606425Z",
+            "source": "FidelityFX-SDK-v1.1.3.zip",
+            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/fsr_31_vk/fsr_31_vk_v1.0.1.39157_23A87C10A859D5756EDBE5A6D7F692B5.zip",
+            "release_notes": "3.1.3",
+            "signature_subject": "Advanced Micro Devices, Inc.",
+            "channel": "stable",
+            "is_dev": false,
+            "min_driver": null,
+            "hash_algorithm": "md5"
+          },
+          {
+            "version": "1.0.1.39321",
+            "version_packed": 281474976815513,
+            "filename": "amd_fidelityfx_vk.dll",
+            "sha256": "794d0884d482dfd53eac77977e5ade8c",
+            "size_bytes": 9294408,
+            "signed": true,
+            "released_at": "2024-12-16T11:05:45Z",
+            "source": "beeradmoore/dlss-swapper",
+            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/fsr_31_vk/fsr_31_vk_v1.0.1.39321_794D0884D482DFD53EAC77977E5ADE8C.zip",
+            "release_notes": "3.1.3",
+            "signature_subject": "Advanced Micro Devices, Inc.",
+            "channel": "stable",
+            "is_dev": false,
+            "min_driver": null,
+            "hash_algorithm": "md5"
+          },
+          {
+            "version": "1.0.1.41314",
+            "version_packed": 281474976817506,
+            "filename": "amd_fidelityfx_vk.dll",
+            "sha256": "9718fd774c61be1af6af411cf65394cd",
+            "size_bytes": 9332432,
+            "signed": true,
+            "released_at": "2025-05-07T13:17:37Z",
+            "source": "FidelityFX-SDK-v1.1.4.zip",
+            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/fsr_31_vk/fsr_31_vk_v1.0.1.41314_9718FD774C61BE1AF6AF411CF65394CD.zip",
+            "release_notes": "3.1.4",
+            "signature_subject": "Advanced Micro Devices, Inc.",
+            "channel": "stable",
+            "is_dev": false,
+            "min_driver": null,
+            "hash_algorithm": "md5"
+          },
+          {
+            "version": "1.0.1.42386",
+            "version_packed": 281474976818578,
+            "filename": "amd_fidelityfx_vk.dll",
+            "sha256": "8f036c984d570b58c1cd312bb5c780ab",
+            "size_bytes": 9342112,
+            "signed": true,
+            "released_at": "2025-06-09T11:45:17Z",
+            "source": "beeradmoore/dlss-swapper",
+            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/fsr_31_vk/fsr_31_vk_v1.0.1.42386_8F036C984D570B58C1CD312BB5C780AB.zip",
+            "release_notes": "3.1.4",
+            "signature_subject": "Advanced Micro Devices, Inc.",
+            "channel": "stable",
+            "is_dev": false,
+            "min_driver": null,
+            "hash_algorithm": "md5"
           }
         ]
       }
@@ -71,6 +351,108 @@
       "xell": {
         "latest": "3.0.1",
         "releases": [
+          {
+            "version": "1.0.0.139",
+            "version_packed": 281474976710795,
+            "filename": "libxell.dll",
+            "sha256": "d469069d3935032f907106331161e78a",
+            "size_bytes": 237968,
+            "signed": true,
+            "released_at": "2026-05-29T13:04:54.606614500Z",
+            "source": "Marvel Rivals",
+            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/xell/xell_v1.0.0.139_D469069D3935032F907106331161E78A.zip",
+            "release_notes": "",
+            "signature_subject": "Intel Corporation",
+            "channel": "stable",
+            "is_dev": false,
+            "min_driver": null,
+            "hash_algorithm": "md5"
+          },
+          {
+            "version": "1.0.1.6",
+            "version_packed": 281474976776198,
+            "filename": "libxell.dll",
+            "sha256": "ac3c8aebdf60f932cfded7d2bcef93f0",
+            "size_bytes": 267152,
+            "signed": true,
+            "released_at": "2025-02-04T17:33:12Z",
+            "source": "beeradmoore/dlss-swapper",
+            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/xell/xell_v1.0.1.6_AC3C8AEBDF60F932CFDED7D2BCEF93F0.zip",
+            "release_notes": "",
+            "signature_subject": "Intel Corporation",
+            "channel": "stable",
+            "is_dev": false,
+            "min_driver": null,
+            "hash_algorithm": "md5"
+          },
+          {
+            "version": "1.1.0.6",
+            "version_packed": 281479271677958,
+            "filename": "libxell.dll",
+            "sha256": "b97327b6e9b8073deaf4fa8cbb4286d2",
+            "size_bytes": 346984,
+            "signed": true,
+            "released_at": "2025-03-12T15:40:23Z",
+            "source": "XeSS_SDK_2.0.1.zip",
+            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/xell/xell_v1.1.0.6_B97327B6E9B8073DEAF4FA8CBB4286D2.zip",
+            "release_notes": "",
+            "signature_subject": "Intel Corporation",
+            "channel": "stable",
+            "is_dev": false,
+            "min_driver": null,
+            "hash_algorithm": "md5"
+          },
+          {
+            "version": "1.2.0.9",
+            "version_packed": 281483566645257,
+            "filename": "libxell.dll",
+            "sha256": "7371177f39efbbb60a3f1274244c3eca",
+            "size_bytes": 359792,
+            "signed": true,
+            "released_at": "2025-07-17T21:30:25Z",
+            "source": "XeSS_SDK_2.1.0.zip",
+            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/xell/xell_v1.2.0.9_7371177F39EFBBB60A3F1274244C3ECA.zip",
+            "release_notes": "",
+            "signature_subject": "Intel Corporation",
+            "channel": "stable",
+            "is_dev": false,
+            "min_driver": null,
+            "hash_algorithm": "md5"
+          },
+          {
+            "version": "1.2.1.13",
+            "version_packed": 281483566710797,
+            "filename": "libxell.dll",
+            "sha256": "32eaec31d4f314b0a0e92ef5aaae2d6f",
+            "size_bytes": 360312,
+            "signed": true,
+            "released_at": "2025-10-13T11:35:04Z",
+            "source": "XeSS_SDK_2.1.1.zip",
+            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/xell/xell_v1.2.1.13_32EAEC31D4F314B0A0E92EF5AAAE2D6F.zip",
+            "release_notes": "",
+            "signature_subject": "Intel Corporation",
+            "channel": "stable",
+            "is_dev": false,
+            "min_driver": null,
+            "hash_algorithm": "md5"
+          },
+          {
+            "version": "1.3.0.5",
+            "version_packed": 281487861612549,
+            "filename": "libxell.dll",
+            "sha256": "2747b644c19058fc594650a7f3705218",
+            "size_bytes": 411504,
+            "signed": true,
+            "released_at": "2026-03-03T11:31:50Z",
+            "source": "XeSS_SDK_3.0.0.zip",
+            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/xell/xell_v1.3.0.5_2747B644C19058FC594650A7F3705218.zip",
+            "release_notes": "",
+            "signature_subject": "Intel Corporation",
+            "channel": "stable",
+            "is_dev": false,
+            "min_driver": null,
+            "hash_algorithm": "md5"
+          },
           {
             "version": "2.0.1",
             "version_packed": 562949953486848,
@@ -85,7 +467,8 @@
             "signature_subject": "Intel Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           },
           {
             "version": "2.1.0",
@@ -101,7 +484,8 @@
             "signature_subject": "Intel Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           },
           {
             "version": "2.1.1",
@@ -117,7 +501,8 @@
             "signature_subject": "Intel Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           },
           {
             "version": "3.0.0",
@@ -133,7 +518,8 @@
             "signature_subject": "Intel Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           },
           {
             "version": "3.0.1",
@@ -149,13 +535,167 @@
             "signature_subject": "Intel Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           }
         ]
       },
       "xess_fg": {
         "latest": "3.0.1",
         "releases": [
+          {
+            "version": "0.9.11.9",
+            "version_packed": 38655426569,
+            "filename": "libxess_fg.dll",
+            "sha256": "7c15036490a8c4679d49429773f542ea",
+            "size_bytes": 63566736,
+            "signed": true,
+            "released_at": "2024-10-16T07:41:43Z",
+            "source": "beeradmoore/dlss-swapper",
+            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/xess_fg/xess_fg_v0.9.11.9_7C15036490A8C4679D49429773F542EA.zip",
+            "release_notes": "",
+            "signature_subject": "Intel Corporation",
+            "channel": "stable",
+            "is_dev": false,
+            "min_driver": null,
+            "hash_algorithm": "md5"
+          },
+          {
+            "version": "1.0.0.16",
+            "version_packed": 281474976710672,
+            "filename": "libxess_fg.dll",
+            "sha256": "bf976a1c2e466b1be6fc4b17d76b50d5",
+            "size_bytes": 59355536,
+            "signed": true,
+            "released_at": "2026-05-29T13:04:54.606565400Z",
+            "source": "Marvel Rivals",
+            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/xess_fg/xess_fg_v1.0.0.16_BF976A1C2E466B1BE6FC4B17D76B50D5.zip",
+            "release_notes": "",
+            "signature_subject": "Intel Corporation",
+            "channel": "stable",
+            "is_dev": false,
+            "min_driver": null,
+            "hash_algorithm": "md5"
+          },
+          {
+            "version": "1.0.1.26",
+            "version_packed": 281474976776218,
+            "filename": "libxess_fg.dll",
+            "sha256": "638bc6e8d34559caed89c7015932567e",
+            "size_bytes": 60188048,
+            "signed": true,
+            "released_at": "2025-01-16T16:48:31Z",
+            "source": "beeradmoore/dlss-swapper",
+            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/xess_fg/xess_fg_v1.0.1.26_638BC6E8D34559CAED89C7015932567E.zip",
+            "release_notes": "",
+            "signature_subject": "Intel Corporation",
+            "channel": "stable",
+            "is_dev": false,
+            "min_driver": null,
+            "hash_algorithm": "md5"
+          },
+          {
+            "version": "1.0.1.31",
+            "version_packed": 281474976776223,
+            "filename": "libxess_fg.dll",
+            "sha256": "a51047068f3d1f480f5ffb2bf10f963a",
+            "size_bytes": 60192144,
+            "signed": true,
+            "released_at": "2025-02-04T14:46:44Z",
+            "source": "beeradmoore/dlss-swapper",
+            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/xess_fg/xess_fg_v1.0.1.31_A51047068F3D1F480F5FFB2BF10F963A.zip",
+            "release_notes": "",
+            "signature_subject": "Intel Corporation",
+            "channel": "stable",
+            "is_dev": false,
+            "min_driver": null,
+            "hash_algorithm": "md5"
+          },
+          {
+            "version": "1.1.0.19",
+            "version_packed": 281479271677971,
+            "filename": "libxess_fg.dll",
+            "sha256": "947f3eb49f1b402374fe97f8b5728ffc",
+            "size_bytes": 45557608,
+            "signed": true,
+            "released_at": "2025-03-13T13:01:34Z",
+            "source": "XeSS_SDK_2.0.1.zip",
+            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/xess_fg/xess_fg_v1.1.0.19_947F3EB49F1B402374FE97F8B5728FFC.zip",
+            "release_notes": "",
+            "signature_subject": "Intel Corporation",
+            "channel": "stable",
+            "is_dev": false,
+            "min_driver": null,
+            "hash_algorithm": "md5"
+          },
+          {
+            "version": "1.2.0.87",
+            "version_packed": 281483566645335,
+            "filename": "libxess_fg.dll",
+            "sha256": "904116c83b5c6115cbe41ff3be513997",
+            "size_bytes": 45541752,
+            "signed": true,
+            "released_at": "2025-07-19T00:01:34Z",
+            "source": "XeSS_SDK_2.1.0.zip",
+            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/xess_fg/xess_fg_v1.2.0.87_904116C83B5C6115CBE41FF3BE513997.zip",
+            "release_notes": "",
+            "signature_subject": "Intel Corporation",
+            "channel": "stable",
+            "is_dev": false,
+            "min_driver": null,
+            "hash_algorithm": "md5"
+          },
+          {
+            "version": "1.2.2.118",
+            "version_packed": 281483566776438,
+            "filename": "libxess_fg.dll",
+            "sha256": "b68edb6f20585dbc44b96333bf416622",
+            "size_bytes": 47119216,
+            "signed": true,
+            "released_at": "2025-10-21T22:14:42Z",
+            "source": "XeSS_SDK_2.1.1.zip",
+            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/xess_fg/xess_fg_v1.2.2.118_B68EDB6F20585DBC44B96333BF416622.zip",
+            "release_notes": "",
+            "signature_subject": "Intel Corporation",
+            "channel": "stable",
+            "is_dev": false,
+            "min_driver": null,
+            "hash_algorithm": "md5"
+          },
+          {
+            "version": "1.3.1.68",
+            "version_packed": 281487861678148,
+            "filename": "libxess_fg.dll",
+            "sha256": "ffef0e9856fe361a088d8da96cec34e2",
+            "size_bytes": 22955384,
+            "signed": true,
+            "released_at": "2026-03-03T16:13:54Z",
+            "source": "XeSS_SDK_3.0.0.zip",
+            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/xess_fg/xess_fg_v1.3.1.68_FFEF0E9856FE361A088D8DA96CEC34E2.zip",
+            "release_notes": "",
+            "signature_subject": "Intel Corporation",
+            "channel": "stable",
+            "is_dev": false,
+            "min_driver": null,
+            "hash_algorithm": "md5"
+          },
+          {
+            "version": "1.3.1.78",
+            "version_packed": 281487861678158,
+            "filename": "libxess_fg.dll",
+            "sha256": "e5da7e91e3af8a8340b3fef922912e6e",
+            "size_bytes": 22957432,
+            "signed": true,
+            "released_at": "2026-03-31T00:05:48Z",
+            "source": "XeSS_SDK_3.0.1.zip",
+            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/xess_fg/xess_fg_v1.3.1.78_E5DA7E91E3AF8A8340B3FEF922912E6E.zip",
+            "release_notes": "",
+            "signature_subject": "Intel Corporation",
+            "channel": "stable",
+            "is_dev": false,
+            "min_driver": null,
+            "hash_algorithm": "md5"
+          },
           {
             "version": "2.0.1",
             "version_packed": 562949953486848,
@@ -170,7 +710,8 @@
             "signature_subject": "Intel Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           },
           {
             "version": "2.1.0",
@@ -186,7 +727,8 @@
             "signature_subject": "Intel Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           },
           {
             "version": "2.1.1",
@@ -202,7 +744,8 @@
             "signature_subject": "Intel Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           },
           {
             "version": "3.0.0",
@@ -218,7 +761,8 @@
             "signature_subject": "Intel Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           },
           {
             "version": "3.0.1",
@@ -234,7 +778,8 @@
             "signature_subject": "Intel Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           }
         ]
       },
@@ -255,7 +800,25 @@
             "signature_subject": "Intel Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
+          },
+          {
+            "version": "1.0.0.59",
+            "version_packed": 281474976710715,
+            "filename": "libxess.dll",
+            "sha256": "feb7639e1043d0dc88d638c21871f566",
+            "size_bytes": 9271976,
+            "signed": true,
+            "released_at": "2026-05-29T13:04:54.606454300Z",
+            "source": "XeSS.SDK.1.0.zip",
+            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/xess/xess_v1.0.0.59_FEB7639E1043D0DC88D638C21871F566.zip",
+            "release_notes": "",
+            "signature_subject": "Intel Corporation",
+            "channel": "stable",
+            "is_dev": false,
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "1.0.1",
@@ -271,7 +834,25 @@
             "signature_subject": "Intel Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
+          },
+          {
+            "version": "1.0.1.12",
+            "version_packed": 281474976776204,
+            "filename": "libxess.dll",
+            "sha256": "049bfea8c51245a545dc242a7317b9d3",
+            "size_bytes": 9272488,
+            "signed": true,
+            "released_at": "2026-05-29T13:04:54.606462200Z",
+            "source": "XeSS.SDK.1.0.1.zip",
+            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/xess/xess_v1.0.1.12_049BFEA8C51245A545DC242A7317B9D3.zip",
+            "release_notes": "",
+            "signature_subject": "Intel Corporation",
+            "channel": "stable",
+            "is_dev": false,
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "1.1.0",
@@ -287,7 +868,42 @@
             "signature_subject": "Intel Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
+          },
+          {
+            "version": "1.1.0.18",
+            "version_packed": 281479271677970,
+            "filename": "libxess.dll",
+            "sha256": "c9fb6bb716a087fd537790bebe710d4c",
+            "size_bytes": 15275688,
+            "signed": true,
+            "released_at": "2026-05-29T13:04:54.606467200Z",
+            "source": "Forza Horizon 5",
+            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/xess/xess_v1.1.0.18_C9FB6BB716A087FD537790BEBE710D4C.zip",
+            "release_notes": "",
+            "signature_subject": "Intel Corporation",
+            "channel": "stable",
+            "is_dev": false,
+            "min_driver": null,
+            "hash_algorithm": "md5"
+          },
+          {
+            "version": "1.1.0.21",
+            "version_packed": 281479271677973,
+            "filename": "libxess.dll",
+            "sha256": "7b20cc0a10008f0846ddac99981ac77f",
+            "size_bytes": 15275688,
+            "signed": true,
+            "released_at": "2026-05-29T13:04:54.606472100Z",
+            "source": "XeSS_SDK_1.1.0.zip",
+            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/xess/xess_v1.1.0.21_7B20CC0A10008F0846DDAC99981AC77F.zip",
+            "release_notes": "",
+            "signature_subject": "Intel Corporation",
+            "channel": "stable",
+            "is_dev": false,
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "1.2.0",
@@ -303,7 +919,42 @@
             "signature_subject": "Intel Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
+          },
+          {
+            "version": "1.2.0.10",
+            "version_packed": 281483566645258,
+            "filename": "libxess.dll",
+            "sha256": "4c8d7344a1dcf91af9c01b6321c2ba8a",
+            "size_bytes": 67777552,
+            "signed": true,
+            "released_at": "2023-07-12T16:42:24Z",
+            "source": "beeradmoore/dlss-swapper",
+            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/xess/xess_v1.2.0.10_4C8D7344A1DCF91AF9C01B6321C2BA8A.zip",
+            "release_notes": "",
+            "signature_subject": "Intel Corporation",
+            "channel": "stable",
+            "is_dev": false,
+            "min_driver": null,
+            "hash_algorithm": "md5"
+          },
+          {
+            "version": "1.2.0.13",
+            "version_packed": 281483566645261,
+            "filename": "libxess.dll",
+            "sha256": "b0130df92c02efde7c2c4df42d69ee70",
+            "size_bytes": 67777552,
+            "signed": true,
+            "released_at": "2026-05-29T13:04:54.606481700Z",
+            "source": "XeSS_SDK-1.2.0.zip",
+            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/xess/xess_v1.2.0.13_B0130DF92C02EFDE7C2C4DF42D69EE70.zip",
+            "release_notes": "",
+            "signature_subject": "Intel Corporation",
+            "channel": "stable",
+            "is_dev": false,
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "1.3.0",
@@ -319,7 +970,25 @@
             "signature_subject": "Intel Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
+          },
+          {
+            "version": "1.3.0.28",
+            "version_packed": 281487861612572,
+            "filename": "libxess.dll",
+            "sha256": "dd62b2ef2da5a9be89e18302e38970a2",
+            "size_bytes": 74108944,
+            "signed": true,
+            "released_at": "2026-05-29T13:04:54.606486500Z",
+            "source": "XeSS_SDK-1.3.0.zip",
+            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/xess/xess_v1.3.0.28_DD62B2EF2DA5A9BE89E18302E38970A2.zip",
+            "release_notes": "",
+            "signature_subject": "Intel Corporation",
+            "channel": "stable",
+            "is_dev": false,
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "1.3.1",
@@ -335,7 +1004,42 @@
             "signature_subject": "Intel Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
+          },
+          {
+            "version": "1.3.1.32",
+            "version_packed": 281487861678112,
+            "filename": "libxess.dll",
+            "sha256": "10623c59d5e4571bfd6118337ac69491",
+            "size_bytes": 67095056,
+            "signed": true,
+            "released_at": "2026-05-29T13:04:54.606491900Z",
+            "source": "XeSS_SDK-1.3.1.zip",
+            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/xess/xess_v1.3.1.32_10623C59D5E4571BFD6118337AC69491.zip",
+            "release_notes": "",
+            "signature_subject": "Intel Corporation",
+            "channel": "stable",
+            "is_dev": false,
+            "min_driver": null,
+            "hash_algorithm": "md5"
+          },
+          {
+            "version": "2.0.0.18",
+            "version_packed": 562949953421330,
+            "filename": "libxess.dll",
+            "sha256": "367be8343b288372ff8523438f53b62d",
+            "size_bytes": 120278928,
+            "signed": true,
+            "released_at": "2026-05-29T13:04:54.606497300Z",
+            "source": "Marvel Rivals",
+            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/xess/xess_v2.0.0.18_367BE8343B288372FF8523438F53B62D.zip",
+            "release_notes": "",
+            "signature_subject": "Intel Corporation",
+            "channel": "stable",
+            "is_dev": false,
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "2.0.1",
@@ -351,7 +1055,110 @@
             "signature_subject": "Intel Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
+          },
+          {
+            "version": "2.0.1.29",
+            "version_packed": 562949953486877,
+            "filename": "libxess.dll",
+            "sha256": "8d1adebe2f3fd417fe6ac599114098ac",
+            "size_bytes": 120956304,
+            "signed": true,
+            "released_at": "2025-01-10T21:34:34Z",
+            "source": "beeradmoore/dlss-swapper",
+            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/xess/xess_v2.0.1.29_8D1ADEBE2F3FD417FE6AC599114098AC.zip",
+            "release_notes": "",
+            "signature_subject": "Intel Corporation",
+            "channel": "stable",
+            "is_dev": false,
+            "min_driver": null,
+            "hash_algorithm": "md5"
+          },
+          {
+            "version": "2.0.1.32",
+            "version_packed": 562949953486880,
+            "filename": "libxess.dll",
+            "sha256": "306786b7961439b5330ec10ab9d594b5",
+            "size_bytes": 124195680,
+            "signed": true,
+            "released_at": "2025-01-22T03:02:22Z",
+            "source": "beeradmoore/dlss-swapper",
+            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/xess/xess_v2.0.1.32_306786B7961439B5330EC10AB9D594B5.zip",
+            "release_notes": "",
+            "signature_subject": "Intel Corporation",
+            "channel": "stable",
+            "is_dev": false,
+            "min_driver": null,
+            "hash_algorithm": "md5"
+          },
+          {
+            "version": "2.0.1.34",
+            "version_packed": 562949953486882,
+            "filename": "libxess.dll",
+            "sha256": "4edd90eaa5c1d4c93853734b744c0137",
+            "size_bytes": 124186512,
+            "signed": true,
+            "released_at": "2025-02-04T21:51:57Z",
+            "source": "beeradmoore/dlss-swapper",
+            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/xess/xess_v2.0.1.34_4EDD90EAA5C1D4C93853734B744C0137.zip",
+            "release_notes": "",
+            "signature_subject": "Intel Corporation",
+            "channel": "stable",
+            "is_dev": false,
+            "min_driver": null,
+            "hash_algorithm": "md5"
+          },
+          {
+            "version": "2.0.1.41",
+            "version_packed": 562949953486889,
+            "filename": "libxess.dll",
+            "sha256": "f9e8bcab719e249ba8bd50414d42143f",
+            "size_bytes": 77771112,
+            "signed": true,
+            "released_at": "2025-03-12T17:49:25Z",
+            "source": "XeSS_SDK_2.0.1.zip",
+            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/xess/xess_v2.0.1.41_F9E8BCAB719E249BA8BD50414D42143F.zip",
+            "release_notes": "",
+            "signature_subject": "Intel Corporation",
+            "channel": "stable",
+            "is_dev": false,
+            "min_driver": null,
+            "hash_algorithm": "md5"
+          },
+          {
+            "version": "2.0.2.53",
+            "version_packed": 562949953552437,
+            "filename": "libxess.dll",
+            "sha256": "b6d2a108369fe3cd7fc82af14dd8c60c",
+            "size_bytes": 77788528,
+            "signed": true,
+            "released_at": "2025-07-03T08:08:12Z",
+            "source": "XeSS_SDK_2.1.0.zip",
+            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/xess/xess_v2.0.2.53_B6D2A108369FE3CD7FC82AF14DD8C60C.zip",
+            "release_notes": "",
+            "signature_subject": "Intel Corporation",
+            "channel": "stable",
+            "is_dev": false,
+            "min_driver": null,
+            "hash_algorithm": "md5"
+          },
+          {
+            "version": "2.0.2.68",
+            "version_packed": 562949953552452,
+            "filename": "libxess.dll",
+            "sha256": "d9e2aca10667501dced0e5b69b7d3ea5",
+            "size_bytes": 77795704,
+            "signed": true,
+            "released_at": "2025-10-17T14:23:43Z",
+            "source": "XeSS_SDK_2.1.1.zip",
+            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/xess/xess_v2.0.2.68_D9E2ACA10667501DCED0E5B69B7D3EA5.zip",
+            "release_notes": "",
+            "signature_subject": "Intel Corporation",
+            "channel": "stable",
+            "is_dev": false,
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "2.1.0",
@@ -367,7 +1174,8 @@
             "signature_subject": "Intel Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           },
           {
             "version": "2.1.1",
@@ -383,7 +1191,8 @@
             "signature_subject": "Intel Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           },
           {
             "version": "3.0.0",
@@ -399,7 +1208,8 @@
             "signature_subject": "Intel Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           },
           {
             "version": "3.0.1",
@@ -415,7 +1225,8 @@
             "signature_subject": "Intel Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           }
         ]
       },
@@ -436,7 +1247,59 @@
             "signature_subject": "Intel Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
+          },
+          {
+            "version": "2.0.1.41",
+            "version_packed": 562949953486889,
+            "filename": "libxess_dx11.dll",
+            "sha256": "155cc423a077a4f8435d3919f0f1da80",
+            "size_bytes": 147816,
+            "signed": true,
+            "released_at": "2025-03-12T17:49:26Z",
+            "source": "XeSS_SDK_2.0.1.zip",
+            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/xess_dx11/xess_dx11_v2.0.1.41_155CC423A077A4F8435D3919F0F1DA80.zip",
+            "release_notes": "",
+            "signature_subject": "Intel Corporation",
+            "channel": "stable",
+            "is_dev": false,
+            "min_driver": null,
+            "hash_algorithm": "md5"
+          },
+          {
+            "version": "2.0.2.53",
+            "version_packed": 562949953552437,
+            "filename": "libxess_dx11.dll",
+            "sha256": "c74e52a82017d654e017279d8f374544",
+            "size_bytes": 156024,
+            "signed": true,
+            "released_at": "2025-07-03T08:08:13Z",
+            "source": "XeSS_SDK_2.1.0.zip",
+            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/xess_dx11/xess_dx11_v2.0.2.53_C74E52A82017D654E017279D8F374544.zip",
+            "release_notes": "",
+            "signature_subject": "Intel Corporation",
+            "channel": "stable",
+            "is_dev": false,
+            "min_driver": null,
+            "hash_algorithm": "md5"
+          },
+          {
+            "version": "2.0.2.68",
+            "version_packed": 562949953552452,
+            "filename": "libxess_dx11.dll",
+            "sha256": "e04c7f44bc073d164cbf603215e96eaa",
+            "size_bytes": 156016,
+            "signed": true,
+            "released_at": "2025-10-17T14:23:44Z",
+            "source": "XeSS_SDK_2.1.1.zip",
+            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/xess_dx11/xess_dx11_v2.0.2.68_E04C7F44BC073D164CBF603215E96EAA.zip",
+            "release_notes": "",
+            "signature_subject": "Intel Corporation",
+            "channel": "stable",
+            "is_dev": false,
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "2.1.0",
@@ -452,7 +1315,8 @@
             "signature_subject": "Intel Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           },
           {
             "version": "2.1.1",
@@ -468,7 +1332,8 @@
             "signature_subject": "Intel Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           },
           {
             "version": "3.0.0",
@@ -484,7 +1349,8 @@
             "signature_subject": "Intel Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           },
           {
             "version": "3.0.1",
@@ -500,7 +1366,8 @@
             "signature_subject": "Intel Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           }
         ]
       }
@@ -523,7 +1390,8 @@
             "signature_subject": "Microsoft Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           },
           {
             "version": "1.0.2",
@@ -539,7 +1407,8 @@
             "signature_subject": "Microsoft Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           },
           {
             "version": "1.1.0",
@@ -555,7 +1424,8 @@
             "signature_subject": "Microsoft Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           },
           {
             "version": "1.1.1",
@@ -571,7 +1441,8 @@
             "signature_subject": "Microsoft Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           },
           {
             "version": "1.2.0",
@@ -587,7 +1458,8 @@
             "signature_subject": "Microsoft Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           },
           {
             "version": "1.2.1",
@@ -603,7 +1475,8 @@
             "signature_subject": "Microsoft Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           },
           {
             "version": "1.2.2",
@@ -619,7 +1492,8 @@
             "signature_subject": "Microsoft Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           },
           {
             "version": "1.2.3",
@@ -635,7 +1509,8 @@
             "signature_subject": "Microsoft Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           },
           {
             "version": "1.2.4",
@@ -651,7 +1526,8 @@
             "signature_subject": "Microsoft Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           },
           {
             "version": "1.3.0",
@@ -667,7 +1543,8 @@
             "signature_subject": "Microsoft Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           },
           {
             "version": "1.4.0-preview1-2603.504",
@@ -676,14 +1553,15 @@
             "sha256": "88e5e2f4eedbf0b604d7cecd724bb0c809d5f3479f00f0d138ec1006e354f0a4",
             "size_bytes": 192544,
             "signed": true,
-            "released_at": "2026-05-20T11:46:43.651756800Z",
+            "released_at": "2026-05-29T13:08:22.688417300Z",
             "source": "nuget:microsoft.direct3d.directstorage@1.4.0-preview1-2603.504",
             "cdn_url": "https://api.nuget.org/v3-flatcontainer/microsoft.direct3d.directstorage/1.4.0-preview1-2603.504/microsoft.direct3d.directstorage.1.4.0-preview1-2603.504.nupkg",
             "release_notes": null,
             "signature_subject": "Microsoft Corporation",
             "channel": "experimental",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           }
         ]
       },
@@ -704,7 +1582,8 @@
             "signature_subject": "Microsoft Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           },
           {
             "version": "1.0.2",
@@ -720,7 +1599,8 @@
             "signature_subject": "Microsoft Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           },
           {
             "version": "1.1.0",
@@ -736,7 +1616,8 @@
             "signature_subject": "Microsoft Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           },
           {
             "version": "1.1.1",
@@ -752,7 +1633,8 @@
             "signature_subject": "Microsoft Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           },
           {
             "version": "1.2.0",
@@ -768,7 +1650,8 @@
             "signature_subject": "Microsoft Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           },
           {
             "version": "1.2.1",
@@ -784,7 +1667,8 @@
             "signature_subject": "Microsoft Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           },
           {
             "version": "1.2.2",
@@ -800,7 +1684,8 @@
             "signature_subject": "Microsoft Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           },
           {
             "version": "1.2.3",
@@ -816,7 +1701,8 @@
             "signature_subject": "Microsoft Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           },
           {
             "version": "1.2.4",
@@ -832,7 +1718,8 @@
             "signature_subject": "Microsoft Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           },
           {
             "version": "1.3.0",
@@ -848,7 +1735,8 @@
             "signature_subject": "Microsoft Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           },
           {
             "version": "1.4.0-preview1-2603.504",
@@ -857,14 +1745,15 @@
             "sha256": "8b2f4be29a6cfd090c74e0110864f78a0b7386a4b1b3ba8aaaf9ffd11e69b293",
             "size_bytes": 2572832,
             "signed": true,
-            "released_at": "2026-05-20T11:46:43.651756800Z",
+            "released_at": "2026-05-29T13:08:22.688417300Z",
             "source": "nuget:microsoft.direct3d.directstorage@1.4.0-preview1-2603.504",
             "cdn_url": "https://api.nuget.org/v3-flatcontainer/microsoft.direct3d.directstorage/1.4.0-preview1-2603.504/microsoft.direct3d.directstorage.1.4.0-preview1-2603.504.nupkg",
             "release_notes": null,
             "signature_subject": "Microsoft Corporation",
             "channel": "experimental",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           }
         ]
       }
@@ -880,14 +1769,15 @@
             "sha256": "756c81decd8ab626058e8daaa08d9a19",
             "size_bytes": 12803624,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044981100Z",
+            "released_at": "2026-05-29T13:04:54.606135300Z",
             "source": "Microsoft Flight Simulator (via TechPowerUp)",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss_g/dlss_g_v1.0.1.0_756C81DECD8AB626058E8DAAA08D9A19.zip",
             "release_notes": "",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "1.0.2.0",
@@ -896,14 +1786,15 @@
             "sha256": "36931062a0b9227011885514914c7a3b",
             "size_bytes": 12799528,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044981900Z",
+            "released_at": "2026-05-29T13:04:54.606142200Z",
             "source": "Witcher 3 (via TechPowerUp)",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss_g/dlss_g_v1.0.2.0_36931062A0B9227011885514914C7A3B.zip",
             "release_notes": "",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "1.0.3.0",
@@ -912,14 +1803,15 @@
             "sha256": "9a44c28a5e5a915f884e2ed7dfc5d4b4",
             "size_bytes": 12799528,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044982500Z",
+            "released_at": "2026-05-29T13:04:54.606147600Z",
             "source": "Spiderman Remastered (via TechPowerUp)",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss_g/dlss_g_v1.0.3.0_9A44C28A5E5A915F884E2ED7DFC5D4B4.zip",
             "release_notes": "",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "1.0.4.0",
@@ -928,30 +1820,15 @@
             "sha256": "9bfac44640d2fa6659ac18369f9870f4",
             "size_bytes": 12876840,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044983100Z",
+            "released_at": "2026-05-29T13:04:54.606153800Z",
             "source": "Portal RTX (via TechPowerUp)",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss_g/dlss_g_v1.0.4.0_9BFAC44640D2FA6659AC18369F9870F4.zip",
             "release_notes": "",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
-          },
-          {
-            "version": "1.0.4.0",
-            "version_packed": 281474976972800,
-            "filename": "nvngx_dlssg.dll",
-            "sha256": "de3479e49e53a8ab4950f8c72a415239",
-            "size_bytes": 12876840,
-            "signed": true,
-            "released_at": "2026-05-20T11:44:57.044983800Z",
-            "source": "Portal RTX (via TechPowerUp)",
-            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss_g/dlss_g_v1.0.4.0_DE3479E49E53A8AB4950F8C72A415239.zip",
-            "release_notes": "",
-            "signature_subject": "NVIDIA Corporation",
-            "channel": "stable",
-            "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "1.0.5.0",
@@ -960,14 +1837,15 @@
             "sha256": "4f39303b168462a4f2ecf04fead1a9e8",
             "size_bytes": 12932648,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044986400Z",
+            "released_at": "2026-05-29T13:04:54.606164300Z",
             "source": "Hitman 3 (via TechPowerUp)",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss_g/dlss_g_v1.0.5.0_4F39303B168462A4F2ECF04FEAD1A9E8.zip",
             "release_notes": "",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "1.0.6.0",
@@ -976,14 +1854,15 @@
             "sha256": "f869fbd1ad307071cf7997b66c1e1e76",
             "size_bytes": 12936744,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044987100Z",
+            "released_at": "2026-05-29T13:04:54.606169200Z",
             "source": "Forza Horizon 5 (via TechPowerUp)",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss_g/dlss_g_v1.0.6.0_F869FBD1AD307071CF7997B66C1E1E76.zip",
             "release_notes": "",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "1.0.7.0",
@@ -992,14 +1871,15 @@
             "sha256": "bbaeb66b55bea5a97ef12b949af52bc0",
             "size_bytes": 12936744,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044987700Z",
+            "released_at": "2026-05-29T13:04:54.606174700Z",
             "source": "The Witcher 3 (via TechPowerUp)",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss_g/dlss_g_v1.0.7.0_BBAEB66B55BEA5A97EF12B949AF52BC0.zip",
             "release_notes": "",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "3.1.1.0",
@@ -1008,14 +1888,15 @@
             "sha256": "3209de901666436042f4ce59344df47f",
             "size_bytes": 13181992,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044990300Z",
+            "released_at": "2026-05-29T13:04:54.606180Z",
             "source": "Cyberpunk Overdrive (via TechPowerUp)",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss_g/dlss_g_v3.1.1.0_3209DE901666436042F4CE59344DF47F.zip",
             "release_notes": "",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "3.1.11.0",
@@ -1024,14 +1905,15 @@
             "sha256": "2a3feb039ffb9ea70dc690b21e918417",
             "size_bytes": 12997672,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044991100Z",
+            "released_at": "2026-05-29T13:04:54.606185Z",
             "source": "Forza Horizon 5 (via TechPowerUp)",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss_g/dlss_g_v3.1.11.0_2A3FEB039FFB9EA70DC690B21E918417.zip",
             "release_notes": "",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "3.1.12.0",
@@ -1040,14 +1922,15 @@
             "sha256": "76f8be4e38a0789bce0dcde2cea9a324",
             "size_bytes": 13004328,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044991600Z",
+            "released_at": "2026-05-29T13:04:54.606190500Z",
             "source": "Diablo IV Beta (via TechPowerUp)",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss_g/dlss_g_v3.1.12.0_76F8BE4E38A0789BCE0DCDE2CEA9A324.zip",
             "release_notes": "",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "3.1.13.0",
@@ -1056,14 +1939,15 @@
             "sha256": "ef9b5fa50410a45a13014cb55aae950d",
             "size_bytes": 13001768,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044992300Z",
+            "released_at": "2026-05-29T13:04:54.606195600Z",
             "source": "Diablo IV (via TechPowerUp)",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss_g/dlss_g_v3.1.13.0_EF9B5FA50410A45A13014CB55AAE950D.zip",
             "release_notes": "",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "3.1.30.0",
@@ -1072,14 +1956,15 @@
             "sha256": "8363e2ac2e3e512ac5ab2d364aa4c245",
             "size_bytes": 12569128,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044992900Z",
+            "released_at": "2026-05-29T13:04:54.606201100Z",
             "source": "Desordre (via TechPowerUp)",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss_g/dlss_g_v3.1.30.0_8363E2AC2E3E512AC5AB2D364AA4C245.zip",
             "release_notes": "CL 33088933",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "3.5.0.0",
@@ -1088,14 +1973,15 @@
             "sha256": "1b21da1d91ab05b83625729d0b683797",
             "size_bytes": 12582456,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044993500Z",
+            "released_at": "2026-05-29T13:04:54.606206600Z",
             "source": "NVIDIA UE5 Plugin (via TechPowerUp)",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss_g/dlss_g_v3.5.0.0_1B21DA1D91AB05B83625729D0B683797.zip",
             "release_notes": "CL 33190482",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "3.5.10.0",
@@ -1104,14 +1990,15 @@
             "sha256": "4de45236c2aa62cd25f1d670e0c5deaf",
             "size_bytes": 11698216,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044994200Z",
+            "released_at": "2026-05-29T13:04:54.606211800Z",
             "source": "NVIDIA UE5 Plugin (via TechPowerUp)",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss_g/dlss_g_v3.5.10.0_4DE45236C2AA62CD25F1D670E0C5DEAF.zip",
             "release_notes": "CL 33396148",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "3.6.0.0",
@@ -1120,14 +2007,15 @@
             "sha256": "67453779383c58139267a9b15839bb78",
             "size_bytes": 11727912,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044994800Z",
+            "released_at": "2026-05-29T13:04:54.606217200Z",
             "source": "Naraka Bladepoint (via TechPowerUp)",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss_g/dlss_g_v3.6.0.0_67453779383C58139267A9B15839BB78.zip",
             "release_notes": "CL 33629598",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "3.7.0.0",
@@ -1136,14 +2024,15 @@
             "sha256": "ee98cd63c16316882c3e5d56e51fc680",
             "size_bytes": 11778088,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044995300Z",
+            "released_at": "2026-05-29T13:04:54.606223200Z",
             "source": "NVIDIA SDK (via TechPowerUp)",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss_g/dlss_g_v3.7.0.0_EE98CD63C16316882C3E5D56E51FC680.zip",
             "release_notes": "CL 33904986",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "3.7.1.0",
@@ -1152,14 +2041,15 @@
             "sha256": "b16e50dd7c60d254aab782278c2ef73c",
             "size_bytes": 11779112,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044995800Z",
+            "released_at": "2026-05-29T13:04:54.606228500Z",
             "source": "Senua's Saga: Hellblade II (via TechPowerUp)",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss_g/dlss_g_v3.7.1.0_B16E50DD7C60D254AAB782278C2EF73C.zip",
             "release_notes": "CL 34181968",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "3.7.10.0",
@@ -1168,14 +2058,15 @@
             "sha256": "69e9f9dc32d0aef4e7c986e2339a0e52",
             "size_bytes": 9477688,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.045002Z",
+            "released_at": "2026-05-29T13:04:54.606235100Z",
             "source": "Diablo IV (via TechPowerUp)",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss_g/dlss_g_v3.7.10.0_69E9F9DC32D0AEF4E7C986E2339A0E52.zip",
             "release_notes": "CL 34270846",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "3.8.1.0",
@@ -1184,14 +2075,15 @@
             "sha256": "db7b5c2c8686e1586cc56d5bdb64965c",
             "size_bytes": 9283120,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.045007400Z",
+            "released_at": "2026-05-29T13:04:54.606241Z",
             "source": "Diablo IV (via TechPowerUp)",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss_g/dlss_g_v3.8.1.0_DB7B5C2C8686E1586CC56D5BDB64965C.zip",
             "release_notes": "CL 35007158",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "310.1.0.0",
@@ -1200,14 +2092,15 @@
             "sha256": "11ecc4bf7fe5cefcf4a737e95b6752ff",
             "size_bytes": 7607336,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.045008100Z",
+            "released_at": "2026-05-29T13:04:54.606246Z",
             "source": "Cyberpunk 2077 2.21",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss_g/dlss_g_v310.1.0.0_11ECC4BF7FE5CEFCF4A737E95B6752FF.zip",
             "release_notes": "CL 35304964",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "310.2.0.0",
@@ -1216,14 +2109,15 @@
             "sha256": "26c2eafe046cdd403a1850f71186595c",
             "size_bytes": 7595560,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.045008700Z",
+            "released_at": "2026-05-29T13:04:54.606251400Z",
             "source": "NVIDIA Driver",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss_g/dlss_g_v310.2.0.0_26C2EAFE046CDD403A1850F71186595C.zip",
             "release_notes": "CL 35440459",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "310.2.1.0",
@@ -1232,14 +2126,15 @@
             "sha256": "96cb06ff5a84e4e90591973bf99a7d45",
             "size_bytes": 7597104,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.045009200Z",
+            "released_at": "2026-05-29T13:04:54.606257300Z",
             "source": "beeradmoore/dlss-swapper",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss_g/dlss_g_v310.2.1.0_96CB06FF5A84E4E90591973BF99A7D45.zip",
             "release_notes": "CL 35516211",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "310.3.0.0",
@@ -1255,23 +2150,8 @@
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
-          },
-          {
-            "version": "310.3.0.0",
-            "version_packed": 87257255665205248,
-            "filename": "nvngx_dlssg.dll",
-            "sha256": "90765c321f623237e562fd4232a98b93",
-            "size_bytes": 7933496,
-            "signed": true,
-            "released_at": "2025-05-08T22:32:13Z",
-            "source": "streamline-sdk-v2.8.0.zip",
-            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss_g/dlss_g_v310.3.0.0_90765C321F623237E562FD4232A98B93.zip",
-            "release_notes": "CL 35956306",
-            "signature_subject": "NVIDIA Corporation",
-            "channel": "stable",
-            "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "310.4.0.0",
@@ -1287,7 +2167,8 @@
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "310.5.0.0",
@@ -1303,23 +2184,8 @@
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
-          },
-          {
-            "version": "310.5.0.0",
-            "version_packed": 87257264255139840,
-            "filename": "nvngx_dlssg.dll",
-            "sha256": "27d59d09717e4a9d96d295d051595bde",
-            "size_bytes": 7955568,
-            "signed": true,
-            "released_at": "2025-12-01T19:48:35Z",
-            "source": "streamline-sdk-v2.10.0.zip",
-            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss_g/dlss_g_v310.5.0.0_27D59D09717E4A9D96D295D051595BDE.zip",
-            "release_notes": "CL 36971775",
-            "signature_subject": "NVIDIA Corporation",
-            "channel": "stable",
-            "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "310.5.2.0",
@@ -1335,7 +2201,8 @@
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "310.5.3.0",
@@ -1351,23 +2218,8 @@
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
-          },
-          {
-            "version": "310.5.3.0",
-            "version_packed": 87257264255336448,
-            "filename": "nvngx_dlssg.dll",
-            "sha256": "9f7a3097f41a4e5963eecb3001185ef9",
-            "size_bytes": 7955568,
-            "signed": true,
-            "released_at": "2026-01-21T18:44:36Z",
-            "source": "DLSS-310.5.3.zip",
-            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss_g/dlss_g_v310.5.3.0_9F7A3097F41A4E5963EECB3001185EF9.zip",
-            "release_notes": "CL 37207741",
-            "signature_subject": "NVIDIA Corporation",
-            "channel": "stable",
-            "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "310.6.0.0",
@@ -1383,7 +2235,8 @@
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           }
         ]
       },
@@ -1397,46 +2250,15 @@
             "sha256": "cd523b592b9471b43d0e85d9629a6ae4",
             "size_bytes": 70025768,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044956900Z",
+            "released_at": "2026-05-29T13:04:54.606005100Z",
             "source": "Cyberpunk 2077 Phantom Liberty (via TechPowerUp)",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss_d/dlss_d_v3.5.0.0_CD523B592B9471B43D0E85D9629A6AE4.zip",
             "release_notes": "CL 33263601",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
-          },
-          {
-            "version": "3.5.0.0",
-            "version_packed": 844446404968448,
-            "filename": "nvngx_dlssd.dll",
-            "sha256": "3ed68c9456dc83bdf66b13d1a9c66f18",
-            "size_bytes": 70026792,
-            "signed": true,
-            "released_at": "2026-05-20T11:44:57.044958200Z",
-            "source": "Cyberpunk 2077 Phantom Liberty 2.01 (via TechPowerUp)",
-            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss_d/dlss_d_v3.5.0.0_3ED68C9456DC83BDF66B13D1A9C66F18.zip",
-            "release_notes": "CL 33284283",
-            "signature_subject": "NVIDIA Corporation",
-            "channel": "stable",
-            "is_dev": false,
-            "min_driver": null
-          },
-          {
-            "version": "3.5.0.0",
-            "version_packed": 844446404968448,
-            "filename": "nvngx_dlssd.dll",
-            "sha256": "625907de06a912414fdb8444c91b262c",
-            "size_bytes": 71719976,
-            "signed": true,
-            "released_at": "2026-05-20T11:44:57.044959600Z",
-            "source": "Alan Wake 2 (via TechPowerUp)",
-            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss_d/dlss_d_v3.5.0.0_625907DE06A912414FDB8444C91B262C.zip",
-            "release_notes": "CL 33367307",
-            "signature_subject": "NVIDIA Corporation",
-            "channel": "stable",
-            "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "3.5.10.0",
@@ -1445,14 +2267,15 @@
             "sha256": "ce8b65654872a30dc6b771aae8ca98ad",
             "size_bytes": 71894568,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044960500Z",
+            "released_at": "2026-05-29T13:04:54.606026600Z",
             "source": "Alan Wake  (via TechPowerUp)2",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss_d/dlss_d_v3.5.10.0_CE8B65654872A30DC6B771AAE8CA98AD.zip",
             "release_notes": "CL 33457773",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "3.7.0.0",
@@ -1461,14 +2284,15 @@
             "sha256": "622fcb76d37a2d73811756e891cc80e8",
             "size_bytes": 38426680,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044961100Z",
+            "released_at": "2026-05-29T13:04:54.606031800Z",
             "source": "Portal with RTX (via TechPowerUp)",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss_d/dlss_d_v3.7.0.0_622FCB76D37A2D73811756E891CC80E8.zip",
             "release_notes": "CL 33812812",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "3.7.10.0",
@@ -1477,14 +2301,15 @@
             "sha256": "fdfac845ab72d509a24ea2c16a1619c4",
             "size_bytes": 43790888,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044961700Z",
+            "released_at": "2026-05-29T13:04:54.606036700Z",
             "source": "The First Descendant (via TechPowerUp)",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss_d/dlss_d_v3.7.10.0_FDFAC845AB72D509A24EA2C16A1619C4.zip",
             "release_notes": "CL 34201261",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "3.7.20.0",
@@ -1493,14 +2318,15 @@
             "sha256": "f2f968b15cd295d13d571d0d18170e10",
             "size_bytes": 44006968,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044967700Z",
+            "released_at": "2026-05-29T13:04:54.606041700Z",
             "source": "Star Wars Outlaws (via TechPowerUp)",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss_d/dlss_d_v3.7.20.0_F2F968B15CD295D13D571D0D18170E10.zip",
             "release_notes": "CL 34733527",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "310.1.0.0",
@@ -1509,14 +2335,15 @@
             "sha256": "10c793f0b14efedc595838bb8a09fd28",
             "size_bytes": 65630248,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044968200Z",
+            "released_at": "2026-05-29T13:04:54.606047200Z",
             "source": "Cyberpunk 2077 2.21",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss_d/dlss_d_v310.1.0.0_10C793F0B14EFEDC595838BB8A09FD28.zip",
             "release_notes": "CL 35269843",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "310.2.0.0",
@@ -1525,14 +2352,15 @@
             "sha256": "e6081b848ea68880db8adc83cdfb15dc",
             "size_bytes": 72957992,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044968900Z",
+            "released_at": "2026-05-29T13:04:54.606052Z",
             "source": "NVIDIA Driver",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss_d/dlss_d_v310.2.0.0_E6081B848EA68880DB8ADC83CDFB15DC.zip",
             "release_notes": "CL 35440459",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "310.2.1.0",
@@ -1548,7 +2376,8 @@
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "310.3.0.0",
@@ -1564,23 +2393,8 @@
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
-          },
-          {
-            "version": "310.3.0.0",
-            "version_packed": 87257255665205248,
-            "filename": "nvngx_dlssd.dll",
-            "sha256": "95b33733575ab019b4a864eaf4423f2f",
-            "size_bytes": 83528224,
-            "signed": true,
-            "released_at": "2025-06-06T23:44:07Z",
-            "source": "streamline-sdk-v2.8.0.zip",
-            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss_d/dlss_d_v310.3.0.0_95B33733575AB019B4A864EAF4423F2F.zip",
-            "release_notes": "CL 36091688",
-            "signature_subject": "NVIDIA Corporation",
-            "channel": "stable",
-            "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "310.4.0.0",
@@ -1596,7 +2410,8 @@
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "310.5.0.0",
@@ -1612,23 +2427,8 @@
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
-          },
-          {
-            "version": "310.5.0.0",
-            "version_packed": 87257264255139840,
-            "filename": "nvngx_dlssd.dll",
-            "sha256": "6026c85b9485cb40ed07763d9a411874",
-            "size_bytes": 39383664,
-            "signed": true,
-            "released_at": "2025-11-29T21:27:48Z",
-            "source": "streamline-sdk-v2.10.0.zip",
-            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss_d/dlss_d_v310.5.0.0_6026C85B9485CB40ED07763D9A411874.zip",
-            "release_notes": "CL 36965356",
-            "signature_subject": "NVIDIA Corporation",
-            "channel": "stable",
-            "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "310.5.2.0",
@@ -1644,7 +2444,8 @@
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "310.5.3.0",
@@ -1660,23 +2461,8 @@
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
-          },
-          {
-            "version": "310.5.3.0",
-            "version_packed": 87257264255336448,
-            "filename": "nvngx_dlssd.dll",
-            "sha256": "34e9f4e55c413b4a275b6b134fc71401",
-            "size_bytes": 39390320,
-            "signed": true,
-            "released_at": "2026-01-21T20:48:18Z",
-            "source": "DLSS-310.5.3.zip",
-            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss_d/dlss_d_v310.5.3.0_34E9F4E55C413B4A275B6B134FC71401.zip",
-            "release_notes": "CL 37208806",
-            "signature_subject": "NVIDIA Corporation",
-            "channel": "stable",
-            "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "310.6.0.0",
@@ -1692,7 +2478,8 @@
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           }
         ]
       },
@@ -1713,7 +2500,8 @@
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "1.0.9.0",
@@ -1729,7 +2517,8 @@
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "1.0.11.0",
@@ -1745,7 +2534,8 @@
             "signature_subject": null,
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "1.0.13.0",
@@ -1761,7 +2551,8 @@
             "signature_subject": null,
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "1.0.17.0",
@@ -1777,7 +2568,8 @@
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "1.1.6.0",
@@ -1786,14 +2578,15 @@
             "sha256": "5e7b70421ece9dcca09260a38e4e9172",
             "size_bytes": 5564400,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044795800Z",
+            "released_at": "2026-05-29T13:04:54.605373700Z",
             "source": "Anthem (via TechPowerUp)",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v1.1.6.0_5E7B70421ECE9DCCA09260A38E4E9172.zip",
             "release_notes": "CL 26519365",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "1.1.13.0",
@@ -1802,14 +2595,15 @@
             "sha256": "5ee9de2ae9d76a32c727c1b6ff21e0fa",
             "size_bytes": 5646688,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044796600Z",
+            "released_at": "2026-05-29T13:04:54.605391300Z",
             "source": "Monster Hunter World (via TechPowerUp)",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v1.1.13.0_5EE9DE2AE9D76A32C727C1B6FF21E0FA.zip",
             "release_notes": "CL 27720038",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "1.2.14.0",
@@ -1818,14 +2612,15 @@
             "sha256": "899ebc3ac0637125d7578d87fef42970",
             "size_bytes": 5771120,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044797500Z",
+            "released_at": "2026-05-29T13:04:54.605396900Z",
             "source": "Sword of Legends Online (via TechPowerUp)",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v1.2.14.0_899EBC3AC0637125D7578D87FEF42970.zip",
             "release_notes": "CL 26937653",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "1.3.2.0",
@@ -1834,14 +2629,15 @@
             "sha256": "b92191e7a0b994a297ff8b2012eba529",
             "size_bytes": 5737784,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044798500Z",
+            "released_at": "2026-05-29T13:04:54.605401900Z",
             "source": "Control (via TechPowerUp)",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v1.3.2.0_B92191E7A0B994A297FF8B2012EBA529.zip",
             "release_notes": "CL 27036528",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "2.0.34.0",
@@ -1850,14 +2646,15 @@
             "sha256": "d30c27ca983f9792512c6f5874c60b2e",
             "size_bytes": 6344168,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044799300Z",
+            "released_at": "2026-05-29T13:04:54.605406700Z",
             "source": "Control (via TechPowerUp)",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v2.0.34.0_D30C27CA983F9792512C6F5874C60B2E.zip",
             "release_notes": "CL 28581698",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "2.0.38.0",
@@ -1866,14 +2663,15 @@
             "sha256": "acb8b647ba19dcc638dd50ff621f7801",
             "size_bytes": 6290920,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044800100Z",
+            "released_at": "2026-05-29T13:04:54.605413500Z",
             "source": "F1 2020 (via TechPowerUp)",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v2.0.38.0_ACB8B647BA19DCC638DD50FF621F7801.zip",
             "release_notes": "CL 28843986",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "2.1.16.0",
@@ -1882,14 +2680,15 @@
             "sha256": "1a30408f7ad1bdaec0ef81b5e2313c4e",
             "size_bytes": 11562296,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044800800Z",
+            "released_at": "2026-05-29T13:04:54.605418600Z",
             "source": "Minecraft Bedrock Edition (via TechPowerUp)",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v2.1.16.0_1A30408F7AD1BDAEC0EF81B5E2313C4E.zip",
             "release_notes": "CL 28844053",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "2.1.19.0",
@@ -1898,14 +2697,15 @@
             "sha256": "0a82a657e294219b6dc8875897a2cced",
             "size_bytes": 11731432,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044801500Z",
+            "released_at": "2026-05-29T13:04:54.605422900Z",
             "source": "Death Stranding (via TechPowerUp)",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v2.1.19.0_0A82A657E294219B6DC8875897A2CCED.zip",
             "release_notes": "CL 28939566",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "2.1.24.0",
@@ -1914,14 +2714,15 @@
             "sha256": "5af4c12dde0e9dfa54ed76fe9e4db647",
             "size_bytes": 11772216,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044801900Z",
+            "released_at": "2026-05-29T13:04:54.605427Z",
             "source": "TechPowerUp",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v2.1.24.0_5AF4C12DDE0E9DFA54ED76FE9E4DB647.zip",
             "release_notes": "CL 28996384",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "2.1.25.0",
@@ -1930,14 +2731,15 @@
             "sha256": "18b651a8df80464512ed19fa9859b585",
             "size_bytes": 11773928,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044802500Z",
+            "released_at": "2026-05-29T13:04:54.605431300Z",
             "source": "Control (via TechPowerUp)",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v2.1.25.0_18B651A8DF80464512ED19FA9859B585.zip",
             "release_notes": "CL 29009287",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "2.1.28.0",
@@ -1946,14 +2748,15 @@
             "sha256": "f92355a0a6376447c7d0fc0a3cfc2f43",
             "size_bytes": 11773416,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044803200Z",
+            "released_at": "2026-05-29T13:04:54.605435700Z",
             "source": "Bright Memory Infinite Benchmark (via TechPowerUp)",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v2.1.28.0_F92355A0A6376447C7D0FC0A3CFC2F43.zip",
             "release_notes": "CL 29017803",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "2.1.29.0",
@@ -1969,7 +2772,8 @@
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "2.1.31.0",
@@ -1978,14 +2782,15 @@
             "sha256": "3e68d270cef16027da3ff3ba3b974537",
             "size_bytes": 11773752,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044809300Z",
+            "released_at": "2026-05-29T13:04:54.605445300Z",
             "source": "Watch Dogs Legion (via TechPowerUp)",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v2.1.31.0_3E68D270CEF16027DA3FF3BA3B974537.zip",
             "release_notes": "CL 29083287",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "2.1.35.0",
@@ -1994,14 +2799,15 @@
             "sha256": "fb72213cf0f3cf103a16cfe7d930f707",
             "size_bytes": 11784504,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044810200Z",
+            "released_at": "2026-05-29T13:04:54.605450100Z",
             "source": "TechPowerUp",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v2.1.35.0_FB72213CF0F3CF103A16CFE7D930F707.zip",
             "release_notes": "CL 29167882",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "2.1.39.0",
@@ -2010,14 +2816,15 @@
             "sha256": "6cbf57c2d08d775808aef61c9671db5b",
             "size_bytes": 11887416,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044811Z",
+            "released_at": "2026-05-29T13:04:54.605456900Z",
             "source": "Cyberpunk 2077 (via TechPowerUp)",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v2.1.39.0_6CBF57C2D08D775808AEF61C9671DB5B.zip",
             "release_notes": "CL 29218479",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "2.1.40.0",
@@ -2026,14 +2833,15 @@
             "sha256": "8e3ac0a089abe2b319e2926b38db0ff9",
             "size_bytes": 11888616,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044811800Z",
+            "released_at": "2026-05-29T13:04:54.605461900Z",
             "source": "TechPowerUp",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v2.1.40.0_8E3AC0A089ABE2B319E2926B38DB0FF9.zip",
             "release_notes": "CL 29272686",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "2.1.50.0",
@@ -2042,14 +2850,15 @@
             "sha256": "6672c90b5afef2153259f84929364b2a",
             "size_bytes": 13758192,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044812500Z",
+            "released_at": "2026-05-29T13:04:54.605466400Z",
             "source": "System Shock Demo (via TechPowerUp)",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v2.1.50.0_6672C90B5AFEF2153259F84929364B2A.zip",
             "release_notes": "CL 29518444",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "2.1.51.0",
@@ -2058,14 +2867,15 @@
             "sha256": "4950c49d5e337f3146bcd51a26ab8cc6",
             "size_bytes": 13758192,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044813200Z",
+            "released_at": "2026-05-29T13:04:54.605471200Z",
             "source": "F1 2020 (via TechPowerUp)",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v2.1.51.0_4950C49D5E337F3146BCD51A26AB8CC6.zip",
             "release_notes": "CL 29469881",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "2.1.52.0",
@@ -2074,14 +2884,15 @@
             "sha256": "430ee0d531f4b89a7cc65524ccc5d912",
             "size_bytes": 13758192,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044813800Z",
+            "released_at": "2026-05-29T13:04:54.605476300Z",
             "source": "Fortnite (via TechPowerUp)",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v2.1.52.0_430EE0D531F4B89A7CC65524CCC5D912.zip",
             "release_notes": "CL 29573341",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "2.1.53.0",
@@ -2090,14 +2901,15 @@
             "sha256": "e696265c702cc90cbcf4974faeebb9f4",
             "size_bytes": 13756768,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044814400Z",
+            "released_at": "2026-05-29T13:04:54.605483600Z",
             "source": "TechPowerUp",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v2.1.53.0_E696265C702CC90CBCF4974FAEEBB9F4.zip",
             "release_notes": "CL 29608517",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "2.1.55.0",
@@ -2106,14 +2918,15 @@
             "sha256": "72c53fe8cf9114143680f3bc56cea1a7",
             "size_bytes": 13805424,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044815Z",
+            "released_at": "2026-05-29T13:04:54.605489200Z",
             "source": "Metro Exodus Enhanced (via TechPowerUp)",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v2.1.55.0_72C53FE8CF9114143680F3BC56CEA1A7.zip",
             "release_notes": "CL 29708548",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "2.1.58.0",
@@ -2122,14 +2935,15 @@
             "sha256": "2b1b8d32e4866e7d7734acf2bcc830b1",
             "size_bytes": 14905712,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044815800Z",
+            "released_at": "2026-05-29T13:04:54.605494500Z",
             "source": "COD MW (via TechPowerUp)",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v2.1.58.0_2B1B8D32E4866E7D7734ACF2BCC830B1.zip",
             "release_notes": "CL 29760797",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "2.1.62.0",
@@ -2138,14 +2952,15 @@
             "sha256": "ecf487bc067ed07b90a3452db0203655",
             "size_bytes": 14904688,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044816500Z",
+            "released_at": "2026-05-29T13:04:54.605499800Z",
             "source": "TechPowerUp",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v2.1.62.0_ECF487BC067ED07B90A3452DB0203655.zip",
             "release_notes": "CL 29884341",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "2.1.63.0",
@@ -2154,14 +2969,15 @@
             "sha256": "262b728f1692e2550cf1cc9a41681a59",
             "size_bytes": 14904688,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044817100Z",
+            "released_at": "2026-05-29T13:04:54.605504700Z",
             "source": "No Man's Sky (via TechPowerUp)",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v2.1.63.0_262B728F1692E2550CF1CC9A41681A59.zip",
             "release_notes": "CL 29912254",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "2.1.66.0",
@@ -2170,14 +2986,15 @@
             "sha256": "1a81316e57aba6c9c46fae53936c3933",
             "size_bytes": 14908784,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044817600Z",
+            "released_at": "2026-05-29T13:04:54.605509500Z",
             "source": "Doom Eternal (via TechPowerUp)",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v2.1.66.0_1A81316E57ABA6C9C46FAE53936C3933.zip",
             "release_notes": "CL 30017708",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "2.2.6.0",
@@ -2186,14 +3003,15 @@
             "sha256": "52219034574426fef16b19d2495648c0",
             "size_bytes": 14444400,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044819400Z",
+            "released_at": "2026-05-29T13:04:54.605514700Z",
             "source": "Rainbow Six Siege (via TechPowerUp)",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v2.2.6.0_52219034574426FEF16B19D2495648C0.zip",
             "release_notes": "CL 29980697",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "2.2.9.0",
@@ -2202,14 +3020,15 @@
             "sha256": "5b9b917af8fb72d63f073a0e0f621d94",
             "size_bytes": 14445936,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044820100Z",
+            "released_at": "2026-05-29T13:04:54.605519200Z",
             "source": "F1 2021 (via TechPowerUp)",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v2.2.9.0_5B9B917AF8FB72D63F073A0E0F621D94.zip",
             "release_notes": "CL 30084522",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "2.2.10.0",
@@ -2218,14 +3037,15 @@
             "sha256": "062215c828802b9202ada4ca4d3619b4",
             "size_bytes": 14447984,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044820700Z",
+            "released_at": "2026-05-29T13:04:54.605524100Z",
             "source": "Rust (via TechPowerUp)",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v2.2.10.0_062215C828802B9202ADA4CA4D3619B4.zip",
             "release_notes": "CL 30115323",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "2.2.11.0",
@@ -2234,14 +3054,15 @@
             "sha256": "65345301ba1a985aa9ac3ea6d671abdf",
             "size_bytes": 14449864,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044823100Z",
+            "released_at": "2026-05-29T13:04:54.605529400Z",
             "source": "No Man's Sky (via TechPowerUp)",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v2.2.11.0_65345301BA1A985AA9AC3EA6D671ABDF.zip",
             "release_notes": "CL 30183294",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "2.2.14.0",
@@ -2250,14 +3071,15 @@
             "sha256": "110f5ca0453c6f3901fd148ea5cc7650",
             "size_bytes": 14449872,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044823900Z",
+            "released_at": "2026-05-29T13:04:54.605535800Z",
             "source": "Call of Duty Warzone (via TechPowerUp)",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v2.2.14.0_110F5CA0453C6F3901FD148EA5CC7650.zip",
             "release_notes": "CL 30231549",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "2.2.15.0",
@@ -2266,14 +3088,15 @@
             "sha256": "c9dcdcd97e19529a7c89432693c8ec0c",
             "size_bytes": 14450376,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044824500Z",
+            "released_at": "2026-05-29T13:04:54.605541300Z",
             "source": "Marvel Avengers (via TechPowerUp)",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v2.2.15.0_C9DCDCD97E19529A7C89432693C8EC0C.zip",
             "release_notes": "CL 30254073",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "2.2.16.0",
@@ -2282,30 +3105,15 @@
             "sha256": "8fed151aa1b7975a1e5968b82df4e918",
             "size_bytes": 14448328,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044825Z",
+            "released_at": "2026-05-29T13:04:54.605546400Z",
             "source": "DLSS-2.2.1.zip",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v2.2.16.0_8FED151AA1B7975A1E5968B82DF4E918.zip",
             "release_notes": "CL 30278952",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
-          },
-          {
-            "version": "2.2.16.0",
-            "version_packed": 562958544404480,
-            "filename": "nvngx_dlss.dll",
-            "sha256": "ad5efa68fa353d1f9d4c0c3acbba85c8",
-            "size_bytes": 14673608,
-            "signed": true,
-            "released_at": "2026-05-20T11:44:57.044825500Z",
-            "source": "DLSS-2.2.1.zip",
-            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v2.2.16.0_AD5EFA68FA353D1F9D4C0C3ACBBA85C8.zip",
-            "release_notes": "CL 30278952",
-            "signature_subject": "NVIDIA Corporation",
-            "channel": "stable",
-            "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "2.2.18.0",
@@ -2314,46 +3122,15 @@
             "sha256": "77a75b96dd2d36a4a291f3939d59c221",
             "size_bytes": 14450896,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044828500Z",
+            "released_at": "2026-05-29T13:04:54.605556100Z",
             "source": "UE5 (via TechPowerUp)",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v2.2.18.0_77A75B96DD2D36A4A291F3939D59C221.zip",
             "release_notes": "CL 30305775",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
-          },
-          {
-            "version": "2.2.18.0",
-            "version_packed": 562958544535552,
-            "filename": "nvngx_dlss.dll",
-            "sha256": "b2b6fae8936719cf81d6b5577f257c40",
-            "size_bytes": 14452944,
-            "signed": true,
-            "released_at": "2021-09-21T01:32:44Z",
-            "source": "NVIDIA - Experimental DLSS Models",
-            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v2.2.18.0_B2B6FAE8936719CF81D6B5577F257C40.zip",
-            "release_notes": "CL 30439076",
-            "signature_subject": "NVIDIA Corporation",
-            "channel": "experimental",
-            "is_dev": false,
-            "min_driver": null
-          },
-          {
-            "version": "2.2.18.0",
-            "version_packed": 562958544535552,
-            "filename": "nvngx_dlss.dll",
-            "sha256": "cd71ee48b994ac254dff5dec20828be7",
-            "size_bytes": 14452944,
-            "signed": true,
-            "released_at": "2026-05-20T11:44:57.044830200Z",
-            "source": "NVIDIA - Experimental DLSS Models",
-            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v2.2.18.0_CD71EE48B994AC254DFF5DEC20828BE7.zip",
-            "release_notes": "CL 30439076",
-            "signature_subject": "NVIDIA Corporation",
-            "channel": "experimental",
-            "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "2.3.0.0",
@@ -2362,30 +3139,15 @@
             "sha256": "7bbbb70f34fc4f2977ba442ee5fc37ac",
             "size_bytes": 14452936,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044830700Z",
+            "released_at": "2026-05-29T13:04:54.605580700Z",
             "source": "DLSS-2.3.0.zip",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v2.3.0.0_7BBBB70F34FC4F2977BA442EE5FC37AC.zip",
             "release_notes": "CL 30447826",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
-          },
-          {
-            "version": "2.3.0.0",
-            "version_packed": 562962838323200,
-            "filename": "nvngx_dlss.dll",
-            "sha256": "90b46302dc96fc3d38ba26040daecfc3",
-            "size_bytes": 14677704,
-            "signed": true,
-            "released_at": "2026-05-20T11:44:57.044831300Z",
-            "source": "DLSS-2.3.0.zip",
-            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v2.3.0.0_90B46302DC96FC3D38BA26040DAECFC3.zip",
-            "release_notes": "CL 30447826",
-            "signature_subject": "NVIDIA Corporation",
-            "channel": "stable",
-            "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "2.3.1.0",
@@ -2394,30 +3156,15 @@
             "sha256": "0fc1727ad4a52c29e2897567008b3407",
             "size_bytes": 14452944,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044831900Z",
+            "released_at": "2026-05-29T13:04:54.605592900Z",
             "source": "DLSS-2.3.1.zip",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v2.3.1.0_0FC1727AD4A52C29E2897567008B3407.zip",
             "release_notes": "CL 30473807",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
-          },
-          {
-            "version": "2.3.1.0",
-            "version_packed": 562962838388736,
-            "filename": "nvngx_dlss.dll",
-            "sha256": "93b5f0e7784860ca4c69deadce577561",
-            "size_bytes": 14677712,
-            "signed": true,
-            "released_at": "2026-05-20T11:44:57.044832400Z",
-            "source": "DLSS-2.3.1.zip",
-            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v2.3.1.0_93B5F0E7784860CA4C69DEADCE577561.zip",
-            "release_notes": "CL 30473807",
-            "signature_subject": "NVIDIA Corporation",
-            "channel": "stable",
-            "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "2.3.2.0",
@@ -2426,14 +3173,15 @@
             "sha256": "d62b6857f2f874e3892b30abce3dc603",
             "size_bytes": 14461648,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044832800Z",
+            "released_at": "2026-05-29T13:04:54.605602300Z",
             "source": "Sword and Fairy 7 (via TechPowerUp)",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v2.3.2.0_D62B6857F2F874E3892B30ABCE3DC603.zip",
             "release_notes": "CL 30482926",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "2.3.3.0",
@@ -2442,14 +3190,15 @@
             "sha256": "229dd563c5a7cfe67a927c06333249da",
             "size_bytes": 14462152,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044833300Z",
+            "released_at": "2026-05-29T13:04:54.605606900Z",
             "source": "Swords of Legends Online (via TechPowerUp)",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v2.3.3.0_229DD563C5A7CFE67A927C06333249DA.zip",
             "release_notes": "CL 30520575",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "2.3.4.0",
@@ -2458,14 +3207,15 @@
             "sha256": "49b252e0f803a01c0cf6964ed4b16ad8",
             "size_bytes": 14464712,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044834Z",
+            "released_at": "2026-05-29T13:04:54.605611700Z",
             "source": "Jurassic World Evolution 2 (via TechPowerUp)",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v2.3.4.0_49B252E0F803A01C0CF6964ED4B16AD8.zip",
             "release_notes": "CL 30584640",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "2.3.5.0",
@@ -2474,14 +3224,15 @@
             "sha256": "f59a89ca2150f107a1d9de4ca8ca8ddc",
             "size_bytes": 14467280,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044834500Z",
+            "released_at": "2026-05-29T13:04:54.605616300Z",
             "source": "Horizon Zero Dawn (via TechPowerUp)",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v2.3.5.0_F59A89CA2150F107A1D9DE4CA8CA8DDC.zip",
             "release_notes": "CL 30668210",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "2.3.7.0",
@@ -2490,14 +3241,15 @@
             "sha256": "0c1eda5e9d60b4d66e075fe0cb672794",
             "size_bytes": 14621184,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044837500Z",
+            "released_at": "2026-05-29T13:04:54.605622500Z",
             "source": "Dying Light 2 (via TechPowerUp)",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v2.3.7.0_0C1EDA5E9D60B4D66E075FE0CB672794.zip",
             "release_notes": "CL 30888174",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "2.3.9.0",
@@ -2506,14 +3258,15 @@
             "sha256": "f3938d96eb0600634cb16e01a4d6ea1f",
             "size_bytes": 14619848,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044839700Z",
+            "released_at": "2026-05-29T13:04:54.605630100Z",
             "source": "Chorus (via TechPowerUp)",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v2.3.9.0_F3938D96EB0600634CB16E01A4D6EA1F.zip",
             "release_notes": "CL 30929354",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "2.3.11.0",
@@ -2522,46 +3275,15 @@
             "sha256": "e14d1d3c4da7bb57641ba59a9f456cd4",
             "size_bytes": 14804680,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044842400Z",
+            "released_at": "2026-05-29T13:04:54.605634600Z",
             "source": "DLSS-2.3.3.zip",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v2.3.11.0_E14D1D3C4DA7BB57641BA59A9F456CD4.zip",
             "release_notes": "CL 30954459",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
-          },
-          {
-            "version": "2.3.11.0",
-            "version_packed": 562962839044096,
-            "filename": "nvngx_dlss.dll",
-            "sha256": "ca186073ce212602143fdebd2dc80d33",
-            "size_bytes": 14806784,
-            "signed": true,
-            "released_at": "2026-05-20T11:44:57.044843Z",
-            "source": "Loopmancer",
-            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v2.3.11.0_CA186073CE212602143FDEBD2DC80D33.zip",
-            "release_notes": "CL 31218052",
-            "signature_subject": "NVIDIA Corporation",
-            "channel": "stable",
-            "is_dev": false,
-            "min_driver": null
-          },
-          {
-            "version": "2.3.11.0",
-            "version_packed": 562962839044096,
-            "filename": "nvngx_dlss.dll",
-            "sha256": "476d66c9f9dc333e907cbdd8c3d227c7",
-            "size_bytes": 15029968,
-            "signed": true,
-            "released_at": "2026-05-20T11:44:57.044843800Z",
-            "source": "DLSS-2.3.3.zip",
-            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v2.3.11.0_476D66C9F9DC333E907CBDD8C3D227C7.zip",
-            "release_notes": "CL 30954459",
-            "signature_subject": "NVIDIA Corporation",
-            "channel": "stable",
-            "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "2.4.0.0",
@@ -2570,30 +3292,15 @@
             "sha256": "f395216f5c42b2658a4144837b457ddd",
             "size_bytes": 14803656,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044844600Z",
+            "released_at": "2026-05-29T13:04:54.605649900Z",
             "source": "DLSS-2.4.0.zip",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v2.4.0.0_F395216F5C42B2658A4144837B457DDD.zip",
             "release_notes": "CL 31105907",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
-          },
-          {
-            "version": "2.4.0.0",
-            "version_packed": 562967133290496,
-            "filename": "nvngx_dlss.dll",
-            "sha256": "941eb47df770cbfc434c34ca9239a254",
-            "size_bytes": 15032952,
-            "signed": true,
-            "released_at": "2026-05-20T11:44:57.044845300Z",
-            "source": "DLSS-2.4.0.zip",
-            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v2.4.0.0_941EB47DF770CBFC434C34CA9239A254.zip",
-            "release_notes": "CL 31105907",
-            "signature_subject": "NVIDIA Corporation",
-            "channel": "stable",
-            "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "2.4.2.0",
@@ -2602,30 +3309,15 @@
             "sha256": "fc7f487079b5132e132729ea046dd017",
             "size_bytes": 14815352,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044846Z",
+            "released_at": "2026-05-29T13:04:54.605660500Z",
             "source": "Back4Blood (via TechPowerUp)",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v2.4.2.0_FC7F487079B5132E132729EA046DD017.zip",
             "release_notes": "CL 31258854",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
-          },
-          {
-            "version": "2.4.2.0",
-            "version_packed": 562967133421568,
-            "filename": "nvngx_dlss.dll",
-            "sha256": "68b0e070cadb1a48237b027549f6a216",
-            "size_bytes": 14814464,
-            "signed": true,
-            "released_at": "2026-05-20T11:44:57.044846700Z",
-            "source": "Baldur's Gate 3 (via TechPowerUp)",
-            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v2.4.2.0_68B0E070CADB1A48237B027549F6A216.zip",
-            "release_notes": "CL 31212662",
-            "signature_subject": "NVIDIA Corporation",
-            "channel": "stable",
-            "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "2.4.3.0",
@@ -2634,14 +3326,15 @@
             "sha256": "dea5f1dabf86203c3210e21df9cfcf07",
             "size_bytes": 14816512,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044847400Z",
+            "released_at": "2026-05-29T13:04:54.605674100Z",
             "source": "Evil Dead (via TechPowerUp)",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v2.4.3.0_DEA5F1DABF86203C3210E21DF9CFCF07.zip",
             "release_notes": "CL 31309745",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "2.4.6.0",
@@ -2650,14 +3343,15 @@
             "sha256": "03a5a7be0e4d83487dd68dfb88fd0036",
             "size_bytes": 14852216,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044847800Z",
+            "released_at": "2026-05-29T13:04:54.605680800Z",
             "source": "Microsoft Flight Simulator SU10 (via TechPowerUp)",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v2.4.6.0_03A5A7BE0E4D83487DD68DFB88FD0036.zip",
             "release_notes": "CL 31353423",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "2.4.11.0",
@@ -2666,14 +3360,15 @@
             "sha256": "c1e931321a9818fa896abe03823d4c1e",
             "size_bytes": 14149736,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044849200Z",
+            "released_at": "2026-05-29T13:04:54.605686Z",
             "source": "Sackboy (via TechPowerUp)",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v2.4.11.0_C1E931321A9818FA896ABE03823D4C1E.zip",
             "release_notes": "CL 31481051",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "2.4.12.0",
@@ -2682,46 +3377,15 @@
             "sha256": "0aa6cf6b6779919088455e47fbba0a5f",
             "size_bytes": 14171176,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044849900Z",
+            "released_at": "2026-05-29T13:04:54.605690800Z",
             "source": "Final Fantasy Origin (via TechPowerUp)",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v2.4.12.0_0AA6CF6B6779919088455E47FBBA0A5F.zip",
             "release_notes": "CL 31617536",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
-          },
-          {
-            "version": "2.4.12.0",
-            "version_packed": 562967134076928,
-            "filename": "nvngx_dlss.dll",
-            "sha256": "0a71efba8daff9c284ce6010923c01f1",
-            "size_bytes": 15076392,
-            "signed": true,
-            "released_at": "2026-05-20T11:44:57.044850500Z",
-            "source": "A Plague Tale Requiem (via TechPowerUp)",
-            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v2.4.12.0_0A71EFBA8DAFF9C284CE6010923C01F1.zip",
-            "release_notes": "CL 31836525",
-            "signature_subject": "NVIDIA Corporation",
-            "channel": "stable",
-            "is_dev": false,
-            "min_driver": null
-          },
-          {
-            "version": "2.4.12.0",
-            "version_packed": 562967134076928,
-            "filename": "nvngx_dlss.dll",
-            "sha256": "31bfd8f750f87e5040557d95c2345080",
-            "size_bytes": 24002088,
-            "signed": true,
-            "released_at": "2026-05-20T11:44:57.044851200Z",
-            "source": "Spider-Man: Miles Morales (via TechPowerUp)",
-            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v2.4.12.0_31BFD8F750F87E5040557D95C2345080.zip",
-            "release_notes": "CL 32015014",
-            "signature_subject": "NVIDIA Corporation",
-            "channel": "stable",
-            "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "2.4.13.0",
@@ -2730,14 +3394,15 @@
             "sha256": "578d0a372c0d59a704513bb22a7db234",
             "size_bytes": 25176120,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044851900Z",
+            "released_at": "2026-05-29T13:04:54.605706800Z",
             "source": "WRC Generations (via TechPowerUp)",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v2.4.13.0_578D0A372C0D59A704513BB22A7DB234.zip",
             "release_notes": "CL 32022682",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "2.5.0.0",
@@ -2746,14 +3411,15 @@
             "sha256": "87a8231ac086ad8ee6b3c57140f25dcc",
             "size_bytes": 25176104,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044852400Z",
+            "released_at": "2026-05-29T13:04:54.605711700Z",
             "source": "Marvel's Midnight Suns Dec 10 Patch (via TechPowerUp)",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v2.5.0.0_87A8231AC086AD8EE6B3C57140F25DCC.zip",
             "release_notes": "CL 32141080",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "2.5.1.0",
@@ -2762,14 +3428,15 @@
             "sha256": "dfe932d0b3955e649c1f759382d4e0d4",
             "size_bytes": 25179192,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044854500Z",
+            "released_at": "2026-05-29T13:04:54.605716400Z",
             "source": "Portal RTX new patch (via TechPowerUp)",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v2.5.1.0_DFE932D0B3955E649C1F759382D4E0D4.zip",
             "release_notes": "CL 32211295",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "3.1.1.0",
@@ -2778,46 +3445,15 @@
             "sha256": "4bb567067b16b8fabf05d0817a9c971c",
             "size_bytes": 36687416,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044855100Z",
+            "released_at": "2026-05-29T13:04:54.605721100Z",
             "source": "DLSS-3.1.0.zip",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v3.1.1.0_4BB567067B16B8FABF05D0817A9C971C.zip",
             "release_notes": "CL 32342834",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
-          },
-          {
-            "version": "3.1.1.0",
-            "version_packed": 844429225164800,
-            "filename": "nvngx_dlss.dll",
-            "sha256": "40d468487ea4e0f56595f8de1ac8ed7c",
-            "size_bytes": 36687912,
-            "signed": true,
-            "released_at": "2026-05-20T11:44:57.044855700Z",
-            "source": "Atomic Heart (via TechPowerUp)",
-            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v3.1.1.0_40D468487EA4E0F56595F8DE1AC8ED7C.zip",
-            "release_notes": "CL 32436919",
-            "signature_subject": "NVIDIA Corporation",
-            "channel": "stable",
-            "is_dev": false,
-            "min_driver": null
-          },
-          {
-            "version": "3.1.1.0",
-            "version_packed": 844429225164800,
-            "filename": "nvngx_dlss.dll",
-            "sha256": "1df72f79aaeea7dfa86fae385641078c",
-            "size_bytes": 36856360,
-            "signed": true,
-            "released_at": "2026-05-20T11:44:57.044856500Z",
-            "source": "DLSS-3.1.0.zip",
-            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v3.1.1.0_1DF72F79AAEEA7DFA86FAE385641078C.zip",
-            "release_notes": "CL 32342834",
-            "signature_subject": "NVIDIA Corporation",
-            "channel": "stable",
-            "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "3.1.2.0",
@@ -2826,14 +3462,15 @@
             "sha256": "fcede5737d34413ce16cc0be9a6203af",
             "size_bytes": 35399736,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044857100Z",
+            "released_at": "2026-05-29T13:04:54.605735700Z",
             "source": "The Last of Us (via TechPowerUp)",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v3.1.2.0_FCEDE5737D34413CE16CC0BE9A6203AF.zip",
             "release_notes": "CL 32544569",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "3.1.11.0",
@@ -2842,46 +3479,15 @@
             "sha256": "e557b8eb18fbd710f82073d9f6fa55a9",
             "size_bytes": 35385384,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044857800Z",
+            "released_at": "2026-05-29T13:04:54.605740400Z",
             "source": "DLSS-3.1.10.zip",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v3.1.11.0_E557B8EB18FBD710F82073D9F6FA55A9.zip",
             "release_notes": "CL 32597869",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
-          },
-          {
-            "version": "3.1.11.0",
-            "version_packed": 844429225820160,
-            "filename": "nvngx_dlss.dll",
-            "sha256": "adb36f4684e64ada9c8d82ad365e6d19",
-            "size_bytes": 35385912,
-            "signed": true,
-            "released_at": "2026-05-20T11:44:57.044858400Z",
-            "source": "NVIDIA SDK (via TechPowerUp)",
-            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v3.1.11.0_ADB36F4684E64ADA9C8D82AD365E6D19.zip",
-            "release_notes": "CL 32597869",
-            "signature_subject": "NVIDIA Corporation",
-            "channel": "stable",
-            "is_dev": false,
-            "min_driver": null
-          },
-          {
-            "version": "3.1.11.0",
-            "version_packed": 844429225820160,
-            "filename": "nvngx_dlss.dll",
-            "sha256": "6b1e6a22cc459b636d9a0170c56a46b6",
-            "size_bytes": 35552824,
-            "signed": true,
-            "released_at": "2026-05-20T11:44:57.044859200Z",
-            "source": "DLSS-3.1.10.zip",
-            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v3.1.11.0_6B1E6A22CC459B636D9A0170C56A46B6.zip",
-            "release_notes": "CL 32597869",
-            "signature_subject": "NVIDIA Corporation",
-            "channel": "stable",
-            "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "3.1.13.0",
@@ -2890,46 +3496,15 @@
             "sha256": "22b2359cf7ec76f523feeec53fa81464",
             "size_bytes": 35386424,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044862800Z",
+            "released_at": "2026-05-29T13:04:54.605755700Z",
             "source": "NVIDIA SDK (via TechPowerUp)",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v3.1.13.0_22B2359CF7EC76F523FEEEC53FA81464.zip",
             "release_notes": "CL 32824515",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
-          },
-          {
-            "version": "3.1.13.0",
-            "version_packed": 844429225951232,
-            "filename": "nvngx_dlss.dll",
-            "sha256": "4db1c0e9c79757bda8fd9116d8137d2f",
-            "size_bytes": 35400248,
-            "signed": true,
-            "released_at": "2026-05-20T11:44:57.044863400Z",
-            "source": "DLSS-3.1.13.zip",
-            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v3.1.13.0_4DB1C0E9C79757BDA8FD9116D8137D2F.zip",
-            "release_notes": "CL 32841675",
-            "signature_subject": "NVIDIA Corporation",
-            "channel": "stable",
-            "is_dev": false,
-            "min_driver": null
-          },
-          {
-            "version": "3.1.13.0",
-            "version_packed": 844429225951232,
-            "filename": "nvngx_dlss.dll",
-            "sha256": "e985d98c7b57c8f0fae244b6fce106e8",
-            "size_bytes": 35568696,
-            "signed": true,
-            "released_at": "2026-05-20T11:44:57.044864200Z",
-            "source": "DLSS-3.1.13.zip",
-            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v3.1.13.0_E985D98C7B57C8F0FAE244B6FCE106E8.zip",
-            "release_notes": "CL 32841675",
-            "signature_subject": "NVIDIA Corporation",
-            "channel": "stable",
-            "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "3.1.30.0",
@@ -2938,30 +3513,15 @@
             "sha256": "96f5ced18c119946e4a674c14d908692",
             "size_bytes": 51717160,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044865Z",
+            "released_at": "2026-05-29T13:04:54.605771400Z",
             "source": "DLSS-3.1.30.zip",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v3.1.30.0_96F5CED18C119946E4A674C14D908692.zip",
             "release_notes": "CL 33088933",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
-          },
-          {
-            "version": "3.1.30.0",
-            "version_packed": 844429227065344,
-            "filename": "nvngx_dlss.dll",
-            "sha256": "5baca22835d10d0069de04b54a5cc2cd",
-            "size_bytes": 51860520,
-            "signed": true,
-            "released_at": "2026-05-20T11:44:57.044865500Z",
-            "source": "DLSS-3.1.30.zip",
-            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v3.1.30.0_5BACA22835D10D0069DE04B54A5CC2CD.zip",
-            "release_notes": "CL 33088933",
-            "signature_subject": "NVIDIA Corporation",
-            "channel": "stable",
-            "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "3.5.0.0",
@@ -2970,46 +3530,15 @@
             "sha256": "a6b5079411a58630799478ebb6baa722",
             "size_bytes": 51716648,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044866100Z",
+            "released_at": "2026-05-29T13:04:54.605785300Z",
             "source": "DLSS-3.5.0.zip",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v3.5.0.0_A6B5079411A58630799478EBB6BAA722.zip",
             "release_notes": "CL 33190482",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
-          },
-          {
-            "version": "3.5.0.0",
-            "version_packed": 844446404968448,
-            "filename": "nvngx_dlss.dll",
-            "sha256": "bf68025b3603c382fca65b148b979682",
-            "size_bytes": 51716136,
-            "signed": true,
-            "released_at": "2026-05-20T11:44:57.044866600Z",
-            "source": "DLSS Demo",
-            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v3.5.0.0_BF68025B3603C382FCA65B148B979682.zip",
-            "release_notes": "CL 33199489",
-            "signature_subject": "NVIDIA Corporation",
-            "channel": "stable",
-            "is_dev": false,
-            "min_driver": null
-          },
-          {
-            "version": "3.5.0.0",
-            "version_packed": 844446404968448,
-            "filename": "nvngx_dlss.dll",
-            "sha256": "b4c2d62576a96b82cfc47e6bb5282244",
-            "size_bytes": 51859496,
-            "signed": true,
-            "released_at": "2026-05-20T11:44:57.044867200Z",
-            "source": "DLSS-3.5.0.zip",
-            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v3.5.0.0_B4C2D62576A96B82CFC47E6BB5282244.zip",
-            "release_notes": "CL 33190482",
-            "signature_subject": "NVIDIA Corporation",
-            "channel": "stable",
-            "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "3.5.10.0",
@@ -3018,30 +3547,15 @@
             "sha256": "ac477775c31346f60c17a7f4f0aa1983",
             "size_bytes": 53689400,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044867800Z",
+            "released_at": "2026-05-29T13:04:54.605800Z",
             "source": "DLSS-3.5.10.zip",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v3.5.10.0_AC477775C31346F60C17A7F4F0AA1983.zip",
             "release_notes": "CL 33396148",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
-          },
-          {
-            "version": "3.5.10.0",
-            "version_packed": 844446405623808,
-            "filename": "nvngx_dlss.dll",
-            "sha256": "c8fae97c2df886cbf8eb1cc671f9b87c",
-            "size_bytes": 53850152,
-            "signed": true,
-            "released_at": "2026-05-20T11:44:57.044870300Z",
-            "source": "DLSS-3.5.10.zip",
-            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v3.5.10.0_C8FAE97C2DF886CBF8EB1CC671F9B87C.zip",
-            "release_notes": "CL 33396148",
-            "signature_subject": "NVIDIA Corporation",
-            "channel": "stable",
-            "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "3.6.0.0",
@@ -3050,14 +3564,15 @@
             "sha256": "49ce45d36d0fe6e498f2aae54d94bdee",
             "size_bytes": 47438904,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044870900Z",
+            "released_at": "2026-05-29T13:04:54.605810500Z",
             "source": "Naraka Bladepoint (via TechPowerUp)",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v3.6.0.0_49CE45D36D0FE6E498F2AAE54D94BDEE.zip",
             "release_notes": "CL 33629598",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "3.7.0.0",
@@ -3066,30 +3581,15 @@
             "sha256": "956faf7e5de9c4634c5869389f91f11b",
             "size_bytes": 51255848,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044871400Z",
+            "released_at": "2026-05-29T13:04:54.605815700Z",
             "source": "DLSS-3.7.0.zip",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v3.7.0.0_956FAF7E5DE9C4634C5869389F91F11B.zip",
             "release_notes": "CL 33860605",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
-          },
-          {
-            "version": "3.7.0.0",
-            "version_packed": 844454994903040,
-            "filename": "nvngx_dlss.dll",
-            "sha256": "060f8a4c3c25925de8e86f73451fc615",
-            "size_bytes": 51412024,
-            "signed": true,
-            "released_at": "2026-05-20T11:44:57.044874500Z",
-            "source": "DLSS-3.7.0.zip",
-            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v3.7.0.0_060F8A4C3C25925DE8E86F73451FC615.zip",
-            "release_notes": "CL 33860605",
-            "signature_subject": "NVIDIA Corporation",
-            "channel": "stable",
-            "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "3.7.10.0",
@@ -3098,30 +3598,15 @@
             "sha256": "12627ab9ee39858b6a28039a32d1b7c2",
             "size_bytes": 51276856,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044875Z",
+            "released_at": "2026-05-29T13:04:54.605826Z",
             "source": "DLSS-3.7.10.zip",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v3.7.10.0_12627AB9EE39858B6A28039A32D1B7C2.zip",
             "release_notes": "CL 34360990",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
-          },
-          {
-            "version": "3.7.10.0",
-            "version_packed": 844454995558400,
-            "filename": "nvngx_dlss.dll",
-            "sha256": "6af88a88ba51c1abe5a81ed0afa08cfc",
-            "size_bytes": 51432488,
-            "signed": true,
-            "released_at": "2026-05-20T11:44:57.044875600Z",
-            "source": "DLSS-3.7.10.zip",
-            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v3.7.10.0_6AF88A88BA51C1ABE5A81ED0AFA08CFC.zip",
-            "release_notes": "CL 34360990",
-            "signature_subject": "NVIDIA Corporation",
-            "channel": "stable",
-            "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "3.7.20.0",
@@ -3130,46 +3615,15 @@
             "sha256": "53dbec92bb250e667cbc532d5d782316",
             "size_bytes": 51291680,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044876100Z",
+            "released_at": "2026-05-29T13:04:54.605841200Z",
             "source": "NVIDIA Driver (DirectSR) (via TechPowerUp)",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v3.7.20.0_53DBEC92BB250E667CBC532D5D782316.zip",
             "release_notes": "CL 0",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
-          },
-          {
-            "version": "3.7.20.0",
-            "version_packed": 844454996213760,
-            "filename": "nvngx_dlss.dll",
-            "sha256": "78eb8bfb301eaa9fbfe90db9edeb20ae",
-            "size_bytes": 51281960,
-            "signed": true,
-            "released_at": "2026-05-20T11:44:57.044877500Z",
-            "source": "DLSS-3.7.20.zip",
-            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v3.7.20.0_78EB8BFB301EAA9FBFE90DB9EDEB20AE.zip",
-            "release_notes": "CL 34733527",
-            "signature_subject": "NVIDIA Corporation",
-            "channel": "stable",
-            "is_dev": false,
-            "min_driver": null
-          },
-          {
-            "version": "3.7.20.0",
-            "version_packed": 844454996213760,
-            "filename": "nvngx_dlss.dll",
-            "sha256": "feb2fa31ae7e4a418a367281aee41e47",
-            "size_bytes": 51438136,
-            "signed": true,
-            "released_at": "2026-05-20T11:44:57.044878300Z",
-            "source": "DLSS-3.7.20.zip",
-            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v3.7.20.0_FEB2FA31AE7E4A418A367281AEE41E47.zip",
-            "release_notes": "CL 34733527",
-            "signature_subject": "NVIDIA Corporation",
-            "channel": "stable",
-            "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "3.8.10.0",
@@ -3178,14 +3632,15 @@
             "sha256": "aed94e7029846c356882db166b824f5e",
             "size_bytes": 24925344,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044878900Z",
+            "released_at": "2026-05-29T13:04:54.605856900Z",
             "source": "NVIDIA Driver (DirectSR) (via TechPowerUp)",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v3.8.10.0_AED94E7029846C356882DB166B824F5E.zip",
             "release_notes": "CL 0",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "310.1.0.0",
@@ -3194,14 +3649,15 @@
             "sha256": "117595d4839dcab18501249cbeee9b7a",
             "size_bytes": 44609064,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044879500Z",
+            "released_at": "2026-05-29T13:04:54.605862300Z",
             "source": "Cyberpunk 2077 2.21",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v310.1.0.0_117595D4839DCAB18501249CBEEE9B7A.zip",
             "release_notes": "CL 35322723",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "310.2.1.0",
@@ -3210,14 +3666,15 @@
             "sha256": "3a875f45c315d09e5f4548cc9288f178",
             "size_bytes": 48971832,
             "signed": true,
-            "released_at": "2026-05-20T11:44:57.044880100Z",
+            "released_at": "2026-05-29T13:04:54.605870500Z",
             "source": "NVIDIA Driver",
             "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v310.2.1.0_3A875F45C315D09E5F4548CC9288F178.zip",
             "release_notes": "CL 35454170",
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "310.3.0.0",
@@ -3233,23 +3690,8 @@
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
-          },
-          {
-            "version": "310.3.0.0",
-            "version_packed": 87257255665205248,
-            "filename": "nvngx_dlss.dll",
-            "sha256": "d75ce10f6555a2c94ad4a5f2c1bc622e",
-            "size_bytes": 49165856,
-            "signed": true,
-            "released_at": "2025-05-08T22:37:18Z",
-            "source": "streamline-sdk-v2.8.0.zip",
-            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v310.3.0.0_D75CE10F6555A2C94AD4A5F2C1BC622E.zip",
-            "release_notes": "CL 35956306",
-            "signature_subject": "NVIDIA Corporation",
-            "channel": "stable",
-            "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "310.4.0.0",
@@ -3265,23 +3707,8 @@
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
-          },
-          {
-            "version": "310.4.0.0",
-            "version_packed": 87257259960172544,
-            "filename": "nvngx_dlss.dll",
-            "sha256": "8440daa19ae3df3402f24d1f26ed23b9",
-            "size_bytes": 30135840,
-            "signed": true,
-            "released_at": "2025-08-12T21:48:27Z",
-            "source": "DLSS-310.4.0.zip",
-            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v310.4.0.0_8440DAA19AE3DF3402F24D1F26ED23B9.zip",
-            "release_notes": "CL 36386704",
-            "signature_subject": "NVIDIA Corporation",
-            "channel": "stable",
-            "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "310.5.0.0",
@@ -3297,23 +3724,8 @@
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
-          },
-          {
-            "version": "310.5.0.0",
-            "version_packed": 87257264255139840,
-            "filename": "nvngx_dlss.dll",
-            "sha256": "87db238e66c9d8e1016b65c6c109c9fc",
-            "size_bytes": 65523824,
-            "signed": true,
-            "released_at": "2025-12-20T01:52:25Z",
-            "source": "DLSS-310.5.0.zip",
-            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v310.5.0.0_87DB238E66C9D8E1016B65C6C109C9FC.zip",
-            "release_notes": "CL 37081176",
-            "signature_subject": "NVIDIA Corporation",
-            "channel": "stable",
-            "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "310.5.2.0",
@@ -3329,7 +3741,8 @@
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "310.5.3.0",
@@ -3345,23 +3758,8 @@
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
-          },
-          {
-            "version": "310.5.3.0",
-            "version_packed": 87257264255336448,
-            "filename": "nvngx_dlss.dll",
-            "sha256": "a11b9b55e322fade3f11ca26d4437217",
-            "size_bytes": 65523824,
-            "signed": true,
-            "released_at": "2026-01-21T20:53:46Z",
-            "source": "DLSS-310.5.3.zip",
-            "cdn_url": "https://dlss-swapper-downloads.beeradmoore.com/dlss/dlss_v310.5.3.0_A11B9B55E322FADE3F11CA26D4437217.zip",
-            "release_notes": "CL 37208806",
-            "signature_subject": "NVIDIA Corporation",
-            "channel": "stable",
-            "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           },
           {
             "version": "310.6.0.0",
@@ -3377,7 +3775,8 @@
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "md5"
           }
         ]
       },
@@ -3398,7 +3797,8 @@
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           },
           {
             "version": "2.8.0",
@@ -3414,7 +3814,8 @@
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           },
           {
             "version": "2.9.0",
@@ -3430,7 +3831,8 @@
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           },
           {
             "version": "2.10.0",
@@ -3446,7 +3848,8 @@
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           },
           {
             "version": "2.10.3",
@@ -3462,7 +3865,8 @@
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           },
           {
             "version": "2.11.1",
@@ -3478,7 +3882,8 @@
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           }
         ]
       },
@@ -3499,7 +3904,8 @@
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           },
           {
             "version": "2.8.0",
@@ -3515,7 +3921,8 @@
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           },
           {
             "version": "2.9.0",
@@ -3531,7 +3938,8 @@
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           },
           {
             "version": "2.10.0",
@@ -3547,7 +3955,8 @@
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           },
           {
             "version": "2.10.3",
@@ -3563,7 +3972,8 @@
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           },
           {
             "version": "2.11.1",
@@ -3579,7 +3989,8 @@
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           }
         ]
       },
@@ -3600,7 +4011,8 @@
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           },
           {
             "version": "2.8.0",
@@ -3616,7 +4028,8 @@
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           },
           {
             "version": "2.9.0",
@@ -3632,7 +4045,8 @@
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           },
           {
             "version": "2.10.0",
@@ -3648,7 +4062,8 @@
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           },
           {
             "version": "2.10.3",
@@ -3664,7 +4079,8 @@
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           },
           {
             "version": "2.11.1",
@@ -3680,7 +4096,8 @@
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           }
         ]
       },
@@ -3701,7 +4118,8 @@
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           },
           {
             "version": "2.8.0",
@@ -3717,7 +4135,8 @@
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           },
           {
             "version": "2.9.0",
@@ -3733,7 +4152,8 @@
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           },
           {
             "version": "2.10.0",
@@ -3749,7 +4169,8 @@
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           },
           {
             "version": "2.10.3",
@@ -3765,7 +4186,8 @@
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           },
           {
             "version": "2.11.1",
@@ -3781,7 +4203,8 @@
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           }
         ]
       },
@@ -3802,7 +4225,8 @@
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           },
           {
             "version": "2.8.0",
@@ -3818,7 +4242,8 @@
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           },
           {
             "version": "2.9.0",
@@ -3834,7 +4259,8 @@
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           },
           {
             "version": "2.10.0",
@@ -3850,7 +4276,8 @@
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           },
           {
             "version": "2.10.3",
@@ -3866,7 +4293,8 @@
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           },
           {
             "version": "2.11.1",
@@ -3882,7 +4310,8 @@
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           }
         ]
       },
@@ -3903,7 +4332,8 @@
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           },
           {
             "version": "2.8.0",
@@ -3919,7 +4349,8 @@
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           },
           {
             "version": "2.9.0",
@@ -3935,7 +4366,8 @@
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           },
           {
             "version": "2.10.0",
@@ -3951,7 +4383,8 @@
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           },
           {
             "version": "2.10.3",
@@ -3967,7 +4400,8 @@
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           },
           {
             "version": "2.11.1",
@@ -3983,11 +4417,11256 @@
             "signature_subject": "NVIDIA Corporation",
             "channel": "stable",
             "is_dev": false,
-            "min_driver": null
+            "min_driver": null,
+            "hash_algorithm": "sha256"
           }
         ]
       }
     }
   },
-  "incompatible_games": []
+  "incompatible_games": [],
+  "anticheat": {
+    "by_appid": {
+      "20": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "30": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "50": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "60": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "70": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "80": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "300": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "320": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "360": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "440": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "500": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "550": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "730": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "2200": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "2210": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "2400": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "2620": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "2630": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "3970": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "7940": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "9010": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "9050": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "9460": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "10000": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "10090": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "10170": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "13140": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "13520": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "13540": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "15000": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "15120": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "17300": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "17330": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "17430": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "17580": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "19830": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "19900": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "20590": {
+        "anticheats": [
+          "Packman",
+          "Anti-Cheat Expert",
+          "Riot Vanguard"
+        ],
+        "anti_tamper": [],
+        "status": "Denied"
+      },
+      "21090": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "21120": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "24840": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "24860": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "24960": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "29520": {
+        "anticheats": [
+          "nProtect GameGuard",
+          "SARD Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "32770": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "33900": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "35450": {
+        "anticheats": [
+          "PunkBuster",
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "39000": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "42160": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "44350": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "47790": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "48190": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "61700": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "61730": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "63500": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "90800": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "91310": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "107410": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "113400": {
+        "anticheats": [
+          "SARD Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "201870": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "202090": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "202970": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "203290": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "208090": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "208480": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "209870": {
+        "anticheats": [
+          "BattlEye",
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "212160": {
+        "anticheats": [
+          "Nexon Game Security",
+          "XIGNCODE3"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "212200": {
+        "anticheats": [
+          "nProtect GameGuard",
+          "HackShield",
+          "Nexon Game Security"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "212480": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "212630": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "216150": {
+        "anticheats": [
+          "nProtect GameGuard",
+          "HackShield",
+          "XIGNCODE3"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "218230": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "220240": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "221040": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "221100": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "223650": {
+        "anticheats": [
+          "XIGNCODE3"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "224580": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "226700": {
+        "anticheats": [
+          "Fredaikis Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "227940": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "230410": {
+        "anticheats": [
+          "Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "232090": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "234140": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "234510": {
+        "anticheats": [
+          "PunkBuster",
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "234530": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "236390": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "242050": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "250740": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "251570": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "252490": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Denied"
+      },
+      "252950": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "253490": {
+        "anticheats": [
+          "Easy Anti-Cheat",
+          "nProtect GameGuard",
+          "XIGNCODE3"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "253530": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "261430": {
+        "anticheats": [
+          "nProtect GameGuard",
+          "XIGNCODE3",
+          "SARD Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "261550": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "264360": {
+        "anticheats": [
+          "nProtect GameGuard",
+          "XIGNCODE3"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "265300": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "266410": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "269210": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "271590": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [
+          "Arxan Anti-Tamper"
+        ],
+        "status": "Denied"
+      },
+      "273350": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "274940": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "282440": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "285190": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "286940": {
+        "anticheats": [
+          "Easy Anti-Cheat",
+          "XIGNCODE3"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "287700": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "291480": {
+        "anticheats": [
+          "MRAC Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "291550": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "292730": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Arxan Anti-Tamper"
+        ],
+        "status": "Supported"
+      },
+      "293220": {
+        "anticheats": [
+          "Easy Anti-Cheat",
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "299360": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "301520": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "304030": {
+        "anticheats": [
+          "XIGNCODE3"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "304390": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": "Supported"
+      },
+      "304930": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "307950": {
+        "anticheats": [
+          "SARD Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "311210": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Arxan Anti-Tamper"
+        ],
+        "status": "Supported"
+      },
+      "312650": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "312660": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": "Running"
+      },
+      "312670": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "315210": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": "Supported"
+      },
+      "321960": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "322780": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "323370": {
+        "anticheats": [
+          "nProtect GameGuard",
+          "XIGNCODE3"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "327690": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "328060": {
+        "anticheats": [
+          "Easy Anti-Cheat",
+          "nProtect GameGuard",
+          "HackShield",
+          "XTrap"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "331370": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "333930": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "337000": {
+        "anticheats": [],
+        "anti_tamper": [
+          "SecuROM",
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "339610": {
+        "anticheats": [
+          "XIGNCODE3"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "344760": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "346110": {
+        "anticheats": [
+          "BattlEye",
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "349720": {
+        "anticheats": [
+          "Easy Anti-Cheat",
+          "XIGNCODE3"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "350640": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "355840": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "356190": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "359550": {
+        "anticheats": [
+          "BattlEye",
+          "Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": "Denied"
+      },
+      "364360": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "368260": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "369200": {
+        "anticheats": [
+          "Nexon Game Security"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "371660": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "373700": {
+        "anticheats": [
+          "nProtect GameGuard",
+          "XIGNCODE3"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "374280": {
+        "anticheats": [
+          "Saberclaw Anticheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "374520": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "375230": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "375910": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "376210": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "377140": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "378860": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "380600": {
+        "anticheats": [
+          "Denuvo Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "381210": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "381990": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "383120": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "386180": {
+        "anticheats": [
+          "BattlEye",
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "386360": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "389430": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "391040": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "393380": {
+        "anticheats": [
+          "Easy Anti-Cheat",
+          "Valve Anti-Cheat",
+          "Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "393420": {
+        "anticheats": [
+          "Epic Online Services"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "394230": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Arxan Anti-Tamper"
+        ],
+        "status": null
+      },
+      "394690": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "407530": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "410570": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "418460": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "420560": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "421020": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "427100": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "429660": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "433350": {
+        "anticheats": [
+          "BattlEye",
+          "nProtect GameGuard"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "433850": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "435410": {
+        "anticheats": [
+          "Steam"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "436520": {
+        "anticheats": [
+          "BattlEye",
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "437220": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "438100": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "438490": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "438740": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [
+          "Arxan Anti-Tamper"
+        ],
+        "status": "Running"
+      },
+      "439350": {
+        "anticheats": [
+          "Easy Anti-Cheat",
+          "XIGNCODE3"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "440000": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "440900": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "443110": {
+        "anticheats": [
+          "StarForce MMOG"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "444090": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "445220": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "445310": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "446560": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "447040": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": "Running"
+      },
+      "454650": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "456610": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "457590": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "458770": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "460870": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "460930": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": "Broken"
+      },
+      "465280": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "466130": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "470220": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper",
+          "VMProtect"
+        ],
+        "status": null
+      },
+      "473690": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "476600": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Arxan Anti-Tamper"
+        ],
+        "status": "Supported"
+      },
+      "482730": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "482750": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "488790": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "491540": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "493340": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "495420": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Arxan Anti-Tamper"
+        ],
+        "status": null
+      },
+      "495910": {
+        "anticheats": [
+          "Nexon Game Security",
+          "Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "505460": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "513650": {
+        "anticheats": [
+          "BattlEye",
+          "XIGNCODE3"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "513710": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "515220": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "517630": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "518150": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "519190": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "520530": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "526980": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "530700": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "532210": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "543460": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "544920": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "546050": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "547860": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "550470": {
+        "anticheats": [
+          "nProtect GameGuard",
+          "XTrap"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "550650": {
+        "anticheats": [
+          "BattlEye",
+          "nProtect GameGuard"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "550900": {
+        "anticheats": [
+          "HackShield"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "552500": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "552520": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper",
+          "VMProtect"
+        ],
+        "status": "Supported"
+      },
+      "553850": {
+        "anticheats": [
+          "nProtect GameGuard"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "555160": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "555440": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "558230": {
+        "anticheats": [
+          "nProtect GameGuard",
+          "XIGNCODE3"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "562810": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "573100": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "574050": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "578080": {
+        "anticheats": [
+          "BattlEye",
+          "Zakynthos"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "579820": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "581320": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "582160": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper",
+          "VMProtect"
+        ],
+        "status": null
+      },
+      "582660": {
+        "anticheats": [
+          "Easy Anti-Cheat",
+          "XIGNCODE3"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "585080": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "592580": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "592600": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "594570": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "594650": {
+        "anticheats": [
+          "Easy Anti-Cheat",
+          "AnyBrain"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "609150": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "611360": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "619080": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "621830": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "622170": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "624090": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "624120": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "624910": {
+        "anticheats": [
+          "XIGNCODE3"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "625340": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "626690": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": "Broken"
+      },
+      "629820": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "633230": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "637100": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "637650": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "641080": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper",
+          "VMProtect"
+        ],
+        "status": "Broken"
+      },
+      "644290": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "646910": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "647590": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "648350": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "650070": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "650510": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "651150": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "653120": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "656240": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "668580": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "671860": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "674020": {
+        "anticheats": [
+          "MRAC Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "678950": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": "Broken"
+      },
+      "678960": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "681660": {
+        "anticheats": [
+          "BattlEye",
+          "XIGNCODE3"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "686810": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "690790": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "694280": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "700600": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "703080": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "707010": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "714080": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "714370": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "736220": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "737800": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "738530": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": "Running"
+      },
+      "739630": {
+        "anticheats": [
+          "GuardingPearSoftware's Anti Cheat Pro"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "742120": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "747970": {
+        "anticheats": [
+          "Easy Anti-Cheat",
+          "XIGNCODE3"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "751240": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "752480": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "753650": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Planned"
+      },
+      "755790": {
+        "anticheats": [
+          "Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "760160": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Denied"
+      },
+      "761890": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "763420": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "766370": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "770240": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "775430": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper",
+          "VMProtect"
+        ],
+        "status": null
+      },
+      "779340": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "783770": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "785260": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "790540": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "790820": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "798510": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "801550": {
+        "anticheats": [
+          "Denuvo Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "801800": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "809890": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "812140": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper",
+          "VMProtect"
+        ],
+        "status": null
+      },
+      "813780": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Arxan Anti-Tamper"
+        ],
+        "status": null
+      },
+      "813820": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "815940": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "816020": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "819500": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "820520": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "823130": {
+        "anticheats": [
+          "EQU8"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "834910": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "835860": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "845070": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "868270": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "869480": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "872200": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "872790": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "872820": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "874240": {
+        "anticheats": [
+          "Easy Anti-Cheat",
+          "nProtect GameGuard"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "876460": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "880850": {
+        "anticheats": [
+          "Easy Anti-Cheat",
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "884660": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": "Denied"
+      },
+      "889750": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "890400": {
+        "anticheats": [
+          "nProtect GameGuard"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "895400": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "903950": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "905640": {
+        "anticheats": [
+          "Easy Anti-Cheat",
+          "HackShield",
+          "nProtect GameGuard"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "915810": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "916440": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper",
+          "VMProtect"
+        ],
+        "status": null
+      },
+      "918570": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "920690": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "921940": {
+        "anticheats": [
+          "XIGNCODE3"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "922620": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "924970": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "927350": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "928600": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "933110": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Arxan Anti-Tamper"
+        ],
+        "status": null
+      },
+      "939510": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "939960": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper",
+          "VMProtect"
+        ],
+        "status": null
+      },
+      "950050": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "950180": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "953580": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "960170": {
+        "anticheats": [
+          "XIGNCODE3"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "961200": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "964440": {
+        "anticheats": [
+          "Easy Anti Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "971700": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "973580": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "976730": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "990080": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "991560": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "996470": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1004640": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1008080": {
+        "anticheats": [
+          "Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "1008580": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "1009290": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "1012110": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "1017900": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Arxan Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1024890": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "1029690": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": "Running"
+      },
+      "1038250": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1049590": {
+        "anticheats": [
+          "XIGNCODE3",
+          "Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "1056640": {
+        "anticheats": [
+          "XIGNCODE3"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "1057240": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "1058650": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "1063730": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "1064070": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1064220": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "1064221": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "1064270": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "1064271": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "1064272": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "1064273": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "1085660": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": "Denied"
+      },
+      "1088850": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1093170": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "1097150": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "1097840": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [
+          "Arxan Anti-Tamper"
+        ],
+        "status": "Running"
+      },
+      "1099410": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1100600": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1100620": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1101840": {
+        "anticheats": [
+          "Easy Anti-Cheat",
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "1106750": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "1113000": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1114150": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "1121710": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "1131290": {
+        "anticheats": [
+          "nProtect GameGuard"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "1132210": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "1133430": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "1134570": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1142710": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1153700": {
+        "anticheats": [
+          "XIGNCODE3"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "1163550": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "1171690": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "1172470": {
+        "anticheats": [
+          "Easy Anti-Cheat",
+          "Hyperion"
+        ],
+        "anti_tamper": [],
+        "status": "Denied"
+      },
+      "1172710": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "1184140": {
+        "anticheats": [
+          "Nexon Game Security"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "1186040": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "1189800": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "1190340": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "1203220": {
+        "anticheats": [
+          "NEAC Protect"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "1222680": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1222690": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1222730": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": "Supported"
+      },
+      "1225560": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1225570": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1225580": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1225590": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1233550": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "1233570": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1235140": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1237320": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1237950": {
+        "anticheats": [
+          "FairFight"
+        ],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": "Supported"
+      },
+      "1237980": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": "Supported"
+      },
+      "1238080": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1238810": {
+        "anticheats": [
+          "EA Javelin"
+        ],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": "Denied"
+      },
+      "1238820": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "1238840": {
+        "anticheats": [
+          "EA Javelin"
+        ],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": "Denied"
+      },
+      "1238860": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "1238880": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": "Running"
+      },
+      "1239520": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1240440": {
+        "anticheats": [
+          "Arbiter",
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "1244460": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1245480": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "1245620": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [
+          "Arxan Anti-Tamper"
+        ],
+        "status": "Supported"
+      },
+      "1249970": {
+        "anticheats": [
+          "SARD Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "1250410": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Arxan Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1252330": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1254120": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "1259970": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1262240": {
+        "anticheats": [
+          "EA Javelin"
+        ],
+        "anti_tamper": [],
+        "status": "Denied"
+      },
+      "1262540": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1262580": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1263850": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1263860": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1268750": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "1273400": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1276760": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "1282270": {
+        "anticheats": [
+          "Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "1282590": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1285190": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1286320": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "1292630": {
+        "anticheats": [
+          "XIGNCODE3"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "1293830": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Arxan Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1294660": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "1294810": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1295660": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1301210": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "1304930": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "1307710": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1313860": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1328660": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1357840": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1359090": {
+        "anticheats": [
+          "Denuvo Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "1364020": {
+        "anticheats": [
+          "Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "1364780": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1367080": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "1372110": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "1372880": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "1377580": {
+        "anticheats": [
+          "Xigncode"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "1382330": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1399780": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "1413480": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1422450": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "1430190": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "1433140": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "1436900": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "1451190": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1460830": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "1462570": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1466860": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Arxan Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1487210": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1490890": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1491000": {
+        "anticheats": [
+          "MRAC Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "1493750": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "1501750": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "1506830": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1517290": {
+        "anticheats": [
+          "EA Javelin"
+        ],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": "Denied"
+      },
+      "1519350": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1531430": {
+        "anticheats": [
+          "XIGNCODE3"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "1549180": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "1549250": {
+        "anticheats": [
+          "nProtect GameGuard"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "1556200": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "1566690": {
+        "anticheats": [
+          "SCUE4"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "1566880": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "1568590": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "1569040": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1570010": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1599340": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "1602010": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1604030": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "1604270": {
+        "anticheats": [
+          "Broken Arrow Anti-Cheat System"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "1607250": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "1611910": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1649080": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1657090": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "1665460": {
+        "anticheats": [
+          "Denuvo Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "1671200": {
+        "anticheats": [
+          "Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "1677350": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1687950": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1689620": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "1691340": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "1692070": {
+        "anticheats": [
+          "XIGNCODE3"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "1692250": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1693980": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1708520": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1761390": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1765520": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "1777620": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1785150": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "1785650": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1789480": {
+        "anticheats": [
+          "Easy Anti-Cheat",
+          "Denuvo Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "1794960": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1795190": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1805480": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1808500": {
+        "anticheats": [
+          "Easy Anti-Cheat",
+          "Denuvo Anti-Cheat",
+          "AnyBrain",
+          "Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "1809700": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1810820": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1811260": {
+        "anticheats": [
+          "EA Javelin"
+        ],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1816670": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "1824220": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "1844380": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1846380": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1849250": {
+        "anticheats": [
+          "EA Javelin"
+        ],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1858630": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "1868170": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1868180": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1872800": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "1873030": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "1874880": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "1875830": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1881700": {
+        "anticheats": [
+          "Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "1888160": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [
+          "Arxan Anti-Tamper"
+        ],
+        "status": "Supported"
+      },
+      "1904540": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1913210": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "1913730": {
+        "anticheats": [
+          "Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "1922560": {
+        "anticheats": [
+          "EA Javelin"
+        ],
+        "anti_tamper": [],
+        "status": "Denied"
+      },
+      "1928420": {
+        "anticheats": [
+          "NetEase Yidun"
+        ],
+        "anti_tamper": [],
+        "status": "Denied"
+      },
+      "1937780": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1938010": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1938090": {
+        "anticheats": [
+          "Ricochet Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "1941540": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1955960": {
+        "anticheats": [
+          "MRAC Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "1957780": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": "Denied"
+      },
+      "1969870": {
+        "anticheats": [
+          "Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "1971870": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1973530": {
+        "anticheats": [
+          "Warden Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "1973710": {
+        "anticheats": [
+          "Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "1984270": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "1985820": {
+        "anticheats": [
+          "Ricochet Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "1995520": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "2000950": {
+        "anticheats": [
+          "Ricochet Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "2012510": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "2022670": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "2051010": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "2051620": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "2054970": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "2055290": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "2058030": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "2058180": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "2058190": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "2064650": {
+        "anticheats": [
+          "VMProtect"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "2064870": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "2072450": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "2073620": {
+        "anticheats": [
+          "Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": "Denied"
+      },
+      "2073850": {
+        "anticheats": [
+          "Denuvo Anti-Cheat",
+          "AnyBrain",
+          "Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "2073930": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "2074920": {
+        "anticheats": [
+          "Easy Anti-Cheat",
+          "Nexon Game Security"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "2078450": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "2096600": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "2096610": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "2100280": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "2108330": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "2138720": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "2139460": {
+        "anticheats": [
+          "NEAC Protect",
+          "Netease Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "2140330": {
+        "anticheats": [
+          "EA Javelin"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "2161700": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "2169200": {
+        "anticheats": [
+          "Denuvo Anti Cheat"
+        ],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": "Running"
+      },
+      "2170050": {
+        "anticheats": [
+          "XIGNCODE3"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "2183900": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "2185060": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "2195250": {
+        "anticheats": [
+          "EA Javelin"
+        ],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": "Denied"
+      },
+      "2208920": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper",
+          "VMProtect"
+        ],
+        "status": null
+      },
+      "2215200": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "2215260": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper",
+          "VMProtect"
+        ],
+        "status": null
+      },
+      "2221490": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "2221920": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper",
+          "VMProtect"
+        ],
+        "status": null
+      },
+      "2231380": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": "Supported"
+      },
+      "2239550": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper",
+          "VMProtect"
+        ],
+        "status": "Supported"
+      },
+      "2244210": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "2246340": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "2252570": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "2254740": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "2279730": {
+        "anticheats": [
+          "XIGNCODE3"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "2287220": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "2288340": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "2288350": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "2290180": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "2338770": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "2346550": {
+        "anticheats": [
+          "Denuvo Anti-Cheat"
+        ],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "2350280": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "2352620": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "2358720": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "2361770": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "2362060": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "2369390": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper",
+          "VMProtect"
+        ],
+        "status": null
+      },
+      "2373990": {
+        "anticheats": [
+          "XIGNCODE3",
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "2375550": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "2379390": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": "Running"
+      },
+      "2383760": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "2385530": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "2395210": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "2399830": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "2424110": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "2426960": {
+        "anticheats": [
+          "nProtect GameGuard"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "2429640": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "2437170": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "2443720": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Denied"
+      },
+      "2448970": {
+        "anticheats": [
+          "Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "2450450": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "2452280": {
+        "anticheats": [
+          "Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "2479810": {
+        "anticheats": [
+          "AnyBrain",
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "2486820": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "2488620": {
+        "anticheats": [
+          "EA Javelin"
+        ],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": "Denied"
+      },
+      "2495100": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "2499860": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "2506530": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "2507950": {
+        "anticheats": [
+          "Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "2513280": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "2523720": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "2556990": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "2582560": {
+        "anticheats": [
+          "EA Javelin"
+        ],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "2590150": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "2591280": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper",
+          "VMProtect"
+        ],
+        "status": null
+      },
+      "2613870": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "2622380": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "2624870": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "2627260": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Arxan Anti-Tamper"
+        ],
+        "status": null
+      },
+      "2641470": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": "Denied"
+      },
+      "2669320": {
+        "anticheats": [
+          "EA Javelin"
+        ],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": "Denied"
+      },
+      "2679460": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "2680010": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "2687970": {
+        "anticheats": [
+          "Denuvo Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "2688950": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "2690190": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "2698940": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "2705130": {
+        "anticheats": [
+          "AnyBrain",
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "2730810": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "2741360": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper",
+          "VMProtect"
+        ],
+        "status": null
+      },
+      "2750080": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "2751000": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper",
+          "VMProtect"
+        ],
+        "status": null
+      },
+      "2767030": {
+        "anticheats": [
+          "NEAC Protect"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "2782500": {
+        "anticheats": [
+          "NEAC Protect"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "2783360": {
+        "anticheats": [
+          "Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "2799860": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "2805060": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "2807960": {
+        "anticheats": [
+          "EA Javelin"
+        ],
+        "anti_tamper": [],
+        "status": "Denied"
+      },
+      "2814990": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "2827230": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "2833580": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "2840770": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper",
+          "VMProtect"
+        ],
+        "status": null
+      },
+      "2842040": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper",
+          "VMProtect"
+        ],
+        "status": null
+      },
+      "2852190": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "2853730": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper",
+          "VMProtect"
+        ],
+        "status": "Running"
+      },
+      "2854480": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "2873440": {
+        "anticheats": [
+          "XIGNCODE3"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "2878600": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": "Supported"
+      },
+      "2878980": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": "Running"
+      },
+      "2918300": {
+        "anticheats": [
+          "EQU8"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "2928600": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "2929170": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "2943650": {
+        "anticheats": [
+          "NEAC Protect"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "2951690": {
+        "anticheats": [
+          "XIGNCODE3"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "2958130": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "2963870": {
+        "anticheats": [
+          "Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "2963950": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "2987800": {
+        "anticheats": [
+          "CrackProof"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "2993780": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "3004100": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "3014320": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "3016760": {
+        "anticheats": [
+          "nProtect GameGuard"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "3017860": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "3035570": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper",
+          "VMProtect"
+        ],
+        "status": null
+      },
+      "3059520": {
+        "anticheats": [
+          "EA Javelin"
+        ],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": "Denied"
+      },
+      "3061810": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "3065800": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "3077390": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "3092530": {
+        "anticheats": [
+          "Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "3092660": {
+        "anticheats": [
+          "Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "3094260": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "3104410": {
+        "anticheats": [
+          "Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "3112260": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "3126180": {
+        "anticheats": [
+          "Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "3139440": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "3159330": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "3164330": {
+        "anticheats": [
+          "Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "3183280": {
+        "anticheats": [
+          "XIGNCODE3"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "3224770": {
+        "anticheats": [
+          "CrackProof"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "3230400": {
+        "anticheats": [
+          "EA Javelin"
+        ],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "3239650": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "3240220": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "3274580": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "3321460": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "3354750": {
+        "anticheats": [
+          "EA Javelin"
+        ],
+        "anti_tamper": [],
+        "status": "Denied"
+      },
+      "3357650": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "3405690": {
+        "anticheats": [
+          "EA Javelin"
+        ],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": "Denied"
+      },
+      "3416640": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "3472040": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "3483510": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "3489700": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "3500390": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "3504780": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "3513350": {
+        "anticheats": [
+          "Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "3545060": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "3551340": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "3557620": {
+        "anticheats": [
+          "Nexon Game Security",
+          "XIGNCODE3"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "3561320": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "3595230": {
+        "anticheats": [
+          "Ricochet Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "3595270": {
+        "anticheats": [
+          "Ricochet Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "3659280": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "3679080": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "3681810": {
+        "anticheats": [
+          "Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "3717070": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "3751950": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "3764200": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper",
+          "VMProtect"
+        ],
+        "status": null
+      },
+      "3768760": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "3929740": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "3932890": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": "Planned"
+      },
+      "3936610": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "3937550": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "3950020": {
+        "anticheats": [
+          "Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "4078430": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "4115450": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "4128260": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "4128400": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "4148530": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "4162040": {
+        "anticheats": [
+          "HoYoKProtect"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "4260840": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "4508340": {
+        "anticheats": [
+          "Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      }
+    },
+    "by_name": {
+      "007firstlight": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "2xko": {
+        "anticheats": [
+          "Riot Vanguard"
+        ],
+        "anti_tamper": [],
+        "status": "Denied"
+      },
+      "3on3freestyle": {
+        "anticheats": [
+          "XIGNCODE3"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "3on3freestylerebound": {
+        "anticheats": [
+          "XIGNCODE3"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "6seasonsandagame": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "7daystodie": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "absolver": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "acecombat8wingsoftheve": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "aewfightforever": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "ageofempiresdefinitiveedition": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Arxan Anti-Tamper"
+        ],
+        "status": null
+      },
+      "ageofempiresiidefinitiveedition": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Arxan Anti-Tamper"
+        ],
+        "status": null
+      },
+      "ageofempiresiiidefinitiveedition": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Arxan Anti-Tamper"
+        ],
+        "status": null
+      },
+      "ageofempiresiv": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Arxan Anti-Tamper"
+        ],
+        "status": null
+      },
+      "ageofempiresmobile": {
+        "anticheats": [
+          "Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "aion": {
+        "anticheats": [
+          "nProtect GameGuard",
+          "XIGNCODE3",
+          "SARD Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "alaraprime": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "albiononline": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "americasarmy": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "americasarmy3": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "americasarmyprovinggrounds": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "anno117paxromana": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "anno1800": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper",
+          "VMProtect"
+        ],
+        "status": null
+      },
+      "anno2205": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "anthem": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "apbreloaded": {
+        "anticheats": [
+          "SARD Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "apexlegends": {
+        "anticheats": [
+          "Easy Anti-Cheat",
+          "Hyperion"
+        ],
+        "anti_tamper": [],
+        "status": "Denied"
+      },
+      "archeage": {
+        "anticheats": [
+          "XIGNCODE3"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "arcraiders": {
+        "anticheats": [
+          "Easy Anti-Cheat",
+          "Denuvo Anti-Cheat",
+          "AnyBrain",
+          "Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "arenabreakoutinfinite": {
+        "anticheats": [
+          "Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": "Denied"
+      },
+      "argo": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "arknightsendfield": {
+        "anticheats": [
+          "Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "arksurvivalascended": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "arksurvivalevolved": {
+        "anticheats": [
+          "BattlEye",
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "arksurvivalofthefittest": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "arma2": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "arma3": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "armareforger": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "armoredcorevifiresofrubicon": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [
+          "Arxan Anti-Tamper"
+        ],
+        "status": "Supported"
+      },
+      "armoredwarfare": {
+        "anticheats": [
+          "StarForce MMOG"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "arpiel": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "ashesofcreationapocalypse": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "assassinscreedblackflagresynced": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "assassinscreedbrotherhood": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "assassinscreediii": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "assassinscreedivblackflag": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "assassinscreedmirage": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper",
+          "VMProtect"
+        ],
+        "status": null
+      },
+      "assassinscreedodyssey": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper",
+          "VMProtect"
+        ],
+        "status": null
+      },
+      "assassinscreedorigins": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper",
+          "VMProtect"
+        ],
+        "status": null
+      },
+      "assassinscreedrevelations": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "assassinscreedshadows": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "assassinscreedvalhalla": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper",
+          "VMProtect"
+        ],
+        "status": null
+      },
+      "atlas": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "atomfall": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "atomicheart": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "atotalwarsagatroy": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "auditiononline": {
+        "anticheats": [
+          "Easy Anti-Cheat",
+          "XIGNCODE3"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "avadogtag": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "avatarfrontiersofpandora": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper",
+          "VMProtect"
+        ],
+        "status": null
+      },
+      "avorion": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "babylonsfall": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "back4blood": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "battlebitremastered": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "battleborn": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Arxan Anti-Tamper"
+        ],
+        "status": null
+      },
+      "battlecorearena": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "battlefield1": {
+        "anticheats": [
+          "EA Javelin"
+        ],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": "Denied"
+      },
+      "battlefield1942": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "battlefield2": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "battlefield2042": {
+        "anticheats": [
+          "EA Javelin"
+        ],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": "Denied"
+      },
+      "battlefield2142": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "battlefield3": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "battlefield4": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "battlefield6": {
+        "anticheats": [
+          "EA Javelin"
+        ],
+        "anti_tamper": [],
+        "status": "Denied"
+      },
+      "battlefieldbadcompany2": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "battlefieldhardline": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": "Running"
+      },
+      "battlefieldheroes": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "battlefieldplay4free": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "battlefieldv": {
+        "anticheats": [
+          "EA Javelin"
+        ],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": "Denied"
+      },
+      "battlefieldvietnam": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "battlefleetgothicarmada2": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "battleteams2": {
+        "anticheats": [
+          "Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "battlezone2017": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "beyondgoodampevil20thanniversaryedition": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "beyondthewire": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "blackcloverquartetknights": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "blackdesert": {
+        "anticheats": [
+          "Easy Anti-Cheat",
+          "XIGNCODE3"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "blacklightretribution": {
+        "anticheats": [
+          "BattlEye",
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "blackmythwukong": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "blackshotmercenarywarfarefps": {
+        "anticheats": [
+          "BattlEye",
+          "nProtect GameGuard"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "blacksquad": {
+        "anticheats": [
+          "BattlEye",
+          "nProtect GameGuard"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "bladeampsoul": {
+        "anticheats": [
+          "nProtect GameGuard",
+          "XIGNCODE3"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "blankosblockparty": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "bleachrebirthofsouls": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "bleedingedge": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "blessonline": {
+        "anticheats": [
+          "BattlEye",
+          "XIGNCODE3"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "blessunleashed": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "blindfire": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "blocknload": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "bluearchive": {
+        "anticheats": [
+          "Nexon Game Security",
+          "XIGNCODE3"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "blueprotocolstarresonance": {
+        "anticheats": [
+          "Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "borderlands4": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "boundary2023": {
+        "anticheats": [
+          "Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "bravelydefaultflyingfairyhdremaster": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "brawlhalla": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "brokenarrow": {
+        "anticheats": [
+          "Broken Arrow Anti-Cheat System"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "burnoutparadiseremastered": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "cabalonline": {
+        "anticheats": [
+          "Easy Anti-Cheat",
+          "nProtect GameGuard",
+          "XIGNCODE3"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "caliber": {
+        "anticheats": [
+          "SARD Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "callofduty": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "callofduty2": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "callofduty4modernwarfare": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "callofdutyblackops6": {
+        "anticheats": [
+          "Ricochet Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "callofdutyblackopsii": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "callofdutyblackopsiii": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Arxan Anti-Tamper"
+        ],
+        "status": "Supported"
+      },
+      "callofdutyinfinitewarfare": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Arxan Anti-Tamper"
+        ],
+        "status": "Supported"
+      },
+      "callofdutymobile": {
+        "anticheats": [
+          "Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "callofdutymodernwarfare": {
+        "anticheats": [
+          "Ricochet Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "callofdutymodernwarfareii": {
+        "anticheats": [
+          "Ricochet Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "callofdutymodernwarfareiii": {
+        "anticheats": [
+          "Ricochet Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "callofdutyonline": {
+        "anticheats": [
+          "Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "callofdutyvanguard": {
+        "anticheats": [
+          "Ricochet Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "callofdutywarzone20": {
+        "anticheats": [
+          "Ricochet Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "callofdutyworldatwar": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "callofdutywwii": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Arxan Anti-Tamper"
+        ],
+        "status": "Supported"
+      },
+      "captaintsubasariseofnewchampions": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "cardlifecardboardsurvival": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "carxstreet": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "centuryageofashes": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "championsofanteria": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "chimeraland": {
+        "anticheats": [
+          "Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "chivalry2": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "chronoodyssey": {
+        "anticheats": [
+          "XIGNCODE3"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "citybattlevirtualearth": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "citytransportsimulator2026": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "codevein": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "codeveinii": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "combatarms": {
+        "anticheats": [
+          "Easy Anti-Cheat",
+          "HackShield",
+          "nProtect GameGuard"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "conanexiles": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "concord": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Denied"
+      },
+      "constructionsimulator": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "contractwarsclient": {
+        "anticheats": [
+          "Saberclaw Anticheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "counterstrike2": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "counterstrikeconditionzero": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "counterstrikeglobaloffensive": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "counterstrikeonline": {
+        "anticheats": [
+          "nProtect GameGuard",
+          "HackShield",
+          "Nexon Game Security",
+          "XIGNCODE3"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "crackdown3": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Arxan Anti-Tamper"
+        ],
+        "status": null
+      },
+      "crasher": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "crimsondesert": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "crittercrunch": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "crossfire": {
+        "anticheats": [
+          "Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "crossfirehd": {
+        "anticheats": [
+          "Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "crossout": {
+        "anticheats": [
+          "BattlEye",
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "crowz": {
+        "anticheats": [
+          "XIGNCODE3"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "crsedcuisineroyale": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": "Denied"
+      },
+      "crucible": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "crysis": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "crysis2remastered": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "crysis3remastered": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "crysiswarhead": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "damagedcore": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "darwinproject": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "dauntless": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "dayofdefeat": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "dayofdefeatsource": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "dayz": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "dayzmod": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "deadbydaylight": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "deadisland": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "deadlock": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "deadrising4": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "deadside": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "deadspace2023": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "deathgardenbloodharvest": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "deathloop": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "deceit2": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "deceiveinc": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "deltaforce2024": {
+        "anticheats": [
+          "Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "demonslayerkimetsunoyaibasweeptheboard": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "demonslayerkimetsunoyaibathehinokamichronicles": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "demonslayerkimetsunoyaibathehinokamichronicles2": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "depth": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "destiny2": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": "Denied"
+      },
+      "deusexmankinddivided": {
+        "anticheats": [],
+        "anti_tamper": [
+          "SecuROM",
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "diabotical": {
+        "anticheats": [
+          "EQU8"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "diaboticalrogue": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "digimonstorytimestranger": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "dirt4": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "dirt5": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "dirtrally20": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "dirtybomb": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "discoverytourancientegypt": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper",
+          "VMProtect"
+        ],
+        "status": null
+      },
+      "divineknockout": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "djmaxrespectv": {
+        "anticheats": [
+          "XIGNCODE3"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "doom3": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "doomthedarkages": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "dragonageinquisition": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "dragonballfighterz": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": "Broken"
+      },
+      "dragonballthebreakers": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "dragonballxenoverse2": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "dragonquestheroesii": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "dragonquestviireimagined": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "dragonquestxi": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "dragonsaga": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "dragonsdogmaii": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "dreadnought": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "dueprocess": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Planned"
+      },
+      "duetnightabyss": {
+        "anticheats": [
+          "Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "dukenukemforeverrestorationproject": {
+        "anticheats": [
+          "In-House"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "duneawakening": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "dungeonborne": {
+        "anticheats": [
+          "Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "dungeonfighteronline": {
+        "anticheats": [
+          "Nexon Game Security",
+          "Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "dyinglightbadblood": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "dystopia": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "easportsfc24": {
+        "anticheats": [
+          "EA Javelin"
+        ],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": "Denied"
+      },
+      "easportsfc25": {
+        "anticheats": [
+          "EA Javelin"
+        ],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": "Denied"
+      },
+      "easportsfc26": {
+        "anticheats": [
+          "EA Javelin"
+        ],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": "Denied"
+      },
+      "easportsfconline": {
+        "anticheats": [
+          "Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "easportspgatour": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "easportswrc": {
+        "anticheats": [
+          "EA Javelin"
+        ],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "ebaseballprospirit": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "echoesofaincrad": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "edgeofnowhere": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "efootball": {
+        "anticheats": [
+          "Denuvo Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "efootballpes2020": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "efootballpes2021seasonupdate": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "eldenring": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [
+          "Arxan Anti-Tamper"
+        ],
+        "status": "Supported"
+      },
+      "eldenringnightreign": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "elsword": {
+        "anticheats": [
+          "nProtect GameGuard",
+          "XIGNCODE3"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "empyriongalacticsurvival": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "enemyterritoryquakewars": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "enlisted": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "epicseven": {
+        "anticheats": [
+          "XIGNCODE3"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "escapefromtarkov": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": "Planned"
+      },
+      "escapefromtarkovarena": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "eternalmagic": {
+        "anticheats": [
+          "XIGNCODE3"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "eternalreturnblacksurvival": {
+        "anticheats": [
+          "XIGNCODE3",
+          "Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "etrianodysseyhd": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "etrianodysseyiihd": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "etrianodysseyiiihd": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "evegunjack": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "everybodysgolfhotshots": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "evevanguard": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "evildeadthegame": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "evilgenius2worlddomination": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "evolvestage2": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "exoborne": {
+        "anticheats": [
+          "AnyBrain",
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "exoprimal": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "f12016": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "f12017": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "f12018": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "f12019": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "f12021": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "f122": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "f123": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "f124": {
+        "anticheats": [
+          "EA Javelin"
+        ],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": "Denied"
+      },
+      "f125": {
+        "anticheats": [
+          "EA Javelin"
+        ],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": "Denied"
+      },
+      "f1manager2022": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "f1manager2023": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "f1manager2024": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper",
+          "VMProtect"
+        ],
+        "status": null
+      },
+      "faaastpenguin": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "fallguys": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "fantasylifeithegirlwhostealstime": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "farchangingtides": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "farcry": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "farcry2": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "farcry3": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "farcry5": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper",
+          "VMProtect"
+        ],
+        "status": "Supported"
+      },
+      "farcry6": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper",
+          "VMProtect"
+        ],
+        "status": null
+      },
+      "farcrynewdawn": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper",
+          "VMProtect"
+        ],
+        "status": null
+      },
+      "farcryprimal": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "farlight84": {
+        "anticheats": [
+          "NetEase Yidun"
+        ],
+        "anti_tamper": [],
+        "status": "Denied"
+      },
+      "fatetrigger": {
+        "anticheats": [
+          "Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "faultelderorb": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "fe": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "fear": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "fearonline": {
+        "anticheats": [
+          "XIGNCODE3"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "fearperseusmandate": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "fearthewolves": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "fellowship": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "fernbussimulator": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "fifa15": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "fifa16": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "fifa17": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "fifa18": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "fifa19": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "fifa20": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "fifa21": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "fifa22": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "fifa23": {
+        "anticheats": [
+          "EA Javelin"
+        ],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "finalfantasytacticstheivalicechronicles": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "finalfantasyxv": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "firefightingsimulatorthesquad": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "fishingplanet": {
+        "anticheats": [
+          "Denuvo Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "flippinmisfits": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "flyff": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "footballmanager2017": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "footballmanager2018": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "footballmanager2019": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "footballmanager2020": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "footballmanager2020touch": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "footballmanager2021": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "footballmanager2021touch": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "footballmanager2022": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "footballmanager2023": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "footballmanager2024": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "footballmanager26": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "footballmanagertouch2017": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "footballmanagertouch2018": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "footballmanagertouch2019": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "forhonor": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": "Supported"
+      },
+      "fortifyte": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "fortnite": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Denied"
+      },
+      "fortressforever": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "forzahorizon3": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Arxan Anti-Tamper"
+        ],
+        "status": null
+      },
+      "forzahorizon4": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Arxan Anti-Tamper"
+        ],
+        "status": null
+      },
+      "forzamotorsport7": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Arxan Anti-Tamper"
+        ],
+        "status": null
+      },
+      "foxhole": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "fractalspace": {
+        "anticheats": [
+          "Steam"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "fracturedlands": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "fragpunk": {
+        "anticheats": [
+          "NEAC Protect"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "freedomwarsremastered": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "freestyle2streetbasketball": {
+        "anticheats": [
+          "XIGNCODE3"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "fridaythe13ththegame": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [
+          "Arxan Anti-Tamper"
+        ],
+        "status": "Running"
+      },
+      "friendsvsfriends": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "frontlinesfuelofwar": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "gameofthroneskingsroad": {
+        "anticheats": [
+          "XIGNCODE3"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "garfieldkart2allyoucandrift": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "gears5": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [
+          "Arxan Anti-Tamper"
+        ],
+        "status": "Running"
+      },
+      "gearsofwar4": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Arxan Anti-Tamper"
+        ],
+        "status": null
+      },
+      "gearsofwarreloaded": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "genshinimpact": {
+        "anticheats": [
+          "HoYoKProtect"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "ghostintheshellstandalonecomplexfirstassaultonline": {
+        "anticheats": [
+          "Nexon Game Security"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "ghostsoftabor": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": "Denied"
+      },
+      "gigantic": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "goddessofvictorynikke": {
+        "anticheats": [
+          "Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "godeater2rageburst": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "godeaterresurrection": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "goosegooseduck": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "grandtheftautov": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [
+          "Arxan Anti-Tamper"
+        ],
+        "status": "Denied"
+      },
+      "grandtheftautovenhanced": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "gransaga": {
+        "anticheats": [
+          "nProtect GameGuard"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "grayzonewarfare": {
+        "anticheats": [
+          "AnyBrain",
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "grid2": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "gridlegends": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "gundamevolution": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "gunztheduel": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "halflife": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "halflife2deathmatch": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "halflifecrossproductmultiplayer": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "halflifedeathmatchsource": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "halflifeopposingforce": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "halo2anniversary": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "halo3": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "halo3odst": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "halo4": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "halocombatevolvedanniversary": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "haloinfinite": {
+        "anticheats": [
+          "Arbiter",
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "haloreach": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "halothemasterchiefcollection": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "handball17": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "harrypotterquidditchchampions": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": "Supported"
+      },
+      "hatsunemikuprojectdivamegamix": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "hawked": {
+        "anticheats": [
+          "MRAC Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "heat": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "heavenburnsred": {
+        "anticheats": [
+          "Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "helldivers2": {
+        "anticheats": [
+          "nProtect GameGuard"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "hellisothers": {
+        "anticheats": [
+          "Easy Anti Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "hellletloose": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "hellokittyislandadventure": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "heroesampgenerals": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "herosiege": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "hhourworldselite": {
+        "anticheats": [
+          "Easy Anti-Cheat",
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "hideampholdouth2o": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "highguard": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "hiredops": {
+        "anticheats": [
+          "Saberclaw Anticheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "hogwartslegacy": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "honkaiimpact3rd": {
+        "anticheats": [
+          "Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "honkaistarrail": {
+        "anticheats": [
+          "HoYoKProtect"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "hoodoutlawsamplegends": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "huntingsimulator": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "huntshowdown1896": {
+        "anticheats": [
+          "Easy Anti-Cheat",
+          "AnyBrain"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "hurtworld": {
+        "anticheats": [
+          "Epic Online Services"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "hyperscape": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "icarusonline": {
+        "anticheats": [
+          "XIGNCODE3"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "immortalsfenyxrising": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper",
+          "VMProtect"
+        ],
+        "status": null
+      },
+      "inazumaelevenvictoryroad": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "infestationthenewbeginning": {
+        "anticheats": [
+          "Fredaikis Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "infestationworld": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "infinitynikki": {
+        "anticheats": [
+          "Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "insurgencysandstorm": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "intershelter": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "intruder": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "iracing": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "ironsight": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "ithasmyface": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "jabronibrawlepisode3": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "jointoperationstyphoonrising": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "jojosbizarreadventureallstarbattler": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "judgment": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "jumpforce": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "jurassicworldevolution": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "jurassicworldevolution2": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "jurassicworldevolution3": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "justcause4": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "justdance2017": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "justiceonline": {
+        "anticheats": [
+          "NEAC Protect"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "kartriderdrift": {
+        "anticheats": [
+          "Nexon Game Security"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "killingfloor2": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "killingfloor3": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "kingarthurlegendsrise": {
+        "anticheats": [
+          "XIGNCODE3"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "kingdomunderfire2": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "kingshunt": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "knightonline": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "knockoutcity": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "kogama": {
+        "anticheats": [
+          "KoGaMa Built-in Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "kritikaonline": {
+        "anticheats": [
+          "Easy Anti-Cheat",
+          "XIGNCODE3"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "lastoasis": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "latale": {
+        "anticheats": [
+          "nProtect GameGuard",
+          "XIGNCODE3"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "leagueoflegends": {
+        "anticheats": [
+          "Packman",
+          "Anti-Cheat Expert",
+          "Riot Vanguard"
+        ],
+        "anti_tamper": [],
+        "status": "Denied"
+      },
+      "left4dead": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "left4dead2": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "leftalive": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "legendsofruneterra": {
+        "anticheats": [
+          "Packman"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "legobatmanlegacyofthedarkknight": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "lemnisgate": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "lifeisstrange2": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "lifeisstrangereunion": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "likeadragongaidenthemanwhoerasedhisname": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "likeadragoninfinitewealth": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "likeadragonishin": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "likeadragonpirateyakuzainhawaii": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "limbuscompany": {
+        "anticheats": [
+          "Warden Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "lineage": {
+        "anticheats": [
+          "nProtect GameGuard",
+          "SARD Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "lineageii": {
+        "anticheats": [
+          "nProtect GameGuard",
+          "XIGNCODE3"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "lineofsight": {
+        "anticheats": [
+          "BattlEye",
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "loadout": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "lordsofthefallen": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "lordsofthefallen2023": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "lostark": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "lostinrandom": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "lostjudgment": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "lostsaga": {
+        "anticheats": [
+          "Easy Anti-Cheat",
+          "nProtect GameGuard"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "lunaonlinereborn": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "mabinogi": {
+        "anticheats": [
+          "nProtect GameGuard",
+          "HackShield",
+          "Nexon Game Security"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "maddennfl19": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "maddennfl20": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "maddennfl21": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "maddennfl22": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "maddennfl24": {
+        "anticheats": [
+          "EA Javelin"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "maddennfl25": {
+        "anticheats": [
+          "EA Javelin"
+        ],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "maddennfl26": {
+        "anticheats": [
+          "EA Javelin"
+        ],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "madmax": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "mafiatheoldcountry": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "magickawizardwars": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "maneater": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "maplestory": {
+        "anticheats": [
+          "nProtect GameGuard",
+          "HackShield",
+          "XIGNCODE3"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "marathon2026": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "marauders": {
+        "anticheats": [
+          "Easy Anti-Cheat",
+          "Denuvo Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "marvelrivals": {
+        "anticheats": [
+          "NEAC Protect"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "marvelsguardiansofthegalaxy": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "marvelsmidnightsuns": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "mechabreak": {
+        "anticheats": [
+          "Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "mechwarriorlivinglegends": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "medalofhonor2010": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "medalofhonorairborne": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "medalofhonorwarfighter": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "megamanstarforcelegacycollection": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "megatonmusashiwired": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "memoriesofmars": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "metalgearsolidvthephantompain": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "metalslugawakening": {
+        "anticheats": [
+          "Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "metaphorrefantazio": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "metin2": {
+        "anticheats": [
+          "HackShield"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "microsoftflightsimulator2020": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Arxan Anti-Tamper"
+        ],
+        "status": null
+      },
+      "middleearthshadowofwar": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "midnightghosthunt": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "mightampmagicclashofheroes": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "mightampmagicheroesvii": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "mightampmagicheroesviitrialbyfire": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "militaryconflictvietnam": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "miniroyale": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "mirrorsedgecatalyst": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "mobilesuitgundambattleoperation2": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "monopoly2024": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "monopolymadness": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "monopolyplus": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "monopolystarwarsheroesvsvillains": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "monsterhunteronline": {
+        "anticheats": [
+          "nProtect GameGuard"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "monsterhunterstories3twistedreflection": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "monsterhunterwilds": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "monsterjamshowdown": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "monstrum2": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "moonbasealpha": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "mortalkombat1": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "motogp25": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "mountampbladeiibannerlord": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "mulegend": {
+        "anticheats": [
+          "Easy Anti-Cheat",
+          "nProtect GameGuard"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "mumuplayer": {
+        "anticheats": [
+          "Netease AC"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "myheroultrarumble": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "narakabladepoint": {
+        "anticheats": [
+          "NEAC Protect"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "narutotoborutoshinobistriker": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "nba2k24": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "nba2k25": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": "Running"
+      },
+      "nba2k26": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "needforspeed2016": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "needforspeededge": {
+        "anticheats": [
+          "Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "needforspeedheat": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "needforspeedhotpursuitremastered": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "needforspeedmobile": {
+        "anticheats": [
+          "Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "needforspeedpayback": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "needforspeedprostreet": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "needforspeedunbound": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "needforspeedundercover": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "nevernesstoeverness": {
+        "anticheats": [
+          "Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "newgundambreaker": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": "Running"
+      },
+      "newworld": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "nextdaysurvival": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "ninjagaiden4": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Arxan Anti-Tamper"
+        ],
+        "status": null
+      },
+      "nostale": {
+        "anticheats": [
+          "nProtect GameGuard",
+          "XTrap"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "octopathtraveler0": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "oddballers": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "offensivecombatredux": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "offthegrid": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "oncehuman": {
+        "anticheats": [
+          "NEAC Protect",
+          "Netease Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "onepunchmanaheronobodyknows": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "openfortress": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "outpostinfinitysiege": {
+        "anticheats": [
+          "SCUE4"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "overstep": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "overturn": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "paladinschampionsoftherealm": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "pandemicexpress": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "panzer": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "paragontheoverprime": {
+        "anticheats": [
+          "XIGNCODE3"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "pavlovvr": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "paxdei": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "persona3portable": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "persona3reload": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "persona4arenaultimax": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "persona4golden": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "persona4revival": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "persona5royal": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "persona5strikers": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "persona5tactica": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "pgatour2k25": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "phantasystaronline2newgenesis": {
+        "anticheats": [
+          "XIGNCODE3"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "phantasystaruniverse": {
+        "anticheats": [
+          "nProtect GameGuard"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "phantasystaruniverseambitionoftheilluminus": {
+        "anticheats": [
+          "nProtect GameGuard"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "phantombladezero": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "phantomers": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "phasmophobia": {
+        "anticheats": [
+          "GuardingPearSoftware's Anti Cheat Pro"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "planetcoaster": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "planetcoaster2": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "planetside2": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "planetzoo": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "plantsvszombiesbattleforneighborville": {
+        "anticheats": [
+          "EA Javelin"
+        ],
+        "anti_tamper": [],
+        "status": "Denied"
+      },
+      "plantsvszombiesgardenwarfare2": {
+        "anticheats": [
+          "EA Javelin"
+        ],
+        "anti_tamper": [],
+        "status": "Denied"
+      },
+      "portal2communityedition": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "pragmata": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "predatorhuntinggrounds": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "predecessor": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "prey": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "princeofpersiathelostcrown": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper",
+          "VMProtect"
+        ],
+        "status": null
+      },
+      "pristontale": {
+        "anticheats": [
+          "nProtect GameGuard"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "proevolutionsoccer2017": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "proevolutionsoccer2018": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "proevolutionsoccer2018lite": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "proevolutionsoccer2019": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "professionalbaseballspirits20242025": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "projectcars2": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "propnight": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "pubgbattlegrounds": {
+        "anticheats": [
+          "BattlEye",
+          "Zakynthos"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "pubglite": {
+        "anticheats": [
+          "XIGNCODE3"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "puellamagimadokamagicamagiaexedra": {
+        "anticheats": [
+          "CrackProof"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "puyopuyotetris": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "quake4": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "quakeiiiarena": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "quakelive": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "quantumleague": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "rabbidspartyoflegends": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper",
+          "VMProtect"
+        ],
+        "status": null
+      },
+      "radikalfighters": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "ragnarokonline": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "raidouremasteredthemysteryofthesoullessarmy": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "rappelz": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "realmroyalereforged": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "redfall": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "redorchestra2heroesofstalingrad": {
+        "anticheats": [
+          "PunkBuster",
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "reignofkings": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "rematch": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "rend": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "residentevil6": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "residentevilrequiem": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper",
+          "VMProtect"
+        ],
+        "status": null
+      },
+      "returntocastlewolfenstein": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "reverse1999": {
+        "anticheats": [
+          "Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "rfonline": {
+        "anticheats": [
+          "Easy Anti-Cheat",
+          "nProtect GameGuard"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "ricochet": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "ridersrepublic": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "ringofelysium": {
+        "anticheats": [
+          "Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "riseofagon": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "riseoferos": {
+        "anticheats": [
+          "Denuvo Anti-Cheat"
+        ],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "risingstorm": {
+        "anticheats": [
+          "PunkBuster",
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "risingstorm2vietnam": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "robinsonthejourney": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "roblox": {
+        "anticheats": [
+          "Hyperion"
+        ],
+        "anti_tamper": [],
+        "status": "Denied"
+      },
+      "robocraft": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "rocketarena": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "rocketleague": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "rockshot": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "roguecompany": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "rumbleverse": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "rust": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Denied"
+      },
+      "s4league": {
+        "anticheats": [
+          "BattlEye",
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "sabotaj": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "salthe": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "scionsoffate": {
+        "anticheats": [
+          "Easy Anti-Cheat",
+          "XIGNCODE3"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "scottpilgrimvstheworldthegame": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper",
+          "VMProtect"
+        ],
+        "status": null
+      },
+      "screamer2026": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "scum": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "seaofsolitude": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "sectorsedge": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "shaiya": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "sherlockholmesthedevilsdaughter": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "shiningresonancerefrain": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "shinmegamitenseiiiinocturnehdremaster": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "shinmegamitenseivvengeance": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "shinobiartofvengeance": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "sidmeierscivilizationvii": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "skate": {
+        "anticheats": [
+          "EA Javelin"
+        ],
+        "anti_tamper": [],
+        "status": "Denied"
+      },
+      "skillspecialforce2": {
+        "anticheats": [
+          "Easy Anti-Cheat",
+          "XIGNCODE3"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "skullandbones": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper",
+          "VMProtect"
+        ],
+        "status": "Running"
+      },
+      "smite": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "smite2": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "sniperelite4": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": "Running"
+      },
+      "sniperelite5": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": "Running"
+      },
+      "snipereliteresistance": {
+        "anticheats": [
+          "Denuvo Anti Cheat"
+        ],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": "Running"
+      },
+      "sniperelitevr": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "sniperghostwarriorcontracts": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "soldieroffortuneiidoublehelix": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "sololevelingarise": {
+        "anticheats": [
+          "XIGNCODE3",
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "sonicampallstarsracingtransformed": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "soniccolorsultimate": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "sonicforces": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "sonicfrontiers": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "sonicorigins": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "sonicracingcrossworlds": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "sonicrumbleparty": {
+        "anticheats": [
+          "XIGNCODE3"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "sonicsuperstars": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "sonicxshadowgenerations": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "sos": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "soulhackers2": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "soulworker": {
+        "anticheats": [
+          "Xigncode"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "southparkthefracturedbutwhole": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "spacejunkies": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "spectredivide": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": "Denied"
+      },
+      "speedball2026": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "spellbreak": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "splitgatearenareloaded": {
+        "anticheats": [
+          "EQU8"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "squad": {
+        "anticheats": [
+          "Easy Anti-Cheat",
+          "Valve Anti-Cheat",
+          "Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "squad44postscriptum": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "squadron42": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "starcitizen": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "starlinkbattleforatlas": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "staroceanthelasthope4kampfullhdremaster": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "starshiptroopersextermination": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "starwarsbattlefront2015": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": "Supported"
+      },
+      "starwarsbattlefrontii2017": {
+        "anticheats": [
+          "FairFight"
+        ],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": "Supported"
+      },
+      "starwarsgalacticracer": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "starwarsoutlaws": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper",
+          "VMProtect"
+        ],
+        "status": null
+      },
+      "starwarssquadrons": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": "Supported"
+      },
+      "stateofdecay2": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Arxan Anti-Tamper"
+        ],
+        "status": null
+      },
+      "steelhunters": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "stellarblade": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "stormgate": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "strangebrigade": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "strangerthanheaven": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "streetfighter6": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "strinova": {
+        "anticheats": [
+          "Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "suddenattack2": {
+        "anticheats": [
+          "CodeMon 7"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "suddenattackzeropoint": {
+        "anticheats": [
+          "Nexon Game Security"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "suicidesquadkillthejusticeleague": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": "Supported"
+      },
+      "summonerswar": {
+        "anticheats": [
+          "nProtect GameGuard"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "superdragonballheroesworldmission": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "supermegabaseball4": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "superpeople": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "survarium": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "swordartonlinealicizationlycoris": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "swordartonlinefatalbullet": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": "Broken"
+      },
+      "swordartonlinefractureddaydream": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "swordartonlinelastrecollection": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "swordofjustice": {
+        "anticheats": [
+          "NEAC Protect"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "swordsampsoldiers": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "synced": {
+        "anticheats": [
+          "Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "syndualityechoofada": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "tacticforce": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "talesofberseria": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "talesrunner": {
+        "anticheats": [
+          "Easy Anti-Cheat",
+          "nProtect GameGuard",
+          "HackShield",
+          "XTrap"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "tarisland": {
+        "anticheats": [
+          "Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "teamfortress2": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "teamfortress2classified": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "teamfortressclassic": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "teamsonicracing": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "tera": {
+        "anticheats": [
+          "nProtect GameGuard",
+          "XIGNCODE3"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "terminullbrigade": {
+        "anticheats": [
+          "Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "testdriveunlimitedsolarcrown": {
+        "anticheats": [
+          "SARD Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "theadventuresofelliotthemillenniumtales": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "theawesomeadventuresofcaptainspirit": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "thebus": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "thecrew2": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "thecrewmotorfest": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "theculling": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "thecycle": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "thecyclefrontier": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "thedaybefore": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "thefinals": {
+        "anticheats": [
+          "Denuvo Anti-Cheat",
+          "AnyBrain",
+          "Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "thefirstberserkerkhazan": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "thefirstdescendant": {
+        "anticheats": [
+          "Easy Anti-Cheat",
+          "Nexon Game Security"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "theisle": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "thekingoffightersallstar": {
+        "anticheats": [
+          "XIGNCODE3"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "themoonlightblade": {
+        "anticheats": [
+          "Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "theoutlasttrials": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "thequietman": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "thesettlersnewallies": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "thesevendeadlysinsorigin": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "theship": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "thetexaschainsawmassacre": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "throneandliberty": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "tibia": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "tomclancysghostreconbreakpoint": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": "Supported"
+      },
+      "tomclancysghostreconfrontline": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "tomclancysghostreconfuturesoldier": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "tomclancysghostreconwildlands": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": "Broken"
+      },
+      "tomclancysrainbowsix3ravenshield": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "tomclancysrainbowsixextraction": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": "Running"
+      },
+      "tomclancysrainbowsixlockdown": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "tomclancysrainbowsixsiege": {
+        "anticheats": [
+          "BattlEye",
+          "Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": "Denied"
+      },
+      "tomclancysrainbowsixvegas": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "tomclancysrainbowsixvegas2": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "tomclancyssplintercellpandoratomorrow": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "tomclancysthedivision2": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "tonyhawksproskater12": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "topspin2k25": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "totallockdown": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "totallyaccuratebattlegrounds": {
+        "anticheats": [
+          "EQU8"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "totalwarpharaoh": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "totalwarthreekingdoms": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "totalwarwarhammer": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "totalwarwarhammerii": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "totalwarwarhammeriii": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "touristbussimulator": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "toweroffantasy": {
+        "anticheats": [
+          "VMProtect"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "towerunite": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "trainsimworld2": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "trialsrising": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper",
+          "VMProtect"
+        ],
+        "status": "Broken"
+      },
+      "tribes3rivals": {
+        "anticheats": [
+          "Denuvo Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "twopointcampus": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "twopointmuseum": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "umamusumeprettyderby": {
+        "anticheats": [
+          "CrackProof"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "unchartedwatersonline": {
+        "anticheats": [
+          "nProtect GameGuard"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "undawn": {
+        "anticheats": [
+          "Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "undecember": {
+        "anticheats": [
+          "nProtect GameGuard"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "undisputed": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "uno2016": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper",
+          "VMProtect"
+        ],
+        "status": null
+      },
+      "unravel": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "unraveltwo": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "unturned": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "vailvr": {
+        "anticheats": [
+          "Denuvo Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "valiantheartscominghome": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper",
+          "VMProtect"
+        ],
+        "status": null
+      },
+      "valkyriachronicles4": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "valorant": {
+        "anticheats": [
+          "Riot Vanguard",
+          "Packman",
+          "Tencent Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": "Denied"
+      },
+      "vampirethemasqueradebloodhunt": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Denied"
+      },
+      "videohorrorsociety": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "vindictus": {
+        "anticheats": [
+          "Nexon Game Security",
+          "XIGNCODE3"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "virtuafighter5revoworldstage": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "vrchat": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "vrising": {
+        "anticheats": [
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "warface": {
+        "anticheats": [
+          "MRAC Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "warframe": {
+        "anticheats": [
+          "Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "warhammer40000chaosgatedaemonhunters": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "warhammer40000dawnofwariii": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "warhammer40000eternalcrusade": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "warhammer40000spacemarineii": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "warhammer40000speedfreeks": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "warhammerageofsigmarrealmsofruin": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "warhammervermintide2": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "waroftheroses": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "warofthevikings": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "warrobotsfrontiers": {
+        "anticheats": [
+          "MRAC Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "warrock": {
+        "anticheats": [
+          "Easy Anti-Cheat",
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "warthunder": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "watchdogs2": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": "Running"
+      },
+      "watchdogslegion": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper",
+          "VMProtect"
+        ],
+        "status": "Supported"
+      },
+      "wayfinder": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "wbtrwelcomebacktoreality": {
+        "anticheats": [
+          "Easy Anti-Cheat",
+          "Valve Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "whitedayalabyrinthnamedschool2017": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "wildassault": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "wildgate": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "wildhearts": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "willtoliveonline": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "wolfenstein": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "wolfensteinenemyterritory": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "wolfteamreboot": {
+        "anticheats": [
+          "XIGNCODE3"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "worldoftanksheat": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "worldsadrift": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "worldwar3": {
+        "anticheats": [
+          "MRAC Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "worldwariicombatiwojima": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "worldwariicombatroadtoberlin": {
+        "anticheats": [
+          "PunkBuster"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "wormsrumble": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Broken"
+      },
+      "wrc6fiaworldrallychampionship": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "wrc7fiaworldrallychampionship": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "wutheringwaves": {
+        "anticheats": [
+          "Anti-Cheat Expert"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "wwe2k26": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "xdefiant": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": "Supported"
+      },
+      "xerasurvival": {
+        "anticheats": [
+          "Easy Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "yakuzakiwami3ampdarkties": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "yakuzalikeadragon": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "yesterdayorigins": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "z1battleroyale": {
+        "anticheats": [
+          "BattlEye"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "zenlesszonezero": {
+        "anticheats": [
+          "HoYoKProtect"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "zerohour": {
+        "anticheats": [
+          "Denuvo Anti-Cheat"
+        ],
+        "anti_tamper": [],
+        "status": "Running"
+      },
+      "zetaflyff": {
+        "anticheats": [
+          "nProtect GameGuard"
+        ],
+        "anti_tamper": [],
+        "status": null
+      },
+      "zombiearmy4deadwar": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "zombiearmyvr": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "zoneoftheendersthe2ndrunnermars": {
+        "anticheats": [],
+        "anti_tamper": [
+          "Denuvo Anti-Tamper"
+        ],
+        "status": null
+      },
+      "zula": {
+        "anticheats": [
+          "BattlEye",
+          "XIGNCODE3"
+        ],
+        "anti_tamper": [],
+        "status": null
+      }
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "dlssync",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "private": true,
   "scripts": {
     "dev": "tauri dev",
     "build": "tauri build",
+    "prebuild:kill": "node scripts/kill-dlssync.mjs",
     "check": "pnpm --filter dlssync-frontend check",
     "lint:rust": "cargo clippy --workspace --all-targets -- -D warnings",
     "fmt:rust": "cargo fmt --all",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       '@tauri-apps/plugin-updater':
         specifier: ^2.0.0
         version: 2.10.1
+      simple-icons:
+        specifier: ^16.21.0
+        version: 16.21.0
     devDependencies:
       '@fontsource-variable/jetbrains-mono':
         specifier: ^5.2.8
@@ -1040,6 +1043,10 @@ packages:
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
+
+  simple-icons@16.21.0:
+    resolution: {integrity: sha512-kH6LEx5yvBGVNaVrHnZ7D17G16CmmHiI8DD7MwIwgnWmDFTiFu4PhFZLNdV6bMGr61qbHMMTXLoo/T6C25dMGA==}
+    engines: {node: '>=0.12.18'}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -2055,6 +2062,8 @@ snapshots:
   siginfo@2.0.0: {}
 
   signal-exit@4.1.0: {}
+
+  simple-icons@16.21.0: {}
 
   source-map-js@1.2.1: {}
 

--- a/scripts/kill-dlssync.mjs
+++ b/scripts/kill-dlssync.mjs
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+import { execSync } from "node:child_process";
+
+function run(cmd) {
+  try {
+    execSync(cmd, { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const killed =
+  process.platform === "win32"
+    ? run("taskkill /IM dlssync.exe /F /T")
+    : run("pkill -x dlssync");
+
+if (killed) {
+  await new Promise((resolve) => setTimeout(resolve, 700));
+  console.log("[kill-dlssync] closed running DLSSync instance(s)");
+} else {
+  console.log("[kill-dlssync] no running DLSSync instance");
+}

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -56,6 +56,7 @@ backup-store = { path = "../crates/backup-store" }
 notifications-store = { path = "../crates/notifications-store" }
 driver-catalog = { path = "../crates/driver-catalog" }
 driver-install = { path = "../crates/driver-install" }
+system-drivers = { path = "../crates/system-drivers" }
 nvapi-drs = { path = "../crates/nvapi-drs" }
 anticheat-detect = { path = "../crates/anticheat-detect" }
 

--- a/src-tauri/src/commands/apply.rs
+++ b/src-tauri/src/commands/apply.rs
@@ -27,6 +27,11 @@ pub const STAGE_COMPLETE: &str = "complete";
 pub const STAGE_FAILED: &str = "failed";
 pub const STAGE_CANCELLED: &str = "cancelled";
 
+/// How many parent directories above the DLL being replaced the apply guard
+/// searches for a DLSS Enabler marker. Streamline plugins sit in deeply nested
+/// engine plugin folders while the enabler DLL lives near the game root.
+const STREAMLINE_ENABLER_ANCESTOR_HOPS: usize = 8;
+
 #[derive(Debug, Deserialize, Clone)]
 pub struct ApplyRequest {
     pub apply_id: String,
@@ -275,6 +280,15 @@ async fn apply_single_item(
             format!("dll not found: {}", dll_path.display()),
         ));
     }
+
+    if let Some(reason) = streamline_guard(state, &dll_path, &request.target_version) {
+        ctx.fail(
+            "Streamline plugin skipped",
+            reason.clone(),
+            Some("streamline_locked"),
+        );
+        return Ok(failure_outcome(request, &group_id, reason));
+    }
     if let Err(reason) = ensure_writable(&dll_path) {
         let class = if reason.contains("locked") {
             "lock"
@@ -498,6 +512,10 @@ async fn apply_single_item(
         created_at,
         restored_at: None,
         size_bytes: std::fs::metadata(&backup_path).ok().map(|m| m.len()),
+        backup_type: "dll".to_string(),
+        device_class: None,
+        hardware_id: None,
+        driver_provider: None,
     };
     if let Err(e) = state
         .backups
@@ -520,29 +538,65 @@ async fn apply_single_item(
         }
     }
     if let Err(e) = atomic_replace(&staged_dll, &dll_path) {
-        ctx.fail("Replace failed", e.to_string(), Some("other"));
+        let os = e.raw_os_error().unwrap_or(0);
+        let (class, msg) = if os == 32 || os == 33 {
+            (
+                "lock",
+                format!(
+                    "{filename} is locked — the game may still be running. Close it and retry."
+                ),
+            )
+        } else {
+            ("other", format!("atomic replace failed: {e}"))
+        };
         if let Err(roll) = std::fs::copy(&backup_path, &dll_path) {
             tracing::error!(error = %roll, "rollback after replace failure also failed");
         }
-        return Ok(failure_outcome(
-            request,
-            &group_id,
-            format!("atomic replace failed: {e}"),
-        ));
+        ctx.fail("Replace failed", msg.clone(), Some(class));
+        return Ok(failure_outcome(request, &group_id, msg));
     }
     ctx.stage(STAGE_REPLACE, "Installed", None, None);
     drop(staging);
 
-    ctx.stage(STAGE_VERIFY_POST, "Reading new DLL version", None, None);
-    let new_version = tokio::task::spawn_blocking({
+    let post_algo = dll_catalog::HashAlgo::from_hex_len(&release.sha256)
+        .unwrap_or(dll_catalog::HashAlgo::Sha256);
+    let installed_hash = tokio::task::spawn_blocking({
         let dll_path = dll_path.clone();
-        move || pe_version::read_dll_version(&dll_path).ok()
+        move || dll_catalog::hash_file_with(&dll_path, post_algo)
     })
     .await
     .ok()
-    .flatten()
-    .map(|v| v.file_version)
-    .unwrap_or_else(|| release.version.clone());
+    .and_then(|r| r.ok());
+    if !installed_hash
+        .as_deref()
+        .is_some_and(|h| h.eq_ignore_ascii_case(&release.sha256))
+    {
+        if let Err(roll) = std::fs::copy(&backup_path, &dll_path) {
+            tracing::error!(error = %roll, "rollback after post-swap hash mismatch also failed");
+        }
+        let got = installed_hash.unwrap_or_else(|| "unreadable".to_string());
+        let err = format!(
+            "post-swap integrity check failed for {filename}: expected {} got {} — rolled back to \
+             the previous DLL",
+            release.sha256, got
+        );
+        ctx.fail("Post-swap verify failed", err.clone(), Some("hash"));
+        return Ok(failure_outcome(request, &group_id, err));
+    }
+
+    ctx.stage(STAGE_VERIFY_POST, "Reading new DLL version", None, None);
+    let new_version = match tokio::time::timeout(
+        Duration::from_secs(5),
+        tokio::task::spawn_blocking({
+            let dll_path = dll_path.clone();
+            move || pe_version::read_dll_version(&dll_path).ok()
+        }),
+    )
+    .await
+    {
+        Ok(Ok(Some(v))) => v.file_version,
+        _ => release.version.clone(),
+    };
     ctx.stage(
         STAGE_VERIFY_POST,
         &format!("Installed version: {new_version}"),
@@ -734,7 +788,102 @@ pub fn classify_error(message: &str) -> &'static str {
     if lower.contains("backup") {
         return "backup";
     }
+    if lower.contains("streamline plugin")
+        || lower.contains("injector mod")
+        || lower.contains("version-locked")
+    {
+        return "streamline_locked";
+    }
     "other"
+}
+
+/// First numeric dotted segment of a version string (the SDK major), or `None`.
+fn version_major(version: &str) -> Option<u16> {
+    version
+        .split('.')
+        .next()
+        .map(|p| {
+            p.chars()
+                .take_while(|c| c.is_ascii_digit())
+                .collect::<String>()
+        })
+        .filter(|p| !p.is_empty())
+        .and_then(|p| p.parse().ok())
+}
+
+/// Authoritative crash-safety gate for the NVIDIA Streamline version-locked set.
+/// Returns `Some(reason)` when an `sl.*` plugin must NOT be swapped: an injector
+/// mod manages the set, the user has not opted in, or the target crosses the
+/// installed Streamline MAJOR (v1↔v2 is the real cause of the launch crashes —
+/// older games ship SL 1.x and break when newer 2.x plugins are swapped in).
+/// NGX DLLs (`nvngx_*.dll`) are never gated — the driver loads them
+/// independently and they are safe to swap on their own.
+fn streamline_guard(
+    state: &StateHandles,
+    dll_path: &std::path::Path,
+    target_version: &str,
+) -> Option<String> {
+    let filename = dll_path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or_default();
+    if !dll_scanner::is_streamline_plugin(filename) {
+        return None;
+    }
+    let enabler_present =
+        dll_scanner::dlss_enabler_present_near(dll_path, STREAMLINE_ENABLER_ANCESTOR_HOPS);
+    let allow_streamline = state.settings.read().update_prefs.update_streamline;
+    let installed_major = pe_version::read_dll_version(dll_path)
+        .ok()
+        .and_then(|v| version_major(&v.file_version));
+    let target_major = version_major(target_version);
+    streamline_block_reason(
+        filename,
+        enabler_present,
+        allow_streamline,
+        installed_major,
+        target_major,
+    )
+}
+
+/// Pure decision for the Streamline guard, split out so it is testable without a
+/// live `StateHandles`. `None` = safe to swap.
+fn streamline_block_reason(
+    filename: &str,
+    enabler_present: bool,
+    allow_streamline: bool,
+    installed_major: Option<u16>,
+    target_major: Option<u16>,
+) -> Option<String> {
+    if !dll_scanner::is_streamline_plugin(filename) {
+        return None;
+    }
+    if enabler_present {
+        return Some(format!(
+            "{filename} is an NVIDIA Streamline plugin and an injector mod (DLSS Enabler / \
+             OptiScaler / dlssg-to-fsr3) manages the Streamline set for this game — swapping it \
+             mismatches the set and crashes the game on launch (kFeatureReflex context is \
+             missing). Skipped to keep the game working."
+        ));
+    }
+    if !allow_streamline {
+        return Some(format!(
+            "{filename} is an NVIDIA Streamline plugin (sl.*). Updating it without the matching \
+             sl.interposer.dll can crash the game on launch. Enable 'Update NVIDIA Streamline \
+             runtime' in Settings → Advanced to override."
+        ));
+    }
+    if let (Some(installed), Some(target)) = (installed_major, target_major) {
+        if installed != target {
+            return Some(format!(
+                "{filename} is NVIDIA Streamline v{installed}.x in this game but the catalog \
+                 version is v{target}.x. Streamline is version-locked by major release — swapping \
+                 across majors (v{installed} to v{target}) crashes the game on launch. Skipped; \
+                 only same-major Streamline updates are applied."
+            ));
+        }
+    }
+    None
 }
 
 fn ensure_writable(path: &std::path::Path) -> Result<(), String> {
@@ -901,5 +1050,55 @@ mod tests {
         let a = group_id_for("https://example.test/a.zip");
         let b = group_id_for("https://example.test/b.zip");
         assert_ne!(a, b);
+    }
+
+    #[test]
+    fn streamline_guard_allows_ngx_dll_regardless_of_prefs() {
+        assert!(streamline_block_reason("nvngx_dlss.dll", false, false, None, None).is_none());
+        assert!(
+            streamline_block_reason("nvngx_dlssg.dll", true, false, Some(1), Some(2)).is_none()
+        );
+        assert!(streamline_block_reason("libxess.dll", true, false, None, None).is_none());
+    }
+
+    #[test]
+    fn streamline_guard_blocks_plugin_when_streamline_opt_in_off() {
+        let reason = streamline_block_reason("sl.dlss_g.dll", false, false, None, None).unwrap();
+        assert!(reason.contains("Streamline"));
+        assert!(reason.contains("Settings"));
+        assert_eq!(classify_error(&reason), "streamline_locked");
+    }
+
+    #[test]
+    fn streamline_guard_allows_same_major_plugin_when_opted_in_and_no_enabler() {
+        assert!(streamline_block_reason("sl.dlss_g.dll", false, true, Some(2), Some(2)).is_none());
+        assert!(streamline_block_reason("sl.reflex.dll", false, true, None, None).is_none());
+    }
+
+    #[test]
+    fn streamline_guard_blocks_plugin_when_dlss_enabler_present_even_if_opted_in() {
+        let reason =
+            streamline_block_reason("sl.reflex.dll", true, true, Some(2), Some(2)).unwrap();
+        assert!(reason.contains("DLSS Enabler"));
+        assert!(reason.contains("kFeatureReflex"));
+        assert_eq!(classify_error(&reason), "streamline_locked");
+    }
+
+    #[test]
+    fn streamline_guard_blocks_cross_major_swap_even_when_opted_in() {
+        let reason =
+            streamline_block_reason("sl.interposer.dll", false, true, Some(1), Some(2)).unwrap();
+        assert!(reason.contains("version-locked"));
+        assert!(reason.contains("v1"));
+        assert!(reason.contains("v2"));
+        assert_eq!(classify_error(&reason), "streamline_locked");
+    }
+
+    #[test]
+    fn version_major_parses_first_numeric_segment() {
+        assert_eq!(version_major("2.11.1"), Some(2));
+        assert_eq!(version_major("1.5.0.0"), Some(1));
+        assert_eq!(version_major("310.6.0.0"), Some(310));
+        assert_eq!(version_major(""), None);
     }
 }

--- a/src-tauri/src/commands/dlss_profile.rs
+++ b/src-tauri/src/commands/dlss_profile.rs
@@ -24,14 +24,29 @@ const EXE_SKIP_TOKENS: &[&str] = &[
     "touchup",
 ];
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DlssOverrideSource {
+    PerGame,
+    Global,
+    None,
+}
+
 #[derive(Debug, Clone, Serialize)]
-pub struct DlssSettingValue {
-    pub id: u32,
-    pub value: Option<u32>,
+pub struct DlssOverrideReadback {
+    pub config: DlssOverrideConfig,
+    pub source: DlssOverrideSource,
+    pub active_count: u32,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ApplyOutcome {
+    pub needs_elevation: bool,
+    pub denied_settings: Vec<u32>,
 }
 
 #[cfg(windows)]
-fn run_apply(scope: &OverrideScope, settings: &[DrsSetting]) -> Result<(), String> {
+fn run_apply(scope: &OverrideScope, settings: &[DrsSetting]) -> Result<Vec<u32>, String> {
     nvapi_drs::ffi::apply_overrides(scope, settings)
 }
 
@@ -46,7 +61,7 @@ fn run_read(scope: &OverrideScope, ids: &[u32]) -> Result<Vec<(u32, Option<u32>)
 }
 
 #[cfg(not(windows))]
-fn run_apply(_scope: &OverrideScope, _settings: &[DrsSetting]) -> Result<(), String> {
+fn run_apply(_scope: &OverrideScope, _settings: &[DrsSetting]) -> Result<Vec<u32>, String> {
     Err("DLSS overrides require Windows with an NVIDIA driver".to_string())
 }
 
@@ -70,12 +85,16 @@ pub async fn dlss_overrides_supported(state: State<'_, AppState>) -> AppResult<b
 pub async fn apply_dlss_override(
     scope: OverrideScope,
     config: DlssOverrideConfig,
-) -> AppResult<()> {
+) -> AppResult<ApplyOutcome> {
     let settings = config.to_drs_settings();
-    tokio::task::spawn_blocking(move || run_apply(&scope, &settings))
+    let denied = tokio::task::spawn_blocking(move || run_apply(&scope, &settings))
         .await
         .map_err(|e| AppError::Other(format!("dlss apply task: {e}")))?
-        .map_err(AppError::Other)
+        .map_err(AppError::Other)?;
+    Ok(ApplyOutcome {
+        needs_elevation: !denied.is_empty(),
+        denied_settings: denied,
+    })
 }
 
 #[tauri::command]
@@ -87,16 +106,35 @@ pub async fn reset_dlss_override(scope: OverrideScope) -> AppResult<()> {
 }
 
 #[tauri::command]
-pub async fn read_dlss_override(scope: OverrideScope) -> AppResult<Vec<DlssSettingValue>> {
+pub async fn read_dlss_override_config(scope: OverrideScope) -> AppResult<DlssOverrideReadback> {
     let ids = RESETTABLE_IDS.to_vec();
-    let raw = tokio::task::spawn_blocking(move || run_read(&scope, &ids))
-        .await
-        .map_err(|e| AppError::Other(format!("dlss read task: {e}")))?
-        .map_err(AppError::Other)?;
-    Ok(raw
-        .into_iter()
-        .map(|(id, value)| DlssSettingValue { id, value })
-        .collect())
+    tokio::task::spawn_blocking(move || -> Result<DlssOverrideReadback, String> {
+        let config = DlssOverrideConfig::from_drs_settings(&run_read(&scope, &ids)?);
+        if matches!(scope, OverrideScope::PerGame { .. }) && config.is_empty() {
+            let inherited =
+                DlssOverrideConfig::from_drs_settings(&run_read(&OverrideScope::Global, &ids)?);
+            if !inherited.is_empty() {
+                return Ok(DlssOverrideReadback {
+                    active_count: inherited.active_override_count() as u32,
+                    config: inherited,
+                    source: DlssOverrideSource::Global,
+                });
+            }
+        }
+        let source = match (&scope, config.is_empty()) {
+            (_, true) => DlssOverrideSource::None,
+            (OverrideScope::Global, false) => DlssOverrideSource::Global,
+            (OverrideScope::PerGame { .. }, false) => DlssOverrideSource::PerGame,
+        };
+        Ok(DlssOverrideReadback {
+            active_count: config.active_override_count() as u32,
+            config,
+            source,
+        })
+    })
+    .await
+    .map_err(|e| AppError::Other(format!("dlss read config task: {e}")))?
+    .map_err(AppError::Other)
 }
 
 fn collect_executables(dir: &Path, depth: usize, out: &mut Vec<(u64, PathBuf)>) {

--- a/src-tauri/src/commands/drivers.rs
+++ b/src-tauri/src/commands/drivers.rs
@@ -225,10 +225,22 @@ pub async fn install_driver(
         progress_tx: Some(tx),
         ..Default::default()
     };
-    let downloaded = download_to_file(&client, &download_url, &dest, opts)
-        .await
-        .map_err(|e| AppError::Other(e.to_string()))?;
-    let _ = pump.await;
+    let downloaded = match download_to_file(&client, &download_url, &dest, opts).await {
+        Ok(d) => {
+            let _ = pump.await;
+            d
+        }
+        Err(e) => {
+            let _ = pump.await;
+            emit_stage(
+                &app,
+                InstallStage::Failed,
+                &format!("Download failed: {e}"),
+                None,
+            );
+            return Err(AppError::Other(e.to_string()));
+        }
+    };
 
     emit_stage(
         &app,
@@ -238,10 +250,19 @@ pub async fn install_driver(
     );
     let verify_path = downloaded.path.clone();
     let verify_vendor = vendor.clone();
-    tokio::task::spawn_blocking(move || verify_signature(&verify_path, &verify_vendor))
-        .await
-        .map_err(|e| AppError::Other(format!("verify task: {e}")))?
-        .map_err(|e| AppError::Other(e.to_string()))?;
+    if let Err(e) =
+        tokio::task::spawn_blocking(move || verify_signature(&verify_path, &verify_vendor))
+            .await
+            .map_err(|e| AppError::Other(format!("verify task: {e}")))?
+    {
+        emit_stage(
+            &app,
+            InstallStage::Failed,
+            &format!("Signature verification failed: {e}"),
+            None,
+        );
+        return Err(AppError::Other(e.to_string()));
+    }
 
     emit_stage(
         &app,
@@ -256,10 +277,24 @@ pub async fn install_driver(
         None,
     );
     let launch_path = downloaded.path.clone();
-    let exit_code = tokio::task::spawn_blocking(move || launch_installer(&launch_path))
-        .await
-        .map_err(|e| AppError::Other(format!("launch task: {e}")))?
-        .map_err(AppError::Other)?;
+    let exit_code = match tokio::task::spawn_blocking(move || launch_installer(&launch_path)).await
+    {
+        Ok(Ok(code)) => code,
+        Ok(Err(e)) => {
+            emit_stage(
+                &app,
+                InstallStage::Failed,
+                &format!("Launch failed: {e}"),
+                None,
+            );
+            return Err(AppError::Other(e));
+        }
+        Err(e) => {
+            let msg = format!("launch task: {e}");
+            emit_stage(&app, InstallStage::Failed, &msg, None);
+            return Err(AppError::Other(msg));
+        }
+    };
 
     let stage = classify_exit(exit_code);
     let message = describe_exit(exit_code, &vendor);

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -12,4 +12,5 @@ pub mod scan;
 pub mod settings;
 pub mod shell;
 pub mod system;
+pub mod system_drivers;
 pub mod ui_prefs;

--- a/src-tauri/src/commands/notifications.rs
+++ b/src-tauri/src/commands/notifications.rs
@@ -92,6 +92,7 @@ mod tests {
             apply_id: Some(format!("apply-{title}")),
             game_id: Some(format!("steam-{title}")),
             error_class: None,
+            link: None,
         }
     }
 

--- a/src-tauri/src/commands/scan.rs
+++ b/src-tauri/src/commands/scan.rs
@@ -62,6 +62,18 @@ pub async fn detect_dlls(
     Ok(records)
 }
 
+#[tauri::command]
+pub async fn detect_dlss_enabler(
+    _state: State<'_, AppState>,
+    install_dir: String,
+) -> AppResult<bool> {
+    let path = PathBuf::from(install_dir);
+    let present = tokio::task::spawn_blocking(move || dll_scanner::detect_dlss_enabler(&path))
+        .await
+        .map_err(|e| AppError::Other(e.to_string()))?;
+    Ok(present)
+}
+
 fn deduplicate(games: Vec<DetectedGame>) -> Vec<DetectedGame> {
     let mut seen = std::collections::HashSet::new();
     let mut out = Vec::with_capacity(games.len());

--- a/src-tauri/src/commands/system_drivers.rs
+++ b/src-tauri/src/commands/system_drivers.rs
@@ -1,0 +1,496 @@
+//! General PC driver engine commands (audio/network/Bluetooth/input/storage/
+//! chipset/USB/firmware/camera/printer) backed by `system-drivers`
+//! (WMI inventory + Windows Update Agent / Microsoft Update Catalog, with the
+//! anti-downgrade guard). GPUs keep their dedicated vendor sources elsewhere.
+
+use crate::error::{AppError, AppResult};
+use crate::state::AppState;
+use serde::{Deserialize, Serialize};
+use system_drivers::{DeviceGroup, InstallProgress, InstallReport, InstallStage};
+use tauri::{AppHandle, Emitter, State};
+
+const SYSTEM_DRIVER_INSTALL_EVENT: &str = "system_driver_install_progress";
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SystemDriverOutcome {
+    pub success: bool,
+    pub reboot_required: bool,
+    pub result_code: i32,
+    pub message: String,
+}
+
+/// Installed-device context the install carries so it can snapshot the current
+/// driver (`pnputil /export-driver`) and record a rollback-able backup before
+/// applying the update. Sourced from the matched `DriverUpdate` fields.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DriverInstallContext {
+    pub inf_name: Option<String>,
+    pub hardware_id: Option<String>,
+    pub device_class: Option<String>,
+    pub provider: Option<String>,
+    pub current_version: Option<String>,
+}
+
+/// One DriverStore version of a driver package (current or superseded), for the
+/// "old / latest versions" display in System & Components.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DriverStoreVersion {
+    pub published_name: String,
+    pub version: String,
+    pub date: Option<String>,
+    pub provider: String,
+    pub current: bool,
+}
+
+#[cfg(windows)]
+fn scan_blocking() -> Result<Vec<DeviceGroup>, String> {
+    use system_drivers::{
+        dedup_updates, filter_safe_updates, group_by_class, DeviceCatalog, UpdateSource,
+        WmiInventory, WuaSource,
+    };
+    let devices = WmiInventory.inventory().map_err(|e| e.to_string())?;
+    let updates = WuaSource.search().map_err(|e| e.to_string())?;
+    let safe = filter_safe_updates(&devices, updates);
+    let deduped = dedup_updates(&devices, safe);
+    Ok(group_by_class(deduped))
+}
+
+#[cfg(not(windows))]
+fn scan_blocking() -> Result<Vec<DeviceGroup>, String> {
+    Err("system driver scan requires Windows".to_string())
+}
+
+/// WUA download+install are Administrator-only (they fail with E_ACCESSDENIED
+/// when the app runs unelevated). Run the install in an elevated child of
+/// ourselves via UAC — the same per-action elevation model as the GPU installer
+/// — and read back the `InstallReport` JSON it writes. The app stays unelevated.
+/// Elevated WUA install can legitimately take a while (download + driver
+/// service work); cap the wait so a stuck UAC dialog or hung WUA service can
+/// never freeze the UI forever — the child is terminated and a Failed terminal
+/// state is surfaced.
+#[cfg(windows)]
+const SYSTEM_DRIVER_INSTALL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30 * 60);
+
+#[cfg(windows)]
+fn install_blocking(
+    app: &AppHandle,
+    update_id: &str,
+    context: &DriverInstallContext,
+) -> Result<SystemDriverOutcome, String> {
+    let emit = |stage: InstallStage, message: &str, fraction: Option<f64>| {
+        let _ = app.emit(
+            SYSTEM_DRIVER_INSTALL_EVENT,
+            &InstallProgress {
+                stage,
+                message: message.to_string(),
+                fraction,
+            },
+        );
+    };
+
+    emit(
+        InstallStage::Installing,
+        "Waiting for administrator approval…",
+        Some(0.05),
+    );
+
+    let exe = std::env::current_exe().map_err(|e| format!("current_exe: {e}"))?;
+    let safe: String = update_id
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+        .collect();
+    let tmp = std::env::temp_dir();
+    let probe = tmp.join(format!("dlssync-probe-{safe}.tmp"));
+    if let Err(e) = std::fs::write(&probe, b"x") {
+        return Err(format!("temp dir is not writable ({}): {e}", tmp.display()));
+    }
+    let _ = std::fs::remove_file(&probe);
+    let result_path = tmp.join(format!("dlssync-wua-{safe}.json"));
+    let progress_path = tmp.join(format!("dlssync-wua-{safe}.progress.json"));
+    let _ = std::fs::remove_file(&result_path);
+    let _ = std::fs::remove_file(&progress_path);
+
+    let snapshot = plan_driver_snapshot(app, context);
+
+    let mut args = format!(
+        "--wua-install \"{}\" --result \"{}\" --progress-file \"{}\"",
+        update_id,
+        result_path.display(),
+        progress_path.display()
+    );
+    if let Some((inf, dest, _)) = snapshot.as_ref() {
+        args.push_str(&format!(
+            " --snapshot-inf \"{}\" --snapshot-dest \"{}\"",
+            inf,
+            dest.display()
+        ));
+    }
+
+    let mut last_emitted = String::new();
+    let on_tick = || {
+        if let Ok(json) = std::fs::read_to_string(&progress_path) {
+            if json != last_emitted {
+                if let Ok(p) = serde_json::from_str::<InstallProgress>(&json) {
+                    let _ = app.emit(SYSTEM_DRIVER_INSTALL_EVENT, &p);
+                    last_emitted = json;
+                }
+            }
+        }
+    };
+
+    let code = driver_install::launch::launch_elevated(
+        &exe,
+        &args,
+        None,
+        Some(SYSTEM_DRIVER_INSTALL_TIMEOUT),
+        on_tick,
+    )
+    .map_err(|e| e.to_string())?;
+
+    if code == driver_install::launch::UAC_DECLINED_EXIT {
+        let msg = "Administrator approval was declined — the update was not installed.";
+        emit(InstallStage::Failed, msg, Some(1.0));
+        let _ = std::fs::remove_file(&progress_path);
+        return Ok(SystemDriverOutcome {
+            success: false,
+            reboot_required: false,
+            result_code: code,
+            message: msg.to_string(),
+        });
+    }
+
+    let outcome = match std::fs::read_to_string(&result_path) {
+        Ok(json) => match serde_json::from_str::<InstallReport>(&json) {
+            Ok(r) => SystemDriverOutcome {
+                success: r.success,
+                reboot_required: r.reboot_required,
+                result_code: r.result_code,
+                message: r.message,
+            },
+            Err(e) => SystemDriverOutcome {
+                success: false,
+                reboot_required: false,
+                result_code: code,
+                message: format!(
+                    "The update finished (exit {code}) but its result could not be parsed: {e}"
+                ),
+            },
+        },
+        Err(e) => {
+            let message = if code == 3 {
+                "Windows Update refused the install — per-machine access denied (0x80240044). \
+                 Try again, or install this driver from Windows Update directly."
+                    .to_string()
+            } else {
+                format!(
+                    "The elevated installer exited with code {code} without reporting a result ({e})."
+                )
+            };
+            SystemDriverOutcome {
+                success: false,
+                reboot_required: false,
+                result_code: code,
+                message,
+            }
+        }
+    };
+    let _ = std::fs::remove_file(&result_path);
+    let _ = std::fs::remove_file(&progress_path);
+
+    if outcome.success {
+        if let Some((inf, dest, stamp)) = snapshot {
+            record_driver_backup(app, context, &inf, &dest, stamp);
+        }
+    }
+
+    emit(
+        if outcome.success {
+            InstallStage::Completed
+        } else {
+            InstallStage::Failed
+        },
+        &outcome.message,
+        Some(1.0),
+    );
+    Ok(outcome)
+}
+
+/// Decide where the elevated child should export the current driver before the
+/// update, returning `(published_inf, dest_dir, timestamp)`. Only fires when the
+/// device reports a DriverStore `oemNN.inf` and the backup store is open. The
+/// child creates `dest_dir`; we only compute the path here so the parent (which
+/// owns the DB) can record the backup row afterwards.
+#[cfg(windows)]
+fn plan_driver_snapshot(
+    app: &AppHandle,
+    context: &DriverInstallContext,
+) -> Option<(String, std::path::PathBuf, chrono::DateTime<chrono::Utc>)> {
+    use tauri::Manager;
+    let inf = context.inf_name.as_deref()?;
+    if !system_drivers::is_published_oem_inf(inf) {
+        return None;
+    }
+    let state = app.state::<AppState>();
+    let guard = state.backups.read();
+    let root = guard.as_ref()?.root_dir.clone();
+    let key = context
+        .hardware_id
+        .as_deref()
+        .filter(|s| !s.is_empty())
+        .unwrap_or(inf);
+    let stamp = chrono::Utc::now();
+    let dest = root
+        .join("driver-backups")
+        .join(backup_store::sanitize_folder_name(key))
+        .join(stamp.format("%Y-%m-%d %H-%M-%S").to_string());
+    Some((inf.to_string(), dest, stamp))
+}
+
+/// Record a `driver_package` backup row once the elevated child has exported a
+/// non-empty snapshot. A no-op when the export produced nothing (driver not in
+/// the DriverStore as an `oemNN.inf`).
+#[cfg(windows)]
+fn record_driver_backup(
+    app: &AppHandle,
+    context: &DriverInstallContext,
+    inf: &str,
+    dest: &std::path::Path,
+    stamp: chrono::DateTime<chrono::Utc>,
+) {
+    use tauri::Manager;
+    let has_files = std::fs::read_dir(dest)
+        .map(|mut it| it.next().is_some())
+        .unwrap_or(false);
+    if !has_files {
+        return;
+    }
+    let hardware_id = context
+        .hardware_id
+        .clone()
+        .unwrap_or_else(|| "system-driver".to_string());
+    let device_class = context
+        .device_class
+        .clone()
+        .unwrap_or_else(|| "Driver".to_string());
+    let entry = backup_store::BackupEntry {
+        id: uuid::Uuid::new_v4().to_string(),
+        game_id: hardware_id.clone(),
+        dll_family: device_class.clone(),
+        dll_filename: inf.to_string(),
+        original_path: std::path::PathBuf::from(&hardware_id),
+        backup_path: dest.to_path_buf(),
+        previous_version: context.current_version.clone(),
+        previous_sha256: None,
+        created_at: stamp,
+        restored_at: None,
+        size_bytes: None,
+        backup_type: "driver_package".to_string(),
+        device_class: Some(device_class),
+        hardware_id: Some(hardware_id),
+        driver_provider: context.provider.clone(),
+    };
+    let state = app.state::<AppState>();
+    let guard = state.backups.read();
+    if let Some(store) = guard.as_ref() {
+        if let Err(e) = store.insert(&entry) {
+            tracing::warn!(error = %e, "failed to record driver-package backup");
+        }
+    }
+}
+
+#[cfg(not(windows))]
+fn install_blocking(
+    _app: &AppHandle,
+    _update_id: &str,
+    _context: &DriverInstallContext,
+) -> Result<SystemDriverOutcome, String> {
+    Err("driver install requires Windows".to_string())
+}
+
+/// Scan every non-GPU device for a newer signed driver on Windows Update /
+/// the Microsoft Update Catalog, grouped by device class. Honors the
+/// anti-downgrade guard: an entry only appears when it is provably newer than
+/// the installed driver.
+#[tauri::command]
+pub async fn scan_system_drivers() -> AppResult<Vec<DeviceGroup>> {
+    tokio::task::spawn_blocking(scan_blocking)
+        .await
+        .map_err(|e| AppError::Other(format!("system driver scan task: {e}")))?
+        .map_err(AppError::Other)
+}
+
+/// Download + install one driver update by its `UpdateID:RevisionNumber`,
+/// emitting `system_driver_install_progress` events along the way. `context`
+/// carries the matched device's DriverStore INF so the elevated child can
+/// snapshot the current driver (and lay a System Restore checkpoint) before
+/// applying the update — recorded as a rollback-able `driver_package` backup.
+#[tauri::command]
+pub async fn install_system_driver(
+    app: AppHandle,
+    update_id: String,
+    context: Option<DriverInstallContext>,
+) -> AppResult<SystemDriverOutcome> {
+    let context = context.unwrap_or_default();
+    tokio::task::spawn_blocking(move || install_blocking(&app, &update_id, &context))
+        .await
+        .map_err(|e| AppError::Other(format!("system driver install task: {e}")))?
+        .map_err(AppError::Other)
+}
+
+/// Roll a System & Components driver back to a previously-snapshotted version by
+/// re-installing its exported DriverStore package (`pnputil /add-driver
+/// /install`) via an elevated child. Marks the backup restored on success.
+#[tauri::command]
+pub async fn restore_system_driver(
+    state: State<'_, AppState>,
+    backup_id: String,
+) -> AppResult<SystemDriverOutcome> {
+    let entry = {
+        let guard = state.backups.read();
+        let store = guard
+            .as_ref()
+            .ok_or_else(|| AppError::Other("backup store not initialized".into()))?;
+        store.get(&backup_id)?
+    };
+    if entry.backup_type != "driver_package" {
+        return Err(AppError::Other(
+            "this backup is a game DLL, not a system driver".into(),
+        ));
+    }
+    let outcome = restore_blocking(entry.backup_path.clone()).await?;
+    if outcome.success {
+        let guard = state.backups.read();
+        if let Some(store) = guard.as_ref() {
+            store.mark_restored(&backup_id, chrono::Utc::now())?;
+        }
+    }
+    Ok(outcome)
+}
+
+#[cfg(windows)]
+async fn restore_blocking(dir: std::path::PathBuf) -> AppResult<SystemDriverOutcome> {
+    const RESTORE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15 * 60);
+    tokio::task::spawn_blocking(move || -> Result<SystemDriverOutcome, String> {
+        if !dir.is_dir() {
+            return Err(format!("snapshot folder is missing: {}", dir.display()));
+        }
+        let exe = std::env::current_exe().map_err(|e| format!("current_exe: {e}"))?;
+        let tmp = std::env::temp_dir();
+        let result_path = tmp.join(format!("dlssync-restore-{}.json", std::process::id()));
+        let _ = std::fs::remove_file(&result_path);
+        let args = format!(
+            "--restore-driver \"{}\" --result \"{}\"",
+            dir.display(),
+            result_path.display()
+        );
+        let code = driver_install::launch::launch_elevated(
+            &exe,
+            &args,
+            None,
+            Some(RESTORE_TIMEOUT),
+            || {},
+        )
+        .map_err(|e| e.to_string())?;
+        if code == driver_install::launch::UAC_DECLINED_EXIT {
+            return Ok(SystemDriverOutcome {
+                success: false,
+                reboot_required: false,
+                result_code: code,
+                message: "Administrator approval was declined — the rollback did not run."
+                    .to_string(),
+            });
+        }
+        let outcome = match std::fs::read_to_string(&result_path) {
+            Ok(json) => match serde_json::from_str::<InstallReport>(&json) {
+                Ok(r) => SystemDriverOutcome {
+                    success: r.success,
+                    reboot_required: r.reboot_required,
+                    result_code: r.result_code,
+                    message: r.message,
+                },
+                Err(e) => SystemDriverOutcome {
+                    success: false,
+                    reboot_required: false,
+                    result_code: code,
+                    message: format!(
+                        "Rollback finished (exit {code}) but its result was unreadable: {e}"
+                    ),
+                },
+            },
+            Err(e) => SystemDriverOutcome {
+                success: false,
+                reboot_required: false,
+                result_code: code,
+                message: format!(
+                    "The rollback helper exited with code {code} without a result ({e})."
+                ),
+            },
+        };
+        let _ = std::fs::remove_file(&result_path);
+        Ok(outcome)
+    })
+    .await
+    .map_err(|e| AppError::Other(format!("driver rollback task: {e}")))?
+    .map_err(AppError::Other)
+}
+
+#[cfg(not(windows))]
+async fn restore_blocking(_dir: std::path::PathBuf) -> AppResult<SystemDriverOutcome> {
+    Err(AppError::Other("driver rollback requires Windows".into()))
+}
+
+/// List the DriverStore versions (current + superseded) of the driver package
+/// published as `inf_name` (`oemNN.inf`), newest-first, so the UI can show the
+/// installed version alongside the older ones still cached locally. Reads
+/// `pnputil /enum-drivers` (works unelevated); returns an empty list off Windows
+/// or when the package isn't found.
+#[tauri::command]
+pub async fn system_driver_versions(inf_name: String) -> AppResult<Vec<DriverStoreVersion>> {
+    #[cfg(windows)]
+    {
+        tokio::task::spawn_blocking(move || enum_driver_versions(&inf_name))
+            .await
+            .map_err(|e| AppError::Other(format!("driver versions task: {e}")))?
+            .map_err(AppError::Other)
+    }
+    #[cfg(not(windows))]
+    {
+        let _ = inf_name;
+        Ok(Vec::new())
+    }
+}
+
+#[cfg(windows)]
+fn enum_driver_versions(inf_name: &str) -> Result<Vec<DriverStoreVersion>, String> {
+    use std::os::windows::process::CommandExt;
+    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+    let inf = inf_name.to_ascii_lowercase();
+    let output = std::process::Command::new("pnputil.exe")
+        .args(["/enum-drivers"])
+        .creation_flags(CREATE_NO_WINDOW)
+        .output()
+        .map_err(|e| format!("pnputil /enum-drivers: {e}"))?;
+    let text = String::from_utf8_lossy(&output.stdout);
+    let packages = system_drivers::parse_enum_drivers(&text);
+    let Some(original) = packages
+        .iter()
+        .find(|p| p.published_name.eq_ignore_ascii_case(&inf))
+        .map(|p| p.original_name.to_ascii_lowercase())
+    else {
+        return Ok(Vec::new());
+    };
+    let groups = system_drivers::versions_by_original_name(&packages);
+    let list = groups.get(&original).cloned().unwrap_or_default();
+    Ok(list
+        .into_iter()
+        .map(|p| DriverStoreVersion {
+            current: p.published_name.eq_ignore_ascii_case(&inf),
+            published_name: p.published_name,
+            version: p.version,
+            date: p.date,
+            provider: p.provider,
+        })
+        .collect())
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -41,8 +41,134 @@ fn sweep_stale_staging_dirs(root: &std::path::Path) {
     }
 }
 
+/// Dispatch the two ELEVATED-child modes this process can be relaunched in via
+/// UAC (by the System & Components driver commands). Returns the child exit code,
+/// or `None` for a normal (GUI) launch.
+///
+/// - `--restore-driver <dir>`: re-install an exported DriverStore snapshot
+///   (rollback). Writes an `InstallReport` JSON to `--result`.
+/// - `--wua-install <UpdateID:Rev>`: snapshot the current driver
+///   (`--snapshot-inf`/`--snapshot-dest`, best-effort) then run the
+///   Administrator-only WUA download+install. Writes incremental progress to
+///   `--progress-file` and the `InstallReport` to `--result`.
+///
+/// Either way the GUI is never started.
+#[cfg(windows)]
+fn try_run_wua_install_child() -> Option<i32> {
+    let args: Vec<String> = std::env::args().collect();
+    let arg_after = |flag: &str| -> Option<String> {
+        args.iter()
+            .position(|a| a == flag)
+            .and_then(|i| args.get(i + 1))
+            .cloned()
+    };
+
+    if let Some(dir) = arg_after("--restore-driver") {
+        return Some(run_driver_restore_child(&dir, arg_after("--result")));
+    }
+    let update_id = arg_after("--wua-install")?;
+    Some(run_wua_install_child(
+        &update_id,
+        arg_after("--result"),
+        arg_after("--progress-file"),
+        arg_after("--snapshot-inf"),
+        arg_after("--snapshot-dest"),
+    ))
+}
+
+#[cfg(windows)]
+fn run_driver_restore_child(dir: &str, result_path: Option<String>) -> i32 {
+    use system_drivers::InstallReport;
+    let (report, exit) =
+        match system_drivers::driver_snapshot::restore_driver(std::path::Path::new(dir)) {
+            Ok(()) => (
+                InstallReport {
+                    success: true,
+                    reboot_required: true,
+                    result_code: 0,
+                    message: "Driver rolled back from its pre-update snapshot.".to_string(),
+                },
+                0,
+            ),
+            Err(e) => (
+                InstallReport {
+                    success: false,
+                    reboot_required: false,
+                    result_code: -1,
+                    message: format!("Rollback failed: {e}"),
+                },
+                2,
+            ),
+        };
+    if let Some(path) = result_path {
+        if let Ok(json) = serde_json::to_string(&report) {
+            let _ = std::fs::write(&path, json);
+        }
+    }
+    exit
+}
+
+#[cfg(windows)]
+fn run_wua_install_child(
+    update_id: &str,
+    result_path: Option<String>,
+    progress_path: Option<String>,
+    snapshot_inf: Option<String>,
+    snapshot_dest: Option<String>,
+) -> i32 {
+    use system_drivers::{InstallProgress, InstallReport, UpdateSource, WuaSource};
+
+    if let (Some(inf), Some(dest)) = (snapshot_inf.as_deref(), snapshot_dest.as_deref()) {
+        let _ = system_drivers::driver_snapshot::export_driver(inf, std::path::Path::new(dest));
+        let _ = system_drivers::driver_snapshot::create_restore_point(
+            "DLSSync — before System & Components driver update",
+        );
+    }
+
+    let mut on_progress = |p: InstallProgress| {
+        if let Some(path) = progress_path.as_deref() {
+            if let Ok(json) = serde_json::to_string(&p) {
+                let _ = std::fs::write(path, json);
+            }
+        }
+    };
+    let (report, exit) = match WuaSource.install(update_id, &mut on_progress) {
+        Ok(r) if r.success => (r, 0),
+        Ok(r) => (r, 2),
+        Err(e) => {
+            let msg = e.to_string();
+            let lower = msg.to_ascii_lowercase();
+            let exit = if msg.contains("80240044") || lower.contains("access denied") {
+                3
+            } else {
+                2
+            };
+            (
+                InstallReport {
+                    success: false,
+                    reboot_required: false,
+                    result_code: -1,
+                    message: format!("Install failed: {msg}"),
+                },
+                exit,
+            )
+        }
+    };
+    if let Some(path) = result_path {
+        if let Ok(json) = serde_json::to_string(&report) {
+            let _ = std::fs::write(&path, json);
+        }
+    }
+    exit
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    #[cfg(windows)]
+    if let Some(code) = try_run_wua_install_child() {
+        std::process::exit(code);
+    }
+
     let _log_guard = logging::init();
     tracing::info!(version = env!("CARGO_PKG_VERSION"), "DLSSync starting");
 
@@ -187,6 +313,7 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             commands::scan::scan_libraries,
             commands::scan::detect_dlls,
+            commands::scan::detect_dlss_enabler,
             commands::scan::enrich_game_art,
             commands::scan::fetch_steam_art,
             commands::shell::open_path,
@@ -223,11 +350,15 @@ pub fn run() {
             commands::drivers::check_driver_updates,
             commands::drivers::list_driver_history,
             commands::drivers::install_driver,
+            commands::system_drivers::scan_system_drivers,
+            commands::system_drivers::install_system_driver,
+            commands::system_drivers::restore_system_driver,
+            commands::system_drivers::system_driver_versions,
             commands::anticheat::detect_anticheat,
             commands::dlss_profile::dlss_overrides_supported,
             commands::dlss_profile::apply_dlss_override,
             commands::dlss_profile::reset_dlss_override,
-            commands::dlss_profile::read_dlss_override,
+            commands::dlss_profile::read_dlss_override_config,
             commands::dlss_profile::find_game_executable,
             commands::runtime::runtime_mode,
             commands::runtime::open_devtools,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,10 +1,10 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "DLSSync",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "identifier": "io.github.xt0n1-t3ch.dlssync",
   "build": {
-    "beforeBuildCommand": "pnpm --filter dlssync-frontend build",
+    "beforeBuildCommand": "pnpm -w run prebuild:kill && pnpm --filter dlssync-frontend build",
     "beforeDevCommand": "pnpm --filter dlssync-frontend dev",
     "devUrl": "http://localhost:1420",
     "frontendDist": "../frontend/dist"
@@ -32,7 +32,7 @@
   },
   "bundle": {
     "active": true,
-    "targets": ["nsis"],
+    "targets": ["nsis", "msi"],
     "publisher": "xt0n1",
     "homepage": "https://xt0n1.com",
     "copyright": "Copyright 2026 xt0n1. Licensed under Apache-2.0.",
@@ -59,6 +59,10 @@
         "displayLanguageSelector": false,
         "languages": ["English"],
         "compression": "lzma"
+      },
+      "wix": {
+        "language": ["en-US"],
+        "upgradeCode": "ebeac857-6d46-4dea-aeb1-cc5254ffae31"
       }
     }
   },

--- a/src-tauri/tests/dlss_profile_roundtrip.rs
+++ b/src-tauri/tests/dlss_profile_roundtrip.rs
@@ -39,13 +39,16 @@ fn dlss_overrides_apply_read_reset_round_trip_on_global_profile() {
         "config should yield at least one DRS write"
     );
 
-    apply_overrides(&scope, &settings)
-        .expect("apply_overrides should succeed against the live NVIDIA driver");
+    let denied = apply_overrides(&scope, &settings)
+        .expect("apply_overrides should not abort against the live NVIDIA driver");
 
     let written_ids: Vec<u32> = settings.iter().map(|s| s.id).collect();
     let read_back = read_overrides(&scope, &written_ids).expect("read_overrides should succeed");
 
     for s in &settings {
+        if denied.contains(&s.id) {
+            continue;
+        }
         let (_, value) = read_back
             .iter()
             .find(|(id, _)| *id == s.id)
@@ -60,6 +63,22 @@ fn dlss_overrides_apply_read_reset_round_trip_on_global_profile() {
         );
     }
 
+    let reconstructed = DlssOverrideConfig::from_drs_settings(
+        &read_overrides(&scope, RESETTABLE_IDS).expect("read_overrides should succeed"),
+    );
+    if denied.is_empty() {
+        assert_eq!(
+            reconstructed, cfg,
+            "elevated: the read path must reconstruct the exact applied config (forum bug #1)"
+        );
+    } else {
+        assert_eq!(
+            reconstructed.sr_preset, cfg.sr_preset,
+            "SR preset must apply + reconstruct even when FG writes are privilege-denied"
+        );
+        assert!(reconstructed.enable_sr_dll_override);
+    }
+
     reset_overrides(&scope, RESETTABLE_IDS).expect("reset_overrides should succeed");
 
     let after_reset =
@@ -70,6 +89,99 @@ fn dlss_overrides_apply_read_reset_round_trip_on_global_profile() {
             "DRS DWORD {:#x} should be cleared after reset, got {:?}",
             id,
             value,
+        );
+    }
+
+    assert!(
+        DlssOverrideConfig::from_drs_settings(
+            &read_overrides(&scope, RESETTABLE_IDS).expect("read after reset should succeed")
+        )
+        .is_empty(),
+        "a reset profile must read back as an empty (inactive) config"
+    );
+}
+
+#[test]
+#[ignore = "destructive: writes a synthetic per-game NVIDIA profile (reset after); run with --ignored on a Windows host with an NVIDIA driver"]
+fn recommended_sentinel_round_trips_on_a_synthetic_per_game_profile() {
+    let exe = std::env::temp_dir().join("dlssync_e2e_selftest.exe");
+    let scope = OverrideScope::PerGame {
+        executable_path: exe.to_string_lossy().into_owned(),
+    };
+    let _guard = ResetGuard {
+        scope: scope.clone(),
+    };
+
+    let cfg = DlssOverrideConfig {
+        enable_sr_dll_override: true,
+        sr_preset: Some(DlssPreset::Recommended),
+        enable_fg_dll_override: false,
+        fg_preset: None,
+        fg_mode: None,
+        fg_fixed_count: None,
+        fg_dynamic_target_fps: None,
+    };
+    let denied = apply_overrides(&scope, &cfg.to_drs_settings())
+        .expect("apply_overrides should succeed against the live NVIDIA driver");
+    assert!(
+        denied.is_empty(),
+        "SR-only overrides must apply without elevation; denied = {denied:?}"
+    );
+
+    let reconstructed = DlssOverrideConfig::from_drs_settings(
+        &read_overrides(&scope, RESETTABLE_IDS).expect("read_overrides should succeed"),
+    );
+    assert_eq!(
+        reconstructed, cfg,
+        "Recommended must round-trip as Recommended via 0x00FF_FFFF on the live driver"
+    );
+
+    reset_overrides(&scope, RESETTABLE_IDS).expect("reset_overrides should succeed");
+    assert!(
+        DlssOverrideConfig::from_drs_settings(
+            &read_overrides(&scope, RESETTABLE_IDS).expect("read after reset should succeed")
+        )
+        .is_empty(),
+        "a reset profile must read back as empty"
+    );
+}
+
+#[test]
+#[ignore = "destructive: writes a synthetic per-game NVIDIA profile (reset after); run with --ignored on a Windows host with an NVIDIA driver"]
+fn apply_is_resilient_to_privilege_gated_frame_gen_settings() {
+    let fg_mode_id = nvapi_drs::settings::ids::DLSS_FG_FORCED_MODE;
+    let exe = std::env::temp_dir().join("dlssync_e2e_selftest.exe");
+    let scope = OverrideScope::PerGame {
+        executable_path: exe.to_string_lossy().into_owned(),
+    };
+    let _guard = ResetGuard {
+        scope: scope.clone(),
+    };
+
+    let cfg = DlssOverrideConfig {
+        enable_sr_dll_override: true,
+        sr_preset: Some(DlssPreset::K),
+        enable_fg_dll_override: false,
+        fg_preset: None,
+        fg_mode: Some(FrameGenMode::Fixed),
+        fg_fixed_count: Some(FrameGenCount::X2),
+        fg_dynamic_target_fps: None,
+    };
+    let denied = apply_overrides(&scope, &cfg.to_drs_settings())
+        .expect("apply must not abort even when a setting is privilege-denied");
+
+    let read = DlssOverrideConfig::from_drs_settings(
+        &read_overrides(&scope, RESETTABLE_IDS).expect("read_overrides should succeed"),
+    );
+    assert_eq!(read.sr_preset, Some(DlssPreset::K));
+    assert!(read.enable_sr_dll_override);
+    if denied.is_empty() {
+        assert_eq!(read.fg_mode, Some(FrameGenMode::Fixed));
+    } else {
+        assert!(denied.contains(&fg_mode_id));
+        assert_eq!(
+            read.fg_mode, None,
+            "a privilege-denied FG setting must not be written"
         );
     }
 }

--- a/tests/components/ActivityDock.test.ts
+++ b/tests/components/ActivityDock.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { tick } from "svelte";
+import { get } from "svelte/store";
+import { render, fireEvent } from "@testing-library/svelte";
+import ActivityDock from "@/components/ActivityDock.svelte";
+import {
+  activeApplies,
+  driverInstall,
+  systemDriverInstall,
+  applyModalOpen,
+  type ApplyTracker,
+} from "@/lib/stores";
+
+function tracker(over: Partial<ApplyTracker> = {}): ApplyTracker {
+  return {
+    apply_id: "a1",
+    group_id: "g1",
+    game_id: "cyberpunk",
+    game_label: "Cyberpunk 2077",
+    dll_path: "nvngx_dlss.dll",
+    family: "dlss_sr",
+    target_version: "310.2.1",
+    stage: "downloading",
+    failed_at_stage: null,
+    message: "",
+    progress: 0.5,
+    error: null,
+    error_class: null,
+    attempt: 1,
+    bytes_downloaded: 5,
+    bytes_total: 10,
+    bytes_per_sec: 1,
+    started_at: 0,
+    ended_at: null,
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  activeApplies.set({});
+  driverInstall.set({ vendor: null, stage: null, message: "", fraction: null });
+  systemDriverInstall.set({ updateId: null, stage: null, message: "", fraction: null });
+  applyModalOpen.set(false);
+});
+
+describe("ActivityDock (rendered)", () => {
+  it("renders nothing while idle", () => {
+    const { container } = render(ActivityDock);
+    expect(container.querySelector(".activity-dock")).toBeNull();
+  });
+
+  it("shows a single active apply with its label and a determinate progress fill", async () => {
+    const { container } = render(ActivityDock);
+    activeApplies.set({ a1: tracker({ progress: 0.5 }) });
+    await tick();
+    const dock = container.querySelector(".activity-dock");
+    expect(dock).not.toBeNull();
+    expect(container.querySelector(".dock-headline")?.textContent).toBe("Cyberpunk 2077");
+    const fill = container.querySelector(".dock-fill") as HTMLElement | null;
+    expect(fill?.style.width).toBe("50%");
+  });
+
+  it("summarizes multiple concurrent tasks (apply + driver) as a count", async () => {
+    const { container } = render(ActivityDock);
+    activeApplies.set({ a1: tracker(), a2: tracker({ apply_id: "a2", game_label: "inZOI" }) });
+    driverInstall.set({ vendor: "nvidia", stage: "installing", message: "", fraction: null });
+    await tick();
+    expect(container.querySelector(".dock-headline")?.textContent).toBe("3 tasks running");
+  });
+
+  it("uses an indeterminate fill when no fraction is known", async () => {
+    const { container } = render(ActivityDock);
+    driverInstall.set({ vendor: "intel", stage: "installing", message: "", fraction: null });
+    await tick();
+    expect(container.querySelector(".dock-fill-indeterminate")).not.toBeNull();
+  });
+
+  it("opens the apply modal when expanded and an apply is active", async () => {
+    const { container } = render(ActivityDock);
+    activeApplies.set({ a1: tracker() });
+    await tick();
+    await fireEvent.click(container.querySelector(".dock-expand")!);
+    expect(get(applyModalOpen)).toBe(true);
+  });
+
+  it("ignores ended applies (only live work shows)", async () => {
+    const { container } = render(ActivityDock);
+    activeApplies.set({ a1: tracker({ ended_at: 123 }) });
+    await tick();
+    expect(container.querySelector(".activity-dock")).toBeNull();
+  });
+});

--- a/tests/components/BrandMark.test.ts
+++ b/tests/components/BrandMark.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/svelte";
+import BrandMark from "@/components/BrandMark.svelte";
+import { BRANDS } from "@/lib/brands";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("BrandMark — bundled official marks", () => {
+  it("renders an inline svg with the brand path for a known key", () => {
+    const { container } = render(BrandMark, { props: { key: "nvidia" } });
+    const svg = container.querySelector("svg.brand-glyph");
+    expect(svg).not.toBeNull();
+    const path = svg?.querySelector("path");
+    expect(path?.getAttribute("d")).toBe(BRANDS.nvidia.path);
+    expect(container.textContent).toContain("NVIDIA");
+  });
+
+  it("resolves a messy provider string to the right glyph and clean label", () => {
+    const { container } = render(BrandMark, { props: { key: "Advanced Micro Devices, Inc." } });
+    const path = container.querySelector("svg.brand-glyph path");
+    expect(path?.getAttribute("d")).toBe(BRANDS.amd.path);
+    expect(container.textContent?.trim()).toBe("AMD");
+  });
+
+  it("hides the label when showLabel is false but keeps the glyph", () => {
+    const { container } = render(BrandMark, { props: { key: "intel", showLabel: false } });
+    expect(container.querySelector("svg.brand-glyph")).not.toBeNull();
+    expect(container.querySelector(".brand-label")).toBeNull();
+  });
+
+  it("tints the glyph with the vendor token in color tone", () => {
+    const { container } = render(BrandMark, { props: { key: "nvidia", tone: "color" } });
+    const svg = container.querySelector("svg.brand-glyph") as SVGElement | null;
+    expect(svg?.getAttribute("style") ?? "").toContain("var(--vendor-nvidia)");
+  });
+
+  it("uses currentColor in mono tone so it inherits the host color", () => {
+    const { container } = render(BrandMark, { props: { key: "nvidia", tone: "mono" } });
+    const svg = container.querySelector("svg.brand-glyph") as SVGElement | null;
+    expect((svg?.getAttribute("style") ?? "").toLowerCase()).toContain("currentcolor");
+  });
+
+  it("prefers an explicit label over the resolved brand label", () => {
+    const { container } = render(BrandMark, { props: { key: "amd", label: "AMD Radeon" } });
+    expect(container.textContent?.trim()).toBe("AMD Radeon");
+    expect(container.querySelector("svg.brand-glyph path")?.getAttribute("d")).toBe(BRANDS.amd.path);
+  });
+});
+
+describe("BrandMark — dynamic Brandfetch fallback", () => {
+  it("renders a brandfetch <img> for a domain-resolved provider when a client id is configured", () => {
+    vi.stubEnv("VITE_BRANDFETCH_CLIENT_ID", "test123");
+    const { container } = render(BrandMark, { props: { key: "Realtek Semiconductor Corp." } });
+    expect(container.querySelector("svg.brand-glyph")).toBeNull();
+    const img = container.querySelector("img.brand-img") as HTMLImageElement | null;
+    expect(img).not.toBeNull();
+    expect(img?.getAttribute("src")).toContain("cdn.brandfetch.io/realtek.com");
+    expect(img?.getAttribute("src")).toContain("c=test123");
+    expect(container.textContent).toContain("Realtek");
+  });
+
+  it("falls back to label-only (no img, no glyph) for a domain-resolved provider with no client id", () => {
+    vi.stubEnv("VITE_BRANDFETCH_CLIENT_ID", "");
+    const { container } = render(BrandMark, { props: { key: "Realtek Semiconductor Corp." } });
+    expect(container.querySelector("svg.brand-glyph")).toBeNull();
+    expect(container.querySelector("img.brand-img")).toBeNull();
+    expect(container.textContent?.trim()).toBe("Realtek Semiconductor Corp.");
+  });
+
+  it("falls back to label-only with no empty glyph for an unknown provider", () => {
+    vi.stubEnv("VITE_BRANDFETCH_CLIENT_ID", "test123");
+    const { container } = render(BrandMark, { props: { key: "Acme Widgets LLC" } });
+    expect(container.querySelector("svg.brand-glyph")).toBeNull();
+    expect(container.querySelector("img.brand-img")).toBeNull();
+    expect(container.textContent?.trim()).toBe("Acme Widgets LLC");
+  });
+
+  it("renders nothing visible when provider is unknown and showLabel is false", () => {
+    const { container } = render(BrandMark, {
+      props: { key: "Acme Widgets LLC", showLabel: false },
+    });
+    expect(container.querySelector("svg.brand-glyph")).toBeNull();
+    expect(container.querySelector("img.brand-img")).toBeNull();
+    expect(container.querySelector(".brand-label")).toBeNull();
+  });
+});

--- a/tests/components/CommandPalette.test.ts
+++ b/tests/components/CommandPalette.test.ts
@@ -6,6 +6,10 @@ import { commandPaletteOpen } from "@/lib/stores";
 
 afterEach(() => commandPaletteOpen.set(false));
 
+function press(el: Element, key: string): void {
+  el.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true }));
+}
+
 describe("CommandPalette popup (rendered)", () => {
   it("renders nothing while closed", () => {
     commandPaletteOpen.set(false);
@@ -13,37 +17,76 @@ describe("CommandPalette popup (rendered)", () => {
     expect(container.querySelector(".palette")).toBeNull();
   });
 
-  it("renders the spotlight input and category chips when opened", async () => {
+  it("renders the boxed search field, an Esc chip and the category chips", async () => {
     commandPaletteOpen.set(true);
     const { container } = render(CommandPalette);
     await tick();
     const input = container.querySelector(".palette-search input") as HTMLInputElement;
     expect(input).not.toBeNull();
     expect(input.getAttribute("placeholder")).toContain("Search commands");
+    expect(container.querySelector(".palette-search-kbd")?.textContent).toContain("Esc");
     const cats = Array.from(container.querySelectorAll(".category")).map((c) => c.textContent?.trim());
     expect(cats).toEqual(expect.arrayContaining(["All", "Navigate", "Action", "Settings"]));
   });
 
-  it("lists navigation commands with category tags", async () => {
+  it("groups commands under section headers, each row with a category-tinted icon", async () => {
     commandPaletteOpen.set(true);
     const { container } = render(CommandPalette);
     await tick();
+    const heads = Array.from(container.querySelectorAll(".result-group-head")).map((h) => h.textContent?.trim());
+    expect(heads).toEqual(expect.arrayContaining(["Navigate", "Action", "Settings"]));
     expect(container.textContent).toContain("Go to Library");
-    expect(container.textContent).toContain("Go to Catalog");
     expect(container.querySelectorAll(".result").length).toBeGreaterThan(0);
-    const tags = Array.from(container.querySelectorAll(".result-tag")).map((t) => t.getAttribute("data-cat"));
-    expect(tags).toContain("navigate");
+    const cats = Array.from(container.querySelectorAll(".result-icon")).map((i) => i.getAttribute("data-cat"));
+    expect(cats).toContain("navigate");
   });
 
-  it("filters results as the query narrows", async () => {
+  it("renders a keyboard-shortcut chip for commands that declare one", async () => {
+    commandPaletteOpen.set(true);
+    const { container } = render(CommandPalette);
+    await tick();
+    const library = Array.from(container.querySelectorAll(".result")).find((r) => r.textContent?.includes("Go to Library"));
+    const keys = Array.from(library?.querySelectorAll(".result-shortcut kbd") ?? []).map((k) => k.textContent?.trim());
+    expect(keys).toEqual(["G", "L"]);
+  });
+
+  it("filters and highlights the matched characters as the query narrows", async () => {
     commandPaletteOpen.set(true);
     const { container } = render(CommandPalette);
     await tick();
     const input = container.querySelector(".palette-search input") as HTMLInputElement;
-    input.value = "backups";
+    input.value = "catalog";
     input.dispatchEvent(new Event("input", { bubbles: true }));
     await tick();
-    expect(container.textContent).toContain("Go to Backups");
-    expect(container.textContent).not.toContain("Go to Catalog");
+    expect(container.textContent).toContain("Go to Catalog");
+    expect(container.textContent).not.toContain("Go to About");
+    const marks = Array.from(container.querySelectorAll(".result-hl")).map((m) => m.textContent);
+    expect(marks).toContain("Catalog");
+  });
+
+  it("arrow keys move the active selection across group boundaries", async () => {
+    commandPaletteOpen.set(true);
+    const { container } = render(CommandPalette);
+    await tick();
+    const input = container.querySelector(".palette-search input") as HTMLInputElement;
+    const activeTitle = (): string | undefined =>
+      container.querySelector(".result.active .result-title")?.textContent?.trim();
+    expect(activeTitle()).toBe("Go to Library");
+    press(input, "ArrowDown");
+    await tick();
+    expect(activeTitle()).toBe("Go to Catalog");
+  });
+
+  it("shows a rich empty state when nothing matches", async () => {
+    commandPaletteOpen.set(true);
+    const { container } = render(CommandPalette);
+    await tick();
+    const input = container.querySelector(".palette-search input") as HTMLInputElement;
+    input.value = "zzqzzq";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    await tick();
+    expect(container.querySelector(".palette-empty")).not.toBeNull();
+    expect(container.querySelector(".palette-empty-title")?.textContent).toContain("zzqzzq");
+    expect(container.querySelectorAll(".result").length).toBe(0);
   });
 });

--- a/tests/components/ContextMenu.test.ts
+++ b/tests/components/ContextMenu.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { tick } from "svelte";
+import { render, fireEvent } from "@testing-library/svelte";
+import ContextMenu, { type ContextMenuItem } from "@/components/ContextMenu.svelte";
+
+const items: ContextMenuItem[] = [
+  { action: "open_folder", label: "Open folder" },
+  { action: "scan", label: "Scan" },
+  { action: "pin", label: "Pin a version…" },
+  { action: "hide", label: "Hide" },
+];
+
+beforeEach(() => {
+  Object.defineProperty(window, "innerWidth", { value: 1280, configurable: true });
+  Object.defineProperty(window, "innerHeight", { value: 720, configurable: true });
+});
+
+describe("ContextMenu", () => {
+  it("renders a menu with one menuitem per action", async () => {
+    const { getByRole, getAllByRole } = render(ContextMenu, {
+      props: { x: 40, y: 40, items, onSelect: vi.fn(), onClose: vi.fn() },
+    });
+    await tick();
+    expect(getByRole("menu")).toBeTruthy();
+    const menuItems = getAllByRole("menuitem");
+    expect(menuItems.length).toBe(4);
+    expect(menuItems.map((b) => b.textContent?.trim())).toEqual([
+      "Open folder",
+      "Scan",
+      "Pin a version…",
+      "Hide",
+    ]);
+  });
+
+  it("fires onSelect with the chosen action and then closes", async () => {
+    const onSelect = vi.fn();
+    const onClose = vi.fn();
+    const { getAllByRole } = render(ContextMenu, {
+      props: { x: 40, y: 40, items, onSelect, onClose },
+    });
+    await tick();
+    await fireEvent.click(getAllByRole("menuitem")[1]);
+    expect(onSelect).toHaveBeenCalledWith("scan");
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("moves focus down/up with the arrow keys (wrapping)", async () => {
+    const { getByRole, getAllByRole } = render(ContextMenu, {
+      props: { x: 40, y: 40, items, onSelect: vi.fn(), onClose: vi.fn() },
+    });
+    await tick();
+    const menu = getByRole("menu");
+    const menuItems = getAllByRole("menuitem");
+    expect(document.activeElement).toBe(menuItems[0]);
+    await fireEvent.keyDown(menu, { key: "ArrowDown" });
+    expect(document.activeElement).toBe(menuItems[1]);
+    await fireEvent.keyDown(menu, { key: "ArrowUp" });
+    expect(document.activeElement).toBe(menuItems[0]);
+    await fireEvent.keyDown(menu, { key: "ArrowUp" });
+    expect(document.activeElement).toBe(menuItems[menuItems.length - 1]);
+  });
+
+  it("dismisses on Escape", async () => {
+    const onClose = vi.fn();
+    const { getByRole } = render(ContextMenu, {
+      props: { x: 40, y: 40, items, onSelect: vi.fn(), onClose },
+    });
+    await tick();
+    await fireEvent.keyDown(getByRole("menu"), { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("dismisses on an outside pointerdown but not an inside one", async () => {
+    const onClose = vi.fn();
+    const { getByRole } = render(ContextMenu, {
+      props: { x: 40, y: 40, items, onSelect: vi.fn(), onClose },
+    });
+    await tick();
+    await fireEvent.pointerDown(getByRole("menu"));
+    expect(onClose).not.toHaveBeenCalled();
+    await fireEvent.pointerDown(document.body);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("clamps the position so it never overflows the right/bottom viewport edge", async () => {
+    const { getByRole } = render(ContextMenu, {
+      props: { x: 1276, y: 716, items, onSelect: vi.fn(), onClose: vi.fn() },
+    });
+    await tick();
+    await tick();
+    const menu = getByRole("menu") as HTMLElement;
+    const left = parseFloat(menu.style.left);
+    const top = parseFloat(menu.style.top);
+    expect(left).toBeLessThanOrEqual(window.innerWidth);
+    expect(top).toBeLessThanOrEqual(window.innerHeight);
+    expect(left).toBeGreaterThanOrEqual(0);
+    expect(top).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/tests/components/DlssOverridePanel.test.ts
+++ b/tests/components/DlssOverridePanel.test.ts
@@ -1,6 +1,8 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { render } from "@testing-library/svelte";
 import DlssOverridePanel from "@/components/DlssOverridePanel.svelte";
+import { emptyDlssConfig } from "@/lib/dlss";
+import * as api from "@/lib/api";
 
 const globalScope = { scope: "global" } as const;
 
@@ -34,5 +36,20 @@ describe("DlssOverridePanel", () => {
       props: { scope: globalScope, driverPacked: 57000 },
     });
     expect(container.textContent).toContain("572.16 or newer");
+  });
+
+  it("hydrates the form from read_dlss_override_config and labels the source (forum #1)", async () => {
+    const readback: api.DlssOverrideReadback = {
+      config: { ...emptyDlssConfig(), enable_sr_dll_override: true, sr_preset: "k" },
+      source: "global",
+      active_count: 1,
+    };
+    const spy = vi.spyOn(api, "readDlssOverrideConfig").mockResolvedValue(readback);
+    const { findByText } = render(DlssOverridePanel, {
+      props: { scope: globalScope, driverPacked: 61047 },
+    });
+    expect(await findByText(/Preset K/)).toBeTruthy();
+    expect(await findByText("Set in NVIDIA driver")).toBeTruthy();
+    spy.mockRestore();
   });
 });

--- a/tests/components/GameDetailDrawer.test.ts
+++ b/tests/components/GameDetailDrawer.test.ts
@@ -4,10 +4,10 @@ import { fileURLToPath } from "node:url";
 import { resolve, dirname } from "node:path";
 
 const here = dirname(fileURLToPath(import.meta.url));
-const drawerSource = readFileSync(
-  resolve(here, "../../frontend/src/components/GameDetailDrawer.svelte"),
-  "utf8",
-);
+const root = resolve(here, "../../frontend/src");
+const drawerSource = readFileSync(resolve(root, "components/GameDetailDrawer.svelte"), "utf8");
+const appSource = readFileSync(resolve(root, "App.svelte"), "utf8");
+const librarySource = readFileSync(resolve(root, "views/Library.svelte"), "utf8");
 
 function ruleBody(css: string, selector: string): string {
   const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -15,17 +15,36 @@ function ruleBody(css: string, selector: string): string {
   return re.exec(css)?.[1] ?? "";
 }
 
-describe("GameDetailDrawer redesign — scrim, highlight, stripe, rhythm", () => {
-  it("declares the scrim without backdrop-filter and with a radial-gradient base", () => {
-    const scrimBlock = ruleBody(drawerSource, ".drawer-scrim");
-    expect(scrimBlock).not.toMatch(/backdrop-filter/);
-    expect(drawerSource).toMatch(/\.drawer-scrim\s*\{[\s\S]*?radial-gradient/);
-    expect(drawerSource).toMatch(/@media\s*\(prefers-reduced-transparency: reduce\)/);
+describe("GameDetailView — full-page detail, not an overlay drawer", () => {
+  it("renders in-flow (no scrim, no fixed/overlay drawer, no modal attrs)", () => {
+    expect(drawerSource).not.toContain("drawer-scrim");
+    expect(drawerSource).not.toMatch(/\.drawer\s*\{[^}]*position:\s*fixed/);
+    expect(drawerSource).not.toMatch(/role="dialog"/);
+    expect(drawerSource).not.toMatch(/aria-modal/);
+    expect(drawerSource).not.toMatch(/function trapFocus/);
+    expect(drawerSource).not.toMatch(/matchMedia/);
   });
 
-  it("adds a Tahoe-style top-edge highlight on .drawer and a launcher-accent stripe on .drawer-art", () => {
-    expect(drawerSource).toMatch(/\.drawer::before\s*\{[\s\S]*?linear-gradient/);
+  it("has a Back-to-Library affordance wired to onClose, and Escape closes", () => {
+    expect(drawerSource).toMatch(/class="detail-back"[\s\S]*?onclick=\{onClose\}/);
+    expect(drawerSource).toMatch(/Back to Library/);
+    expect(drawerSource).toMatch(/e\.key === "Escape"\) onClose\(\)/);
+  });
+
+  it("uses a compact hero banner (fixed height, not a 16:9 art block) with the launcher-accent stripe", () => {
+    expect(drawerSource).toMatch(/\.detail-hero\s*\{/);
+    const art = ruleBody(drawerSource, ".drawer-art");
+    expect(art).toMatch(/height:\s*clamp/);
+    expect(art).not.toMatch(/aspect-ratio/);
     expect(drawerSource).toMatch(/\.drawer-art::before\s*\{[\s\S]*?--launcher-accent/);
+  });
+
+  it("the KPI summary scrolls with the page (not sticky) and the action bar is sticky-bottom", () => {
+    const summary = ruleBody(drawerSource, ".summary-row");
+    expect(summary).not.toMatch(/position:\s*sticky/);
+    const foot = ruleBody(drawerSource, ".drawer-foot");
+    expect(foot).toMatch(/position:\s*sticky/);
+    expect(foot).toMatch(/bottom:\s*16px/);
   });
 
   it("aligns the warning-banner Learn-more anchor with the link-btn doctrine", () => {
@@ -34,13 +53,18 @@ describe("GameDetailDrawer redesign — scrim, highlight, stripe, rhythm", () =>
     expect(learnMore).toMatch(/border-radius:\s*var\(--radius-md\)/);
     expect(learnMore).not.toMatch(/text-transform:\s*uppercase/);
   });
+});
 
-  it("widens section rhythm: warning-banner 20px, summary-row 16px, advanced-block 16px", () => {
-    const warning = ruleBody(drawerSource, ".warning-banner");
-    expect(warning).toMatch(/margin-bottom:\s*20px/);
-    const summary = ruleBody(drawerSource, ".summary-row");
-    expect(summary).toMatch(/margin-bottom:\s*16px/);
-    const advanced = ruleBody(drawerSource, ".advanced-block");
-    expect(advanced).toMatch(/margin-top:\s*16px/);
+describe("GameDetailView — wired at the app level (replaces the library content)", () => {
+  it("App renders the detail in the content area when a game is open, not Library as an overlay", () => {
+    expect(appSource).toMatch(/import GameDetailDrawer from "\.\/components\/GameDetailDrawer\.svelte"/);
+    expect(appSource).toMatch(/\$currentView === "library" && \$drawerGameId/);
+    expect(appSource).toContain("<GameDetailDrawer");
+  });
+
+  it("Library no longer renders the detail itself and drops the push-padding side-panel", () => {
+    expect(librarySource).not.toContain("GameDetailDrawer");
+    expect(appSource).not.toContain("data-drawer-open");
+    expect(appSource).not.toMatch(/padding-right:\s*var\(--drawer-width\)/);
   });
 });

--- a/tests/components/NotificationsBell.test.ts
+++ b/tests/components/NotificationsBell.test.ts
@@ -1,8 +1,15 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { tick } from "svelte";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 import { render } from "@testing-library/svelte";
 import NotificationsBell from "@/components/NotificationsBell.svelte";
 import { notifications, makeNotificationEntry } from "@/lib/notifications";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const readSrc = (rel: string): string =>
+  readFileSync(resolve(here, "../../frontend/src", rel), "utf8");
 
 beforeEach(() => notifications.set([]));
 afterEach(() => notifications.set([]));
@@ -49,11 +56,65 @@ describe("NotificationsBell popup (rendered)", () => {
     expect(tints).toEqual(["green", "red", "blue", "purple", "orange"]);
   });
 
+  it("renders external link actions: release entry gets GitHub + Nexus, driver entry gets one", async () => {
+    notifications.set([
+      makeNotificationEntry("app_update_available", "DLSSync v1.6.0 available", "Fixed XeSS", {
+        link: "https://github.com/xt0n1-t3ch/DLSSync/releases/tag/v1.6.0",
+      }),
+      makeNotificationEntry("driver_update_available", "GPU driver 999.99 — RTX 4070 Ti SUPER", "New NVIDIA driver", {
+        link: "https://www.nvidia.com/notes",
+      }),
+      makeNotificationEntry("apply_success", "no links here"),
+    ]);
+    const { container } = render(NotificationsBell, { props: { open: true, onClose: vi.fn() } });
+    await tick();
+    const items = container.querySelectorAll(".bell-item");
+    const releaseLinks = items[0].querySelectorAll(".bell-item-link");
+    expect(releaseLinks.length).toBe(2);
+    expect(Array.from(releaseLinks).map((b) => b.textContent?.trim())).toEqual(
+      expect.arrayContaining([expect.stringContaining("GitHub release"), expect.stringContaining("Nexus Mods")]),
+    );
+    expect(items[1].querySelectorAll(".bell-item-link").length).toBe(1);
+    expect(items[2].querySelectorAll(".bell-item-link").length).toBe(0);
+  });
+
+  it("maps the new kinds to badge tints", async () => {
+    notifications.set([
+      makeNotificationEntry("driver_update_available", "gpu"),
+      makeNotificationEntry("system_driver_update_available", "sys"),
+      makeNotificationEntry("backup_restored", "restored"),
+    ]);
+    const { container } = render(NotificationsBell, { props: { open: true, onClose: vi.fn() } });
+    await tick();
+    const tints = Array.from(container.querySelectorAll(".bell-item-badge")).map((b) => b.getAttribute("data-tint"));
+    expect(tints).toEqual(["green", "purple", "green"]);
+  });
+
   it("marks unread entries with the accent stripe", async () => {
     notifications.set([makeNotificationEntry("apply_success", "unread one")]);
     const { container } = render(NotificationsBell, { props: { open: true, onClose: vi.fn() } });
     await tick();
     expect(container.querySelector(".bell-item-unread")).not.toBeNull();
     expect(container.querySelector(".bell-unread-stripe")).not.toBeNull();
+  });
+});
+
+describe("NotificationsBell mount-location contract (frosted-glass fix)", () => {
+  it("panel is fixed-positioned, not absolute inside the TopBar", () => {
+    const src = readSrc("components/NotificationsBell.svelte");
+    expect(src).toMatch(/\.bell-panel\s*\{[^}]*position:\s*fixed/);
+    expect(src).not.toMatch(/\.bell-panel\s*\{[^}]*position:\s*absolute/);
+  });
+
+  it("TopBar no longer nests the panel inside its glass backdrop root", () => {
+    const topbar = readSrc("components/TopBar.svelte");
+    expect(topbar).not.toContain("NotificationsBell");
+    expect(topbar).toContain("data-notifications-toggle");
+  });
+
+  it("the panel is mounted at the app root next to the command palette", () => {
+    const app = readSrc("App.svelte");
+    expect(app).toContain("<NotificationsBell");
+    expect(app).toContain("notificationsOpen");
   });
 });

--- a/tests/components/Toast.test.ts
+++ b/tests/components/Toast.test.ts
@@ -43,4 +43,24 @@ describe("Toast popup (rendered)", () => {
     await tick();
     expect(container.querySelector(".toast-close")).not.toBeNull();
   });
+
+  it("renders a kind-icon tinted to the toast kind", async () => {
+    const { container } = render(Toast);
+    showToast("danger", "boom");
+    await tick();
+    const icon = container.querySelector(".toast-icon");
+    expect(icon).not.toBeNull();
+    expect(icon?.getAttribute("data-kind")).toBe("danger");
+    expect(icon?.querySelector("svg")).not.toBeNull();
+  });
+
+  it("renders an auto-dismiss progress indicator carrying the ttl duration", async () => {
+    const { container } = render(Toast);
+    showToast("info", "draining", 5000);
+    await tick();
+    const progress = container.querySelector(".toast-progress") as HTMLElement | null;
+    expect(progress).not.toBeNull();
+    expect(progress?.getAttribute("data-kind")).toBe("info");
+    expect(progress?.style.getPropertyValue("--toast-ttl")).toBe("5000ms");
+  });
 });

--- a/tests/components/glassDialogUnification.test.ts
+++ b/tests/components/glassDialogUnification.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const componentsDir = resolve(here, "../../frontend/src/components");
+
+function source(name: string): string {
+  return readFileSync(resolve(componentsDir, name), "utf8");
+}
+
+describe("Phase 8 — floating chrome shares the .glass-dialog material", () => {
+  const dialogPanels = [
+    "ApplyProgressModal.svelte",
+    "VersionPickerPopover.svelte",
+    "CatalogVersionsFlyout.svelte",
+    "DriverHistoryFlyout.svelte",
+    "Select.svelte",
+    "NotificationsBell.svelte",
+  ];
+
+  it("applies the .glass-dialog class on every floating-chrome panel", () => {
+    for (const file of dialogPanels) {
+      expect(source(file), `${file} should carry glass-dialog`).toContain("glass-dialog");
+    }
+  });
+
+  const closableDialogs = [
+    "ApplyProgressModal.svelte",
+    "VersionPickerPopover.svelte",
+    "CatalogVersionsFlyout.svelte",
+    "DriverHistoryFlyout.svelte",
+  ];
+
+  it("uses the shared .dialog-close affordance instead of bespoke close buttons", () => {
+    for (const file of closableDialogs) {
+      const src = source(file);
+      expect(src, `${file} should use dialog-close`).toContain('class="dialog-close"');
+      expect(src, `${file} must not keep a bespoke close class`).not.toMatch(
+        /class="(modal-close|picker-close|flyout-close)"/,
+      );
+    }
+  });
+
+  it("drops the bespoke per-component glass/vendor-stripe surfaces", () => {
+    for (const file of dialogPanels) {
+      const src = source(file);
+      expect(src, `${file} must not redefine backdrop-filter locally`).not.toContain(
+        "backdrop-filter: var(--glass-blur)",
+      );
+    }
+    expect(source("CatalogVersionsFlyout.svelte")).not.toContain('class="vendor-stripe"');
+    expect(source("DriverHistoryFlyout.svelte")).not.toContain('class="vendor-stripe"');
+  });
+
+  it("routes vendor accent through the shared stripe via --edge-color", () => {
+    expect(source("CatalogVersionsFlyout.svelte")).toContain("--edge-color={accent}");
+    expect(source("DriverHistoryFlyout.svelte")).toContain("--edge-color={accent}");
+  });
+});

--- a/tests/components/material.test.ts
+++ b/tests/components/material.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { resolve, dirname } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const read = (rel: string): string => readFileSync(resolve(here, rel), "utf8");
+
+const css = read("../../frontend/src/styles/global.css");
+const gameCard = read("../../frontend/src/components/GameCard.svelte");
+const gameListRow = read("../../frontend/src/components/GameListRow.svelte");
+
+function ruleBody(src: string, selector: string): string {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const re = new RegExp(`${escaped}\\s*\\{([^}]*)\\}`);
+  return re.exec(src)?.[1] ?? "";
+}
+
+describe("Phase 4 — flat opaque base material discipline", () => {
+  it("base content-surface tokens are OPAQUE hex, never translucent rgba — dark AND light", () => {
+    for (const token of ["--bg-card", "--bg-card-hover", "--bg-elevated"]) {
+      expect(css).not.toMatch(new RegExp(`${token}:\\s*rgba`, "i"));
+      const hexHits = css.match(new RegExp(`${token}:\\s*#[0-9a-f]{3,8}\\b`, "gi")) ?? [];
+      expect(hexHits.length).toBeGreaterThanOrEqual(2);
+    }
+  });
+
+  it("Library base-layer surfaces declare NO backdrop-filter on the card/row body", () => {
+    expect(ruleBody(gameCard, ".game-card")).not.toMatch(/backdrop-filter/);
+    expect(ruleBody(gameListRow, ".list-row")).not.toMatch(/backdrop-filter/);
+  });
+
+  it("content cards carry no at-rest shadow — structure from borders, not elevation", () => {
+    expect(ruleBody(css, ".aura-card")).not.toMatch(/box-shadow\s*:/);
+    expect(ruleBody(css, ".card")).not.toMatch(/box-shadow\s*:/);
+  });
+
+  it("glass stays reserved for floating chrome — .glass-panel keeps backdrop-filter with a fallback", () => {
+    expect(ruleBody(css, ".glass-panel")).toMatch(/backdrop-filter/);
+    expect(css).toMatch(/@supports not \(\(backdrop-filter/);
+  });
+});

--- a/tests/components/systemDriverUi.test.ts
+++ b/tests/components/systemDriverUi.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { resolve, dirname } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const root = resolve(here, "../../frontend/src");
+const backups = readFileSync(resolve(root, "views/Backups.svelte"), "utf8");
+const drivers = readFileSync(resolve(root, "views/Drivers.svelte"), "utf8");
+const api = readFileSync(resolve(root, "lib/api.ts"), "utf8");
+const stores = readFileSync(resolve(root, "lib/stores.ts"), "utf8");
+const ux = readFileSync(resolve(root, "lib/ux.ts"), "utf8");
+
+describe("Backups — System Drivers section (driver_package)", () => {
+  it("splits driver-package backups out of the DLL listing", () => {
+    expect(backups).toMatch(/backup_type !== "driver_package"/);
+    expect(backups).toMatch(/backup_type === "driver_package"/);
+    expect(backups).toMatch(/for \(const b of dllBackups\)/);
+  });
+
+  it("renders a filterable System Drivers section grouped by device class", () => {
+    expect(backups).toContain("System Drivers");
+    expect(backups).toMatch(/driverClassFilter/);
+    expect(backups).toMatch(/driverGroups/);
+    expect(backups).toMatch(/b\.device_class \?\? "Driver"/);
+  });
+
+  it("wires a Roll back action to restoreSystemDriver with a confirm", () => {
+    expect(backups).toMatch(/restoreSystemDriver/);
+    expect(backups).toMatch(/doDriverRestore/);
+    expect(backups).toMatch(/Roll back/);
+  });
+});
+
+describe("Drivers — admin disclaimer + version history", () => {
+  it("shows the centralized admin-elevation note", () => {
+    expect(ux).toMatch(/export const ADMIN_ELEVATION_NOTE/);
+    expect(drivers).toMatch(/import \{ ADMIN_ELEVATION_NOTE \}/);
+    expect(drivers).toContain("{ADMIN_ELEVATION_NOTE}");
+  });
+
+  it("lazily loads DriverStore versions per card behind target_inf", () => {
+    expect(drivers).toMatch(/toggleVersions/);
+    expect(drivers).toMatch(/systemDriverVersions\(update\.target_inf\)/);
+    expect(drivers).toMatch(/update\.target_inf/);
+    expect(drivers).toContain("Latest available");
+  });
+});
+
+describe("api/stores — install carries snapshot context", () => {
+  it("installSystemDriver forwards a context arg", () => {
+    expect(api).toMatch(/installSystemDriver\(\s*updateId: string,\s*context\?: DriverInstallContext,/);
+    expect(api).toMatch(/invoke\("install_system_driver", \{ updateId, context: context \?\? null \}\)/);
+  });
+
+  it("driverInstallContext maps the matched-device fields", () => {
+    expect(api).toMatch(/export function driverInstallContext/);
+    expect(api).toMatch(/infName: update\.target_inf/);
+    expect(api).toMatch(/hardwareId: update\.target_hardware_id/);
+  });
+
+  it("exposes restoreSystemDriver + systemDriverVersions bindings", () => {
+    expect(api).toMatch(/restore_system_driver/);
+    expect(api).toMatch(/system_driver_versions/);
+  });
+
+  it("the install flow builds the context from the update + class label", () => {
+    expect(stores).toMatch(/driverInstallContext\(update, deviceClassLabel \?\? update\.class\)/);
+  });
+});

--- a/tests/contracts/bundleConfig.test.ts
+++ b/tests/contracts/bundleConfig.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { resolve, dirname } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const config = JSON.parse(
+  readFileSync(resolve(here, "../../src-tauri/tauri.conf.json"), "utf8"),
+);
+
+// dlssync.exe carries CompanyName=xt0n1 / LegalCopyright with Apache-2.0 — so a
+describe("bundle hardening contract (no-cert antivirus friction reduction)", () => {
+  it("identifies a publisher (becomes the PE CompanyName)", () => {
+    expect(config.bundle.publisher).toBe("xt0n1");
+  });
+
+  it("carries a homepage and an Apache-2.0 copyright line", () => {
+    expect(config.bundle.homepage).toMatch(/^https?:\/\//);
+    expect(config.bundle.copyright).toContain("Copyright");
+    expect(config.bundle.copyright).toContain("Apache-2.0");
+  });
+
+  it("installs per-user with no admin elevation (the critical AV-trust setting)", () => {
+    expect(config.bundle.windows.nsis.installMode).toBe("currentUser");
+  });
+
+  it("ships an installer icon and lzma compression (not a generic, packer-like blob)", () => {
+    expect(config.bundle.windows.nsis.installerIcon).toBeTruthy();
+    expect(config.bundle.windows.nsis.compression).toBe("lzma");
+  });
+
+  it("uses the WebView2 download bootstrapper (no opaque embedded runtime blob)", () => {
+    expect(config.bundle.windows.webviewInstallMode.type).toBe(
+      "downloadBootstrapper",
+    );
+  });
+
+  it("offers nsis + msi targets (portable zip is the lowest-friction channel)", () => {
+    expect(config.bundle.targets).toContain("nsis");
+    expect(config.bundle.targets).toContain("msi");
+  });
+});

--- a/tests/e2e/full-app.e2e.mjs
+++ b/tests/e2e/full-app.e2e.mjs
@@ -1,0 +1,214 @@
+
+import fs from "node:fs";
+import path from "node:path";
+
+const CDP = process.env.DLSS_CDP || "http://127.0.0.1:9333";
+const OUT = path.join(process.env.TEMP || ".", "dlss-shots-e2e");
+fs.mkdirSync(OUT, { recursive: true });
+
+const listing = await (await fetch(`${CDP}/json/list`)).json();
+const page = listing.find((t) => t.type === "page") || listing[0];
+if (!page) { console.error(JSON.stringify({ fatal: "no CDP page target — is the app running with --remote-debugging-port?" })); process.exit(1); }
+
+const ws = new WebSocket(page.webSocketDebuggerUrl);
+let seq = 0; const pending = new Map();
+const consoleErrors = []; const exceptions = [];
+ws.onmessage = (e) => {
+  const m = JSON.parse(e.data);
+  if (m.id && pending.has(m.id)) { pending.get(m.id)(m.result); pending.delete(m.id); return; }
+  if (m.method === "Runtime.consoleAPICalled" && (m.params?.type === "error" || m.params?.type === "warning"))
+    consoleErrors.push({ type: m.params.type, text: (m.params.args || []).map((a) => a.value ?? a.description ?? a.type).join(" ") });
+  else if (m.method === "Runtime.exceptionThrown")
+    exceptions.push(m.params?.exceptionDetails?.exception?.description || m.params?.exceptionDetails?.text || "exception");
+};
+const send = (method, params = {}) => new Promise((r) => { const id = ++seq; pending.set(id, r); ws.send(JSON.stringify({ id, method, params })); });
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+await new Promise((res, rej) => { ws.onopen = res; ws.onerror = rej; });
+await send("Page.enable"); await send("Runtime.enable"); await sleep(300);
+
+const ev = async (expr) => {
+  const r = await send("Runtime.evaluate", { expression: expr, returnByValue: true, awaitPromise: true });
+  if (r?.exceptionDetails) return { __err: r.exceptionDetails.text };
+  return r?.result?.value;
+};
+const goto = (title) => ev(`(()=>{const b=document.querySelector('button[title=${JSON.stringify(title)}]');if(b){b.click();return 1}return 0})()`);
+const count = (sel) => ev(`document.querySelectorAll(${JSON.stringify(sel)}).length`);
+const has = (s) => ev(`document.body.innerText.includes(${JSON.stringify(s)})`);
+const shot = async (n) => { const r = await send("Page.captureScreenshot", { format: "png" }); if (r?.data) fs.writeFileSync(path.join(OUT, n), Buffer.from(r.data, "base64")); };
+
+const results = [];
+async function check(name, fn) {
+  try {
+    const out = await fn();
+    const status = out?.gated ? "GATED" : out?.pass ? "PASS" : "FAIL";
+    results.push({ name, status, detail: out?.detail ?? "" });
+  } catch (err) {
+    results.push({ name, status: "FAIL", detail: "threw: " + String(err) });
+  }
+}
+
+await check("shell:mounts + 6 nav items + v1.5.2", async () => {
+  const nav = await ev(`["Library","Catalog","Drivers","Backups","Settings","About"].filter(t=>document.querySelector('button[title="'+t+'"]')).length`);
+  const shell = await ev(`!!document.querySelector('.app-shell,.drivers-view,.catalog-page') || document.body.children.length>0`);
+  return { pass: nav === 6 && shell, detail: `navItems=${nav} shell=${shell}` };
+});
+
+await check("library:cards + updates-hero + grid/list + density + filter + search", async () => {
+  await goto("Library"); await sleep(900);
+  const cards = await count(".game-card");
+  const hero = await count(".updates-hero");
+  const seg = await count(".seg-btn");
+  const search = await count(".lib-section input, header input, input[type=search]");
+  const filterPill = await ev(`!!document.querySelector('button[title*="pending"],button[title*="updates"]')`);
+  await ev(`(()=>{const b=[...document.querySelectorAll('.seg-btn')].find(x=>/list/i.test(x.title||x.textContent));if(b)b.click()})()`); await sleep(400);
+  await ev(`(()=>{const b=[...document.querySelectorAll('.seg-btn')].find(x=>/grid/i.test(x.title||x.textContent));if(b)b.click()})()`); await sleep(300);
+  await shot("01-library.png");
+  return { pass: cards > 0 && hero >= 0 && seg >= 2, detail: `cards=${cards} updatesHero=${hero} segBtns=${seg} filterPill=${filterPill} searchInputs=${search}` };
+});
+
+await check("gameDetail:opens full page + feature rows + DLSS override + back", async () => {
+  await ev(`document.querySelector('.game-card')?.click()`); await sleep(1300);
+  const detail = await count(".detail-view");
+  const back = await count(".detail-back");
+  const featureRows = await count(".feature-row");
+  const summary = await count(".summary-row");
+  const foot = await count(".drawer-foot");
+  const overrideInputs = await ev(`document.querySelectorAll('.drawer-body input, .detail-view input, .detail-view select').length`);
+  await shot("02-game-detail.png");
+  const ok = detail === 1 && back === 1 && featureRows > 0 && summary === 1 && foot === 1;
+  await ev(`document.querySelector('.detail-back')?.click()`); await sleep(700);
+  const returned = await count(".game-card");
+  return { pass: ok && returned > 0, detail: `detailView=${detail} back=${back} featureRows=${featureRows} summary=${summary} foot=${foot} overrideControls=${overrideInputs} returnedToLibrary=${returned > 0}` };
+});
+
+await check("driversGPU:GPU list renders with vendor + version", async () => {
+  await goto("Drivers"); await sleep(1400);
+  const list = await count(".driver-list");
+  const gpuRows = await ev(`document.querySelectorAll('.driver-list > *, .driver-list li, .driver-card').length`);
+  const vendors = await ev(`(() => { const t=(document.querySelector('.driver-list')||{}).innerText||''; return ["NVIDIA","GeForce","RTX","AMD","Radeon","Intel","Arc","Iris"].filter(v=>t.includes(v)); })()`);
+  await shot("03-drivers-gpu.png");
+  return { pass: list >= 1 && gpuRows > 0 && Array.isArray(vendors) && vendors.length > 0, detail: `driverList=${list} gpuRows=${gpuRows} vendorTokens=${JSON.stringify(vendors)}` };
+});
+
+await check("systemComponents:scan + admin note + version history (real data)", async () => {
+  const adminNote = await has("Administrator rights");
+  await ev(`(()=>{const b=[...document.querySelectorAll('button')].find(x=>/Rescan|Scanning/.test(x.textContent));if(b)b.click()})()`);
+  let cards = 0, scanning = true;
+  for (let i = 0; i < 8 && (cards === 0 || scanning); i++) {
+    await sleep(6000);
+    cards = await count(".sys-card");
+    scanning = await ev(`[...document.querySelectorAll('button')].some(b=>/Scanning/.test(b.textContent))`);
+    if (cards > 0 && !scanning) break;
+  }
+  const groups = await count(".sys-group");
+  const verToggle = await count('button[aria-label="Version history"]');
+  let verPanel = false, verText = null;
+  if (verToggle > 0) {
+    await ev(`document.querySelector('button[aria-label="Version history"]').click()`); await sleep(2500);
+    verPanel = await ev(`!!document.querySelector('.sys-versions-panel')`);
+    verText = await ev(`(document.querySelector('.sys-versions-panel')||{}).innerText||null`);
+  }
+  await shot("04-system-components.png");
+  return { pass: adminNote && cards > 0 && groups > 0, detail: `adminNote=${adminNote} cards=${cards} groups=${groups} versionToggle=${verToggle} versionPanel=${verPanel} sample=${JSON.stringify((verText||"").replace(/\n/g," ").slice(0,90))}` };
+});
+
+await check("dlssOverrides:global panel present", async () => {
+  const present = (await has("DLSS Overrides")) || (await ev(`!!document.querySelector('.dlss-override,[class*=override]')`));
+  return { pass: present, detail: `present=${present}` };
+});
+
+await check("catalog:vendor families + version pickers + GPU drivers", async () => {
+  await goto("Catalog"); await sleep(2200);
+  const vendorCards = await count(".vendor-card");
+  const familyRows = await count(".feature-row, .feature-row-btn");
+  const gpuCatRows = await count(".driver-cat-row");
+  const fams = await ev(`["DLSS","FSR","XeSS","Reflex"].filter(f=>document.body.innerText.includes(f))`);
+  const opened = await ev(`(()=>{const b=document.querySelector('.feature-row-btn');if(b){b.click();return 1}return 0})()`); await sleep(900);
+  const flyout = await ev(`!!document.querySelector('.glass-dialog,[class*=flyout],[class*=popover],[role=menu]')`);
+  await ev(`document.body.click()`); await sleep(300);
+  await shot("05-catalog.png");
+  return { pass: vendorCards > 0 && familyRows > 0 && Array.isArray(fams) && fams.length >= 2, detail: `vendorCards=${vendorCards} familyRows=${familyRows} gpuCatRows=${gpuCatRows} families=${JSON.stringify(fams)} pickerOpened=${opened} flyout=${flyout}` };
+});
+
+await check("catalog:DirectStorage (gated on jsdelivr @main propagation)", async () => {
+  const ds = await has("DirectStorage");
+  const ms = await has("Microsoft");
+  return { gated: !ds, pass: ds, detail: ds ? "DirectStorage visible (manifest propagated)" : "GATED: manifest @main not yet propagated to jsdelivr; app still serving stale (no microsoft). Published+verified at source." };
+});
+
+await check("backups:hero + DLL backups + search + group-by", async () => {
+  await goto("Backups"); await sleep(1200);
+  const hero = await count(".backup-hero");
+  const groups = await count(".group-row");
+  const search = await count(".backup-search input");
+  const groupBy = await count(".group-by-toggle .seg-btn, .backup-toolbar .seg-btn");
+  const sysSection = await has("System Drivers");
+  await shot("06-backups.png");
+  return { pass: hero >= 0 && (groups > 0 || (await count(".empty")) > 0) && search >= 1, detail: `hero=${hero} dllGroups=${groups} search=${search} groupByBtns=${groupBy} systemDriversSection=${sysSection} (empty unless a system driver was installed)` };
+});
+
+await check("notifications:bell opens panel", async () => {
+  await goto("Library"); await sleep(400);
+  await ev(`document.querySelector('button[title="Notifications"]')?.click()`); await sleep(700);
+  const panel = await ev(`!!document.querySelector('[class*=notification][class*=panel],.notifications-panel,[data-notifications-panel]') || /notification/i.test(document.body.innerText)`);
+  await shot("07-notifications.png");
+  await ev(`document.body.click()`); await sleep(200);
+  return { pass: panel, detail: `panel=${panel}` };
+});
+
+await check("commandPalette:opens + searches + results", async () => {
+  await ev(`document.querySelector('button[title*="Command palette"]')?.click()`); await sleep(600);
+  const open = await ev(`!!document.querySelector('.palette, [class*=palette]')`);
+  await ev(`(()=>{const i=document.querySelector('.palette input, [class*=palette] input');if(i){i.value='back';i.dispatchEvent(new Event('input',{bubbles:true}))}})()`); await sleep(500);
+  const results = await ev(`document.querySelectorAll('.palette [class*=result], [class*=palette] [class*=result], .palette li, [class*=palette] li').length`);
+  await shot("08-command-palette.png");
+  await ev(`document.dispatchEvent(new KeyboardEvent('keydown',{key:'Escape',bubbles:true}))`); await sleep(200);
+  return { pass: open, detail: `open=${open} results=${results}` };
+});
+
+await check("settings:hero version + sections (tabbed) + tab switch + toggle", async () => {
+  await goto("Settings"); await sleep(900);
+  const hero = await count(".settings-hero");
+  const ver = await has("1.5.2");
+  const sections = await count(".section-title-h, .settings-hero ~ * .section-title");
+  const toggles = await count("input[type=checkbox], .row input, button[role=switch], .seg-btn");
+  const tabs = await count('[role=tab], .tab-btn, .settings-tab');
+  if (tabs > 0) { await ev(`document.querySelectorAll('[role=tab],.tab-btn,.settings-tab')[1]?.click()`); await sleep(400); }
+  await shot("09-settings.png");
+  return { pass: hero >= 1 && ver && sections >= 2 && toggles > 0, detail: `hero=${hero} versionShown=${ver} sectionHeadingsInDom=${sections} toggles=${toggles} tabs=${tabs}` };
+});
+
+await check("about:version v1.5.2 + manifest sources + system info", async () => {
+  await goto("About"); await sleep(800);
+  const ver = await ev(`(document.body.innerText.match(/v?1\\.5\\.2/)||[null])[0]`);
+  const sources = await count(".source-card");
+  const sys = await has("Your system");
+  await shot("10-about.png");
+  return { pass: !!ver && sys, detail: `version=${ver} manifestSources=${sources} systemInfo=${sys}` };
+});
+
+await check("theme:toggle flips dark/light", async () => {
+  await goto("Library"); await sleep(300);
+  const before = await ev(`document.documentElement.getAttribute('data-theme')||document.documentElement.className`);
+  await ev(`document.querySelector('button[title="Toggle theme"]')?.click()`); await sleep(600);
+  const after = await ev(`document.documentElement.getAttribute('data-theme')||document.documentElement.className`);
+  await shot("11-theme.png");
+  await ev(`document.querySelector('button[title="Toggle theme"]')?.click()`); await sleep(300);
+  return { pass: before !== after, detail: `before=${before} after=${after}` };
+});
+
+await check("console:0 errors + 0 exceptions across the run", async () => {
+  return { pass: consoleErrors.length === 0 && exceptions.length === 0, detail: `consoleErrors=${consoleErrors.length} exceptions=${exceptions.length}` };
+});
+
+const pass = results.filter((r) => r.status === "PASS").length;
+const fail = results.filter((r) => r.status === "FAIL").length;
+const gated = results.filter((r) => r.status === "GATED").length;
+console.log("\n===== DLSSync FULL E2E =====");
+for (const r of results) console.log(`[${r.status.padEnd(5)}] ${r.name}\n         ${r.detail}`);
+console.log(`\nSUMMARY pass=${pass} fail=${fail} gated=${gated} | consoleErrors=${consoleErrors.length} exceptions=${exceptions.length}`);
+if (consoleErrors.length) console.log("CONSOLE: " + JSON.stringify(consoleErrors.slice(0, 10)));
+if (exceptions.length) console.log("EXC: " + JSON.stringify(exceptions.slice(0, 10)));
+console.log("shots: " + OUT);
+ws.close();
+process.exit(fail > 0 ? 1 : 0);

--- a/tests/index.md
+++ b/tests/index.md
@@ -23,13 +23,15 @@ Vitest config: [frontend/vitest.config.ts](../frontend/vitest.config.ts). Tauri 
 | [relation.test.ts](unit/relation.test.ts) | `lib/relation` | version compare, sha short-circuit, vendor-sha match, target resolution, `gameStatusFromRecords` across outdated/up-to-date/no-dlls/scan-failed/disabled |
 | [applyErrorClass.test.ts](unit/applyErrorClass.test.ts) | `lib/applyErrorClass` | all 9 error classes, precedence (cancelled→network→signature…), case-insensitivity, action routing, label/tone tables |
 | [labels.test.ts](unit/labels.test.ts) | `lib/labels` | family→vendor/group/catalog-key, feature mapping, streamline filename disambiguation, filename parsing, map-completeness invariants |
-| [ux.test.ts](unit/ux.test.ts) | `lib/ux` | command palette fuzzy match + ranking, recent-stack dedupe/cap, `isModifierComboMatch` (mod/shift/esc/case), vendor routing, command-id uniqueness |
-| [notifications.test.ts](unit/notifications.test.ts) | `lib/notifications` | `makeNotificationEntry` factory: defaults, extras, unique id, ISO timestamp, every NotificationKind |
+| [ux.test.ts](unit/ux.test.ts) | `lib/ux` | command palette fuzzy match + ranking, recent-stack dedupe/cap, `isModifierComboMatch` (mod/shift/esc/case), vendor routing, command-id uniqueness + per-command icon key; `githubReleaseTagUrl` (strips leading v) + `EXTERNAL_URLS` release/Nexus links; `matchedIndices` (contiguous span / subsequence / no-match) + `highlightSegments` hit-split |
+| [notifications.test.ts](unit/notifications.test.ts) | `lib/notifications` | `makeNotificationEntry` factory: defaults, extras incl. `link` (default null + carried), unique id, ISO timestamp, every NotificationKind (incl. driver/system-driver-update + backup-restored) |
 | [launcherLogos.test.ts](unit/launcherLogos.test.ts) | `lib/launcherLogos` | 7 brands present, valid hex bg, non-empty SVG path, order-list integrity |
 | [dlssPresets.test.ts](unit/dlssPresets.test.ts) | `lib/dlss` | SR preset / FG-mode / FG-count option tables, preset labels, per-option description + source URL, driver-version gating (≥572.16 DLSS 4, ≥595.97 Dynamic MFG), active-override detection |
 | [anticheat.test.ts](unit/anticheat.test.ts) | `lib/anticheat` | detection flag (type-guard), joined names, dataset status note, ban-risk warning copy names the anti-cheats |
 | [catalogReleases.test.ts](unit/catalogReleases.test.ts) | `lib/catalogReleases` | `mergeFamilyReleases` across feature families: dedupe by version+sha, newest-first sort, distinct same-version files kept, empty input |
 | [driversActions.test.ts](unit/driversActions.test.ts) | `lib/drivers` | per-vendor action routing: `canInstall` (direct download only), `isOpenPageOnly` (AMD: update + no download + has page), mutual exclusivity, `driverPageUrl` notes→PDF→null fallback, `vendorHelpUrl` per-vendor finder + Windows fallback |
+| [brands.test.ts](unit/brands.test.ts) | `lib/brands` | `BRANDS` registry (4 core vendors + realtek/dell/msi/asus/gigabyte/qualcomm/logitech/razer; non-empty label + real svg path + viewBox + `--vendor-*`/token accent), `resolveBrandKey` (messy WUA provider strings → key; AMD/ATI, Nahimic/A-Volute→realtek, MSI/Micro-Star, ROG→asus, AORUS→gigabyte, Snapdragon→qualcomm; unknown/empty/null→null), `brandLabel` (clean label or echo raw), `brandFor` |
+| [designTokens.test.ts](unit/designTokens.test.ts) | `styles/global.css` | source-level token contract: 8pt `--space-1..8` scale step values, density tokens, the shared tactile (`.hover-lift`/`.press`) + `.glass-dialog`/`.dialog-close` utilities present and centralized |
 
 ## Frontend — integration (`tests/integration/`)
 
@@ -40,6 +42,8 @@ Vitest config: [frontend/vitest.config.ts](../frontend/vitest.config.ts). Tauri 
 | [toastStore.test.ts](integration/toastStore.test.ts) | Toast popup data layer | append/kind/message, FIFO stacking, TTL auto-dismiss (fake timers), targeted dismiss, no-op unknown id |
 | [driverStatus.test.ts](integration/driverStatus.test.ts) | `lib/drivers` | status label/tone maps, update detection + count, sort order (update→unknown→up_to_date→unsupported) + alpha tie-break + no-mutate |
 | [driverInstall.test.ts](integration/driverInstall.test.ts) | `stores.driverInstall` (UI e2e state machine) | shared install store: stray events ignored when idle; **progress survives a view change mid-download (bug-#1 regression guard)**; one-install-at-a-time; cancelled→warning / failed (Intel exit 8)→danger toast + state cleared; AMD empty-URL report never invokes install (open-page path) |
+| [systemDriverInstall.test.ts](integration/systemDriverInstall.test.ts) | `stores.systemDriverInstall` (System & Components install state machine) | shared system-driver install store: stray events ignored when idle; progress survives a view change mid-download; one-install-at-a-time (keyed by `update_id`); success→success toast + scan refreshed; reboot hint surfaced; failed→danger toast + state cleared + no rescan |
+| [optimisticApply.test.ts](integration/optimisticApply.test.ts) | `stores.optimisticToggle` (reversible apply + quiet-undo) | optimistic state applied immediately + Undo toast shown; Undo reverts and dismisses; backend rejection reverts + danger toast; late failure after an Undo does not double-revert |
 
 ## Frontend — component render (`tests/components/`)
 
@@ -50,15 +54,20 @@ WAAPI `Element.prototype.animate` stub so Svelte transitions run headless.
 | File | Component | Coverage |
 |:---|:---|:---|
 | [Toast.test.ts](components/Toast.test.ts) | `Toast` | empty render, message + kind class, stacking, dismiss control |
+| [ActivityDock.test.ts](components/ActivityDock.test.ts) | `ActivityDock` (Tidal bottom bar) | idle→nothing; single apply→label + determinate fill width; multi-task→"N tasks running" count; indeterminate fill when no fraction; expand→`applyModalOpen` true; ended applies ignored (live work only) |
 | [ShortcutOverlay.test.ts](components/ShortcutOverlay.test.ts) | `ShortcutOverlay` | closed→nothing, open dialog + groups + kbd chips, close-button collapses via store |
-| [CommandPalette.test.ts](components/CommandPalette.test.ts) | `CommandPalette` | closed→nothing, spotlight input + category chips, command list + category tags, live query filtering |
-| [NotificationsBell.test.ts](components/NotificationsBell.test.ts) | `NotificationsBell` | closed→nothing, empty state, seeded list + count + dismiss + mark-all, per-kind badge tints, unread stripe |
+| [CommandPalette.test.ts](components/CommandPalette.test.ts) | `CommandPalette` (revamp) | closed→nothing; boxed search field + Esc chip + category chips; grouped section heads (Navigate/Action/Settings) with category-tinted per-row icons; shortcut chip (G L) for commands that declare one; live filter + fuzzy-char highlight (`mark.result-hl`); arrow-key nav across group boundaries; rich empty state echoing the query |
+| [NotificationsBell.test.ts](components/NotificationsBell.test.ts) | `NotificationsBell` | closed→nothing, empty state, seeded list + count + dismiss + mark-all, per-kind badge tints (incl. driver/system-driver/backup), external link actions (release→GitHub+Nexus, driver→vendor, none otherwise), unread stripe; **mount-location contract** (panel `position:fixed` not absolute, lifted out of the glass TopBar, mounted at the app root — frosted-glass fix) |
 | [ApplyProgressModal.test.ts](components/ApplyProgressModal.test.ts) | `ApplyProgressModal` | dialog shell, completed-group title/version/Updated pill, pane-head detail toggle + stat chips + progress, footer Dismiss aura-pill, collapse toggle hide/show |
 | [DlssOverridePanel.test.ts](components/DlssOverridePanel.test.ts) | `DlssOverridePanel` | both feature groups + reversible/anti-cheat note, custom dropdowns + checkboxes (no native controls), DLSS 4 driver warning |
 | [Checkbox.test.ts](components/Checkbox.test.ts) | `Checkbox` | role=checkbox + label, toggle on click, no-toggle when disabled |
 | [Select.test.ts](components/Select.test.ts) | `Select` | selected label on trigger, opens listbox of options on click, marks the chosen option aria-selected |
 | [DriverHistoryFlyout.test.ts](components/DriverHistoryFlyout.test.ts) | `DriverHistoryFlyout` | WHQL-toggle honesty: disabled + label switches when 0 betas loaded; enabled + filter hides 3 betas when 47 WHQL + 3 Beta loaded; footer count `47 of 50` |
-| [GameDetailDrawer.test.ts](components/GameDetailDrawer.test.ts) | `GameDetailDrawer` redesign | source-CSS contract: `.drawer-scrim` has no `backdrop-filter` + has `radial-gradient` + `prefers-reduced-transparency` fallback; `.drawer::before` highlight + `.drawer-art::before` launcher-accent stripe; `.learn-more` aligned with link-btn doctrine; widened section rhythm (warning 20 / summary 16 / advanced 16) |
+| [GameDetailDrawer.test.ts](components/GameDetailDrawer.test.ts) | `GameDetailDrawer` = full-page detail VIEW (rebuilt) | source contract: renders in-flow (no `drawer-scrim`, no fixed/overlay, no `role=dialog`/`aria-modal`/`trapFocus`/`matchMedia`); `.detail-back` "Back to Library" → onClose + Escape; compact `.detail-hero` (`.drawer-art` fixed `height:clamp(...)`, no aspect-ratio) + `.drawer-art::before` launcher-accent stripe; summary scrolls (not sticky) + sticky-bottom `.drawer-foot` action bar; `.learn-more` link-btn doctrine. **App-level wiring**: App renders it when `currentView==="library" && drawerGameId` (replaces Library, not an overlay); Library no longer renders it; push-padding side-panel (`data-drawer-open` / `padding-right:var(--drawer-width)`) removed |
+| [ContextMenu.test.ts](components/ContextMenu.test.ts) | `ContextMenu` | one `role=menuitem` per action; keyboard nav (Arrow/Home/End wrap); Escape + outside-pointerdown dismiss; inside-pointerdown keeps open; action callback fires; viewport clamp keeps the menu on-screen |
+| [BrandMark.test.ts](components/BrandMark.test.ts) | `BrandMark` | known key → inline `svg.brand-glyph` with the brand path + clean label; messy provider string resolves to the right glyph; unknown key → label-only (no empty glyph); `showLabel=false` hides the label; `tone:'color'` tints via `--vendor-*` token, `tone:'mono'` uses `currentColor`; explicit label overrides the resolved one |
+| [material.test.ts](components/material.test.ts) | flat-opaque base material doctrine | source-CSS contract: base content-surface tokens are opaque (never translucent rgba) in both dark and light; GameCard/GameListRow surfaces obey the flat material |
+| [glassDialogUnification.test.ts](components/glassDialogUnification.test.ts) | unified floating-chrome doctrine | source-CSS contract: every modal/flyout/popover/dropdown carries `.glass-dialog`, closable dialogs use `.dialog-close` (no bespoke close classes), no local `backdrop-filter`/`vendor-stripe` remains, accent routes through `--edge-color` |
 
 ## Frontend — contracts (`tests/contracts/`)
 
@@ -69,6 +78,7 @@ Validates the Tauri command boundary (Rust serde struct ↔ TS DTO) against the 
 |:---|:---|:---|
 | [driverRelease.test.ts](contracts/driverRelease.test.ts) | `contracts/driver-release.schema.json` | required-field set guard + NVIDIA/AMD/Intel(Arc)/Intel(integrated 31.x) fixtures conform; AMD empty `download_url` permitted (open-page model) with a notes page present |
 | [anticheatReport.test.ts](contracts/anticheatReport.test.ts) | `contracts/anticheat-report.schema.json` | required-field set guard + detected/clean fixtures conform; rejects an unknown detection source |
+| [bundleConfig.test.ts](contracts/bundleConfig.test.ts) | `src-tauri/tauri.conf.json` bundle block | publisher/homepage/Apache-2.0 copyright present (PE metadata for antivirus-friction reduction in the no-cert release) |
 
 ## Backend — Rust (`cargo test --workspace`)
 
@@ -76,7 +86,7 @@ Inline `#[cfg(test)]` per crate and per command module. All green:
 
 | Area | Module | Coverage |
 |:---|:---|:---|
-| notifications-store | `crates/notifications-store/src/lib.rs` | round-trip, FIFO eviction at 200, concurrency, graceful skip of unknown kinds |
+| notifications-store | `crates/notifications-store/src/lib.rs` | round-trip (all kinds incl. driver/system-driver-update + backup-restored), `link` column round-trip + legacy-DB `ensure_column` migration (old schema reads `link=None`, new inserts persist), FIFO eviction at 200, concurrency, graceful skip of unknown kinds |
 | backup-store | `crates/backup-store/src/lib.rs` | insert/list/delete, folder-name sanitize, path-prefix rewrite |
 | dll-catalog | `crates/dll-catalog/tests/download_resilience.rs` | 12 `wiremock` integration tests (shared-cache one-fetch, retry, cancel, byte-precise progress) |
 | paths | `src-tauri/src/paths.rs` | layout, legacy migration idempotence |
@@ -93,3 +103,4 @@ Inline `#[cfg(test)]` per crate and per command module. All green:
 | DRS round-trip (destructive, opt-in) | `src-tauri/tests/dlss_profile_roundtrip.rs` | `#[cfg(target_os="windows")] #[ignore]` apply→read→reset on the live NVIDIA base profile; ResetGuard restores defaults on panic. Run with `cargo test -p dlssync --test dlss_profile_roundtrip -- --ignored` on a Windows host with NVIDIA driver |
 | driver-install | `crates/driver-install/src/{state,download,verify}.rs` + `tests/download.rs` | install state-machine transitions, exit-code→stage map, log-percent parse; signature gate (rejects unsigned, accepts MS-signed system binary); wiremock download (body→file, 5xx retry, pre-cancel) |
 | drivers command | `src-tauri/src/commands/drivers.rs` | OS-family build threshold, GpuVendor→DriverVendor map, GpuInfo→DeviceId + installed-version normalization |
+| system-drivers (general PC driver engine) | `crates/system-drivers/src/{version,classify,lib,inventory}.rs` + `tests/pipeline.rs` | version parse/zero-padded compare, `extract_version` from WUA title, OLE-date→ISO (Hinnant civil-from-days), **anti-downgrade `is_newer`** (date-dominant, version tie-break, refuse-when-uncomparable); `DeviceClass` taxonomy + `classify` (specific-before-broad); `hwid_core` VEN/DEV·VID/PID extraction + `matches_device`; **`filter_safe_updates`** (drops non-newer, keeps unmatched, annotates target); `group_by_class`; WMI `cim_to_iso` + `device_from_row` mapper; **pipeline** (fake WMI+WUA → inventory→search→filter→group, drops older wifi / keeps newer audio + unmatched bluetooth) + install progress-stage sequence |

--- a/tests/integration/optimisticApply.test.ts
+++ b/tests/integration/optimisticApply.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { get, writable } from "svelte/store";
+import { optimisticToggle, toasts } from "@/lib/stores";
+
+beforeEach(() => {
+  toasts.set([]);
+});
+
+describe("optimisticToggle — reversible apply with quiet-undo", () => {
+  it("applies the optimistic state immediately and shows an Undo toast", async () => {
+    const flag = writable(false);
+    await optimisticToggle({
+      applyOptimistic: () => flag.set(true),
+      revert: () => flag.set(false),
+      commit: () => Promise.resolve(),
+      message: "Feature disabled",
+    });
+    expect(get(flag)).toBe(true);
+    const t = get(toasts).at(-1);
+    expect(t?.kind).toBe("info");
+    expect(t?.message).toBe("Feature disabled");
+    expect(t?.action?.label).toBe("Undo");
+  });
+
+  it("clicking Undo reverts the optimistic state and dismisses the toast", async () => {
+    const flag = writable(false);
+    await optimisticToggle({
+      applyOptimistic: () => flag.set(true),
+      revert: () => flag.set(false),
+      commit: () => Promise.resolve(),
+      message: "Feature disabled",
+    });
+    expect(get(flag)).toBe(true);
+    const t = get(toasts).at(-1);
+    t?.action?.run();
+    expect(get(flag)).toBe(false);
+    expect(get(toasts).length).toBe(0);
+  });
+
+  it("reverts and surfaces a danger toast when the backend commit rejects", async () => {
+    const flag = writable(false);
+    await optimisticToggle({
+      applyOptimistic: () => flag.set(true),
+      revert: () => flag.set(false),
+      commit: () => Promise.reject(new Error("disk full")),
+      message: "Feature disabled",
+    });
+    expect(get(flag)).toBe(false);
+    const last = get(toasts).at(-1);
+    expect(last?.kind).toBe("danger");
+    expect(last?.message).toMatch(/disk full/);
+  });
+
+  it("a backend failure AFTER the user already undid does not double-revert", async () => {
+    const revert = vi.fn();
+    let rejectCommit!: (e: unknown) => void;
+    const pending = optimisticToggle({
+      applyOptimistic: () => undefined,
+      revert,
+      commit: () => new Promise<void>((_, reject) => { rejectCommit = reject; }),
+      message: "Feature disabled",
+    });
+    get(toasts).at(-1)?.action?.run();
+    expect(revert).toHaveBeenCalledTimes(1);
+    rejectCommit(new Error("late failure"));
+    await pending;
+    expect(revert).toHaveBeenCalledTimes(1);
+    expect(get(toasts).some((t) => t.kind === "danger")).toBe(false);
+  });
+});

--- a/tests/integration/systemDriverInstall.test.ts
+++ b/tests/integration/systemDriverInstall.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { get } from "svelte/store";
+import type { SystemDriverOutcome, SystemDriverUpdate } from "@/lib/api";
+
+let pendingResolve: ((outcome: SystemDriverOutcome) => void) | null = null;
+const { scanSpy } = vi.hoisted(() => ({ scanSpy: vi.fn(async () => []) }));
+
+vi.mock("@/lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api")>();
+  return {
+    ...actual,
+    installSystemDriver: vi.fn(
+      () =>
+        new Promise<SystemDriverOutcome>((resolve) => {
+          pendingResolve = resolve;
+        }),
+    ),
+    scanSystemDrivers: scanSpy,
+  };
+});
+
+import {
+  systemDriverInstall,
+  startSystemDriverInstall,
+  applySystemDriverProgress,
+  toasts,
+} from "@/lib/stores";
+
+function update(id: string): SystemDriverUpdate {
+  return {
+    update_id: id,
+    title: "Realtek - MEDIA - 6.0.9600.1",
+    class: "audio",
+    provider: "Realtek Semiconductor Corp.",
+    driver_version: "6.0.9600.1",
+    driver_date: "2026-04-10",
+    hardware_id: "HDAUDIO\\FUNC_01&VEN_10EC&DEV_0256",
+    size_bytes: 12_345_678,
+    target_device: "Realtek High Definition Audio",
+  };
+}
+
+function complete(outcome: SystemDriverOutcome): void {
+  expect(pendingResolve, "install_system_driver was invoked").not.toBeNull();
+  pendingResolve?.(outcome);
+  pendingResolve = null;
+}
+
+beforeEach(() => {
+  systemDriverInstall.set({ updateId: null, stage: null, message: "", fraction: null });
+  toasts.set([]);
+  pendingResolve = null;
+  scanSpy.mockClear();
+});
+
+describe("system driver install — shared store state machine", () => {
+  it("ignores progress events while no install is active", () => {
+    applySystemDriverProgress({ stage: "downloading", message: "stray", fraction: 0.4 });
+    expect(get(systemDriverInstall).updateId).toBeNull();
+    expect(get(systemDriverInstall).stage).toBeNull();
+  });
+
+  it("survives a view change: progress keeps updating the store mid-download", async () => {
+    const p = startSystemDriverInstall(update("u-1:1"));
+    expect(get(systemDriverInstall).updateId).toBe("u-1:1");
+    expect(get(systemDriverInstall).stage).toBe("downloading");
+
+    applySystemDriverProgress({ stage: "downloading", message: "Downloading driver", fraction: 0.5 });
+    expect(get(systemDriverInstall).fraction).toBe(0.5);
+    applySystemDriverProgress({ stage: "installing", message: "Installing", fraction: null });
+    expect(get(systemDriverInstall).stage).toBe("installing");
+
+    complete({ success: true, reboot_required: false, result_code: 2, message: "ok" });
+    await p;
+    expect(get(systemDriverInstall).updateId).toBeNull();
+    expect(get(toasts).at(-1)?.kind).toBe("success");
+    expect(scanSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("only one install runs at a time", async () => {
+    const first = startSystemDriverInstall(update("u-1:1"));
+    expect(get(systemDriverInstall).updateId).toBe("u-1:1");
+    await startSystemDriverInstall(update("u-2:1"));
+    expect(get(systemDriverInstall).updateId).toBe("u-1:1");
+    complete({ success: true, reboot_required: false, result_code: 2, message: "done" });
+    await first;
+  });
+
+  it("surfaces a reboot hint in the success toast", async () => {
+    const p = startSystemDriverInstall(update("u-1:1"));
+    complete({ success: true, reboot_required: true, result_code: 2, message: "ok" });
+    await p;
+    expect(get(toasts).at(-1)?.kind).toBe("success");
+    expect(get(toasts).at(-1)?.message).toMatch(/restart/i);
+  });
+
+  it("parks a failed install in a VISIBLE terminal state (not a silent reset) + danger toast", async () => {
+    const p = startSystemDriverInstall(update("u-1:1"));
+    complete({ success: false, reboot_required: false, result_code: 4, message: "Windows Update returned result code 4." });
+    await p;
+    const s = get(systemDriverInstall);
+    expect(s.updateId).toBe("u-1:1");
+    expect(s.stage).toBe("failed");
+    expect(s.message).toMatch(/result code 4/);
+    expect(get(toasts).at(-1)?.kind).toBe("danger");
+    expect(scanSpy).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/brands.test.ts
+++ b/tests/unit/brands.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from "vitest";
+import {
+  BRANDS,
+  brandFor,
+  brandLabel,
+  brandfetchLogoUrl,
+  resolveBrandDomain,
+  resolveBrandKey,
+  type BrandKey,
+} from "@/lib/brands";
+
+describe("BRANDS", () => {
+  it("bundles real official marks only for vendors with a clean open-source logo", () => {
+    const keys = Object.keys(BRANDS).sort();
+    expect(keys).toEqual(
+      [
+        "amd",
+        "asus",
+        "broadcom",
+        "dell",
+        "intel",
+        "mediatek",
+        "microsoft",
+        "msi",
+        "nvidia",
+        "qualcomm",
+        "razer",
+      ].sort(),
+    );
+  });
+
+  it("each brand has a non-empty label, a real svg path, a viewBox, and a token accent", () => {
+    for (const [key, brand] of Object.entries(BRANDS)) {
+      expect(brand.label, `${key} label`).toBeTruthy();
+      expect(brand.path.length, `${key} path`).toBeGreaterThan(20);
+      expect(brand.path.trimStart().startsWith("M"), `${key} path starts with moveto`).toBe(true);
+      expect(brand.viewBox, `${key} viewBox`).toMatch(/^\d+ \d+ \d+ \d+$/);
+      expect(brand.accentVar.startsWith("--"), `${key} accentVar is a css var name`).toBe(true);
+    }
+  });
+
+  it("maps the core vendors onto their --vendor-* tokens", () => {
+    expect(BRANDS.nvidia.accentVar).toBe("--vendor-nvidia");
+    expect(BRANDS.amd.accentVar).toBe("--vendor-amd");
+    expect(BRANDS.intel.accentVar).toBe("--vendor-intel");
+    expect(BRANDS.microsoft.accentVar).toBe("--vendor-microsoft");
+  });
+});
+
+describe("resolveBrandKey", () => {
+  const cases: ReadonlyArray<readonly [string, BrandKey]> = [
+    ["nvidia", "nvidia"],
+    ["NVIDIA", "nvidia"],
+    ["NVIDIA Corporation", "nvidia"],
+    ["GeForce RTX 4070", "nvidia"],
+    ["amd", "amd"],
+    ["Advanced Micro Devices, Inc.", "amd"],
+    ["Advanced Micro Devices, Inc. - Display", "amd"],
+    ["ATI Technologies Inc.", "amd"],
+    ["AMD Radeon(TM) Graphics", "amd"],
+    ["Intel", "intel"],
+    ["Intel Corporation", "intel"],
+    ["Microsoft", "microsoft"],
+    ["Microsoft Corporation", "microsoft"],
+    ["Dell Inc.", "dell"],
+    ["Alienware", "dell"],
+    ["Micro-Star International", "msi"],
+    ["MSI", "msi"],
+    ["ASUSTeK Computer Inc.", "asus"],
+    ["ROG", "asus"],
+    ["Qualcomm Atheros Communications", "qualcomm"],
+    ["Snapdragon", "qualcomm"],
+    ["Razer Inc.", "razer"],
+    ["Broadcom Inc.", "broadcom"],
+    ["MediaTek Inc.", "mediatek"],
+  ];
+
+  for (const [raw, expected] of cases) {
+    it(`maps "${raw}" -> ${expected}`, () => {
+      expect(resolveBrandKey(raw)).toBe(expected);
+    });
+  }
+
+  it("returns null for vendors served dynamically rather than bundled", () => {
+    expect(resolveBrandKey("Realtek Semiconductor Corp.")).toBeNull();
+    expect(resolveBrandKey("Nahimic")).toBeNull();
+    expect(resolveBrandKey("GIGABYTE")).toBeNull();
+    expect(resolveBrandKey("Logitech")).toBeNull();
+  });
+
+  it("returns null for an unknown provider", () => {
+    expect(resolveBrandKey("Acme Widgets LLC")).toBeNull();
+    expect(resolveBrandKey("Standard system devices")).toBeNull();
+    expect(resolveBrandKey("other")).toBeNull();
+  });
+
+  it("returns null for empty, null, or undefined input", () => {
+    expect(resolveBrandKey("")).toBeNull();
+    expect(resolveBrandKey(null)).toBeNull();
+    expect(resolveBrandKey(undefined)).toBeNull();
+  });
+});
+
+describe("resolveBrandDomain", () => {
+  const cases: ReadonlyArray<readonly [string, string]> = [
+    ["Realtek Semiconductor Corp.", "realtek.com"],
+    ["Nahimic", "nahimic.com"],
+    ["A-Volute", "nahimic.com"],
+    ["Synaptics", "synaptics.com"],
+    ["GIGABYTE", "gigabyte.com"],
+    ["AORUS", "gigabyte.com"],
+    ["Logitech", "logitech.com"],
+    ["Advanced Micro Devices, Inc.", "amd.com"],
+    ["NVIDIA Corporation", "nvidia.com"],
+    ["Microsoft Corporation", "microsoft.com"],
+  ];
+
+  for (const [raw, expected] of cases) {
+    it(`maps "${raw}" -> ${expected}`, () => {
+      expect(resolveBrandDomain(raw)).toBe(expected);
+    });
+  }
+
+  it("returns null for an unmappable provider and for empty input", () => {
+    expect(resolveBrandDomain("Acme Widgets LLC")).toBeNull();
+    expect(resolveBrandDomain(null)).toBeNull();
+    expect(resolveBrandDomain("")).toBeNull();
+  });
+});
+
+describe("brandfetchLogoUrl", () => {
+  it("builds a brandfetch CDN url when a domain and client id are present", () => {
+    const url = brandfetchLogoUrl("realtek.com", { clientId: "abc123", size: 32 });
+    expect(url).toBe("https://cdn.brandfetch.io/realtek.com/w/32/h/32/icon?c=abc123");
+  });
+
+  it("returns null without a client id, and null without a domain", () => {
+    expect(brandfetchLogoUrl("realtek.com", { clientId: "" })).toBeNull();
+    expect(brandfetchLogoUrl(null, { clientId: "abc123" })).toBeNull();
+  });
+});
+
+describe("brandLabel", () => {
+  it("returns the clean brand label for a messy known provider", () => {
+    expect(brandLabel("Advanced Micro Devices, Inc.")).toBe("AMD");
+    expect(brandLabel("MediaTek Inc.")).toBe("MediaTek");
+  });
+
+  it("echoes the raw string for an unknown provider", () => {
+    expect(brandLabel("Acme Widgets LLC")).toBe("Acme Widgets LLC");
+  });
+});
+
+describe("brandFor", () => {
+  it("returns the brand record for a known provider", () => {
+    expect(brandFor("nvidia")?.label).toBe("NVIDIA");
+  });
+
+  it("returns null for an unknown provider", () => {
+    expect(brandFor("Acme Widgets LLC")).toBeNull();
+    expect(brandFor(null)).toBeNull();
+  });
+});

--- a/tests/unit/designTokens.test.ts
+++ b/tests/unit/designTokens.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { resolve, dirname } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const css = readFileSync(
+  resolve(here, "../../frontend/src/styles/global.css"),
+  "utf8",
+);
+
+function ruleBody(source: string, selector: string): string {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`${escaped}\\s*\\{([^}]*)\\}`).exec(source)?.[1] ?? "";
+}
+
+describe("design tokens — spacing scale, density, tactile + glass-dialog utilities", () => {
+  it("defines the 8pt spacing scale --space-1..8 with the canonical step values", () => {
+    const steps: Record<string, string> = {
+      "--space-1": "4px",
+      "--space-2": "8px",
+      "--space-3": "12px",
+      "--space-4": "16px",
+      "--space-5": "24px",
+      "--space-6": "32px",
+      "--space-7": "48px",
+      "--space-8": "64px",
+    };
+    for (const [token, value] of Object.entries(steps)) {
+      expect(css).toMatch(new RegExp(`${token}:\\s*${value};`));
+    }
+  });
+
+  it("exposes a density multiplier hook", () => {
+    expect(css).toMatch(/--density:\s*1;/);
+  });
+
+  it("provides the shared tactile utilities .hover-lift and .press", () => {
+    expect(ruleBody(css, ".hover-lift:hover")).toMatch(
+      /translateY\(-2px\)\s*scale\(1\.02\)/,
+    );
+    expect(ruleBody(css, ".press:active")).toMatch(/scale\(0\.98\)/);
+  });
+
+  it("provides one centralized .glass-dialog util (blur + shadow + 3px stripe + 32px close)", () => {
+    const dialog = ruleBody(css, ".glass-dialog");
+    expect(dialog).toMatch(/backdrop-filter:\s*var\(--glass-blur\)/);
+    expect(dialog).toMatch(/box-shadow:[^;]*var\(--shadow-lg\)/);
+    expect(css).toMatch(/\.glass-dialog::before\s*\{[^}]*width:\s*3px/);
+    const close = ruleBody(css, ".dialog-close");
+    expect(close).toMatch(/width:\s*32px/);
+    expect(close).toMatch(/height:\s*32px/);
+  });
+
+  it("keeps a backdrop-filter fallback for .glass-dialog", () => {
+    expect(css).toMatch(
+      /\.glass-dialog\s*\{\s*background:\s*var\(--glass-fallback\)/,
+    );
+  });
+});

--- a/tests/unit/dlssPresets.test.ts
+++ b/tests/unit/dlssPresets.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import type { DlssPreset } from "@/lib/api";
 import {
   SR_PRESET_OPTIONS,
   FG_MODE_OPTIONS,
@@ -20,10 +21,19 @@ describe("dlss override option tables", () => {
     expect(FG_COUNT_OPTIONS.map((o) => o.value)).toEqual(["app_controlled", "x2", "x3", "x4"]);
   });
 
-  it("labels presets, falling back to the upper-cased value", () => {
+  it("labels the full A-O preset range so any externally-set preset is shown", () => {
     expect(presetLabel("k")).toContain("Preset K");
     expect(presetLabel("recommended")).toContain("Recommended");
-    expect(presetLabel("a")).toBe("A");
+    expect(presetLabel("a")).toContain("Preset A");
+    expect(presetLabel("m")).toContain("Preset M");
+    expect(presetLabel("o")).toContain("Preset O");
+    for (const letter of ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o"] as DlssPreset[]) {
+      expect(SR_PRESET_OPTIONS.some((o) => o.value === letter)).toBe(true);
+    }
+  });
+
+  it("falls back to the upper-cased value for an unrecognized preset", () => {
+    expect(presetLabel("z" as DlssPreset)).toBe("Z");
   });
 });
 

--- a/tests/unit/notifications.test.ts
+++ b/tests/unit/notifications.test.ts
@@ -7,6 +7,9 @@ const ALL_KINDS: NotificationKind[] = [
   "apply_cancelled",
   "app_update_available",
   "catalog_update_available",
+  "driver_update_available",
+  "system_driver_update_available",
+  "backup_restored",
   "scan_failed",
   "catalog_refresh_failed",
 ];
@@ -37,6 +40,14 @@ describe("makeNotificationEntry", () => {
     expect(e.apply_id).toBe("ap-1");
     expect(e.game_id).toBe("g-1");
     expect(e.error_class).toBe("lock");
+  });
+
+  it("defaults link to null and carries it when provided", () => {
+    expect(makeNotificationEntry("apply_success", "ok").link).toBeNull();
+    const release = makeNotificationEntry("app_update_available", "DLSSync v1.6.0 available", "Fixed XeSS", {
+      link: "https://github.com/xt0n1-t3ch/DLSSync/releases/tag/v1.6.0",
+    });
+    expect(release.link).toBe("https://github.com/xt0n1-t3ch/DLSSync/releases/tag/v1.6.0");
   });
 
   it("generates a unique id per call", () => {

--- a/tests/unit/relation.test.ts
+++ b/tests/unit/relation.test.ts
@@ -1,11 +1,13 @@
 import { describe, it, expect } from "vitest";
-import type { DllRecord } from "@/lib/api";
+import type { DllRecord, UpdatePreferences } from "@/lib/api";
 import {
   catalogShaKey,
   buildShasByVendor,
   targetVersion,
   dllRelation,
   isOutdated,
+  isStreamlinePlugin,
+  recordUpdatable,
   gameStatusFromRecords,
   type RelationContext,
 } from "@/lib/relation";
@@ -22,6 +24,22 @@ function rec(partial: Partial<DllRecord>): DllRecord {
 
 function ctx(over: Partial<RelationContext> = {}): RelationContext {
   return { latestByKey: {}, shas: {}, shasByVendor: {}, ...over };
+}
+
+function prefs(over: Partial<UpdatePreferences> = {}): UpdatePreferences {
+  return {
+    update_dlss: true,
+    update_dlss_fg: true,
+    update_dlss_rr: true,
+    update_streamline: false,
+    update_reflex: true,
+    update_xess: true,
+    update_fsr: true,
+    update_direct_storage: true,
+    create_backups: true,
+    auto_apply_all_on_rescan: false,
+    ...over,
+  };
 }
 
 describe("catalogShaKey", () => {
@@ -142,5 +160,68 @@ describe("gameStatusFromRecords", () => {
 
   it("all current is up_to_date", () => {
     expect(gameStatusFromRecords([rec({ current_version: "2.0.0.0" })], outdatedCtx)).toBe("up_to_date");
+  });
+
+  it("a Streamline plugin outdated only is up_to_date when the Streamline switch is off", () => {
+    const records = [rec({ family: "dlss_sr", path: "C:\\g\\sl.dlss.dll", current_version: "1.0.0.0" })];
+    expect(gameStatusFromRecords(records, outdatedCtx, [], null, prefs({ update_streamline: false }))).toBe("up_to_date");
+    expect(gameStatusFromRecords(records, outdatedCtx, [], null, prefs({ update_streamline: true }))).toBe("outdated");
+  });
+
+  it("a Streamline plugin is never offered when DLSS Enabler manages the set", () => {
+    const records = [rec({ family: "reflex", path: "C:\\g\\sl.reflex.dll", current_version: "1.0.0.0" })];
+    const reflexCtx = ctx({ latestByKey: { reflex: "2.0.0.0" } });
+    expect(gameStatusFromRecords(records, reflexCtx, [], null, prefs({ update_streamline: true }), true)).toBe("up_to_date");
+    expect(gameStatusFromRecords(records, reflexCtx, [], null, prefs({ update_streamline: true }), false)).toBe("outdated");
+  });
+});
+
+describe("isStreamlinePlugin", () => {
+  it("matches sl.* dlls case-insensitively and rejects NGX/other dlls", () => {
+    expect(isStreamlinePlugin("sl.dlss.dll")).toBe(true);
+    expect(isStreamlinePlugin("SL.Reflex.DLL")).toBe(true);
+    expect(isStreamlinePlugin("sl.interposer.dll")).toBe(true);
+    expect(isStreamlinePlugin("nvngx_dlss.dll")).toBe(false);
+    expect(isStreamlinePlugin("libxess.dll")).toBe(false);
+  });
+});
+
+describe("recordUpdatable", () => {
+  it("permissive when no prefs are supplied (legacy)", () => {
+    expect(recordUpdatable(rec({ path: "C:\\g\\sl.dlss.dll" }))).toBe(true);
+  });
+
+  it("NGX DLLs follow only their feature pref, never the Streamline switch", () => {
+    const ngx = rec({ family: "dlss_sr", path: "C:\\g\\nvngx_dlss.dll" });
+    expect(recordUpdatable(ngx, prefs({ update_dlss: true, update_streamline: false }))).toBe(true);
+    expect(recordUpdatable(ngx, prefs({ update_dlss: false }))).toBe(false);
+  });
+
+  it("Streamline plugins require BOTH the feature pref and the Streamline switch", () => {
+    const slSr = rec({ family: "dlss_sr", path: "C:\\g\\sl.dlss.dll" });
+    expect(recordUpdatable(slSr, prefs({ update_dlss: true, update_streamline: false }))).toBe(false);
+    expect(recordUpdatable(slSr, prefs({ update_dlss: true, update_streamline: true }))).toBe(true);
+    expect(recordUpdatable(slSr, prefs({ update_dlss: false, update_streamline: true }))).toBe(false);
+  });
+
+  it("a Streamline plugin is blocked when DLSS Enabler is present even if opted in", () => {
+    const slReflex = rec({ family: "reflex", path: "C:\\g\\sl.reflex.dll" });
+    expect(recordUpdatable(slReflex, prefs({ update_reflex: true, update_streamline: true }), true)).toBe(false);
+    expect(recordUpdatable(slReflex, prefs({ update_reflex: true, update_streamline: true }), false)).toBe(true);
+  });
+
+  it("DirectStorage follows its own pref and is never gated by the Streamline switch", () => {
+    const ds = rec({ family: "direct_storage", path: "C:\\g\\dstorage.dll" });
+    expect(recordUpdatable(ds, prefs({ update_direct_storage: true, update_streamline: false }))).toBe(true);
+    expect(recordUpdatable(ds, prefs({ update_direct_storage: false }))).toBe(false);
+  });
+
+  it("XeSS and FSR follow their own prefs, unaffected by the Streamline switch", () => {
+    const xess = rec({ family: "xess_sr", path: "C:\\g\\libxess.dll" });
+    const fsr = rec({ family: "fsr_upscaler", path: "C:\\g\\amd_fidelityfx_dx12.dll" });
+    expect(recordUpdatable(xess, prefs({ update_xess: true, update_streamline: false }))).toBe(true);
+    expect(recordUpdatable(xess, prefs({ update_xess: false }))).toBe(false);
+    expect(recordUpdatable(fsr, prefs({ update_fsr: true, update_streamline: false }))).toBe(true);
+    expect(recordUpdatable(fsr, prefs({ update_fsr: false }))).toBe(false);
   });
 });

--- a/tests/unit/ux.test.ts
+++ b/tests/unit/ux.test.ts
@@ -5,6 +5,10 @@ import {
   pushRecentCommand,
   isModifierComboMatch,
   vendorForFamily,
+  githubReleaseTagUrl,
+  matchedIndices,
+  highlightSegments,
+  EXTERNAL_URLS,
   COMMAND_PALETTE_RECENT_MAX,
   COMMAND_CATEGORY_LABELS,
 } from "@/lib/ux";
@@ -104,6 +108,43 @@ describe("vendorForFamily", () => {
   });
 });
 
+describe("release + external URLs", () => {
+  it("githubReleaseTagUrl builds a tag URL and strips a leading v", () => {
+    expect(githubReleaseTagUrl("1.6.0")).toBe("https://github.com/xt0n1-t3ch/DLSSync/releases/tag/v1.6.0");
+    expect(githubReleaseTagUrl("v1.6.0")).toBe("https://github.com/xt0n1-t3ch/DLSSync/releases/tag/v1.6.0");
+    expect(githubReleaseTagUrl("  V2.0.1 ")).toBe("https://github.com/xt0n1-t3ch/DLSSync/releases/tag/v2.0.1");
+  });
+
+  it("exposes the GitHub releases-latest and Nexus mod links", () => {
+    expect(EXTERNAL_URLS.releasesLatest).toBe("https://github.com/xt0n1-t3ch/DLSSync/releases/latest");
+    expect(EXTERNAL_URLS.nexusMod).toBe("https://www.nexusmods.com/site/mods/1922");
+  });
+});
+
+describe("matchedIndices + highlightSegments (fuzzy highlight)", () => {
+  it("returns a contiguous span for a substring match", () => {
+    expect(matchedIndices("catalog", "Go to Catalog")).toEqual([6, 7, 8, 9, 10, 11, 12]);
+  });
+  it("returns subsequence positions when not contiguous", () => {
+    expect(matchedIndices("gtl", "Go to Library")).toEqual([0, 3, 6]);
+  });
+  it("returns [] when the query is not a subsequence of the text", () => {
+    expect(matchedIndices("zzz", "Go to Library")).toEqual([]);
+    expect(matchedIndices("", "anything")).toEqual([]);
+  });
+  it("splits text into hit / non-hit segments preserving original order and casing", () => {
+    const segs = highlightSegments("Go to Catalog", [6, 7, 8, 9, 10, 11, 12]);
+    expect(segs).toEqual([
+      { text: "Go to ", hit: false },
+      { text: "Catalog", hit: true },
+    ]);
+    expect(segs.map((s) => s.text).join("")).toBe("Go to Catalog");
+  });
+  it("no indices yields a single non-hit segment", () => {
+    expect(highlightSegments("Plain", [])).toEqual([{ text: "Plain", hit: false }]);
+  });
+});
+
 describe("command catalog integrity", () => {
   it("command ids are unique", () => {
     const ids = COMMANDS.map((c) => c.id);
@@ -112,6 +153,12 @@ describe("command catalog integrity", () => {
   it("every command has a category with a label", () => {
     for (const c of COMMANDS) {
       expect(COMMAND_CATEGORY_LABELS[c.category]).toBeTruthy();
+    }
+  });
+  it("every command declares a non-empty icon key", () => {
+    for (const c of COMMANDS) {
+      expect(typeof c.icon).toBe("string");
+      expect(c.icon.length).toBeGreaterThan(0);
     }
   });
 });


### PR DESCRIPTION
Release v1.5.2 — catalog completeness, Streamline crash-safety, System & Components reliability.

Rebased onto main's 1.5.1 (`c93431c`); single linear commit, fast-forward clean.

## Highlights
- **Catalog:** restore DirectStorage and the full AMD/Intel upscaler history via union-merge + dedupe; add DirectStorageCore and FsrDenoiser scanner families; record hash algorithm (md5 vs sha256) per release.
- **Crash-safety:** stop swapping NVIDIA's version-locked Streamline (`sl.*`) DLLs across SDK majors or when an injector mod is present (the Starfield/Subnautica 2 crash); re-hash the destination after a swap and roll back on mismatch; classify a locked file (game running) separately from a real failure.
- **System & Components:** elevated install no longer hangs or vanishes after the UAC prompt — real progress, hard timeout, terminal result, with the per-machine `0x80240044` case surfaced; export-driver snapshot + System Restore point before installing; one-click rollback; filterable System Drivers section in Backups; installed/older/latest version history per driver.
- **DLSS overrides:** resetting no longer creates a phantom per-game profile.
- **Build:** `beforeBuildCommand` closes any running instance first so the release link step can replace the locked exe.
- **Interface:** full-page game detail, top-right command palette, frosted notification center, broader notification coverage, persistent notification links.

## Validation (worktree, commit `296eb30`)
- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — 0 warnings
- `cargo test --workspace` — pass
- `svelte-check` — 0 errors / 0 warnings (198 files)
- Vitest — 328 tests / 39 files pass

New crate `system-drivers` (version/classify/anti-downgrade core + `#[cfg(windows)]` inventory/wua) plus a CDP-driven full-app e2e harness (`tests/e2e/full-app.e2e.mjs`).
