### PR TITLE
fix(ci): attach release assets from nsis and msi subdirs via recursive glob

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -310,8 +310,8 @@ jobs:
           generate_release_notes: false
           body: ${{ steps.notes.outputs.body }}
           files: |
-            release/*-setup.exe
-            release/*-setup.exe.sig
-            release/*-portable.zip
-            release/*.msi
+            release/**/*-setup.exe
+            release/**/*-setup.exe.sig
+            release/**/*-portable.zip
+            release/**/*.msi
             release/latest.json


### PR DESCRIPTION
## Summary

The v1.5.2 release published with only `latest.json` attached — the installer, signature, and portable zip were missing, so the in-app updater would resolve a 404. This restores all release assets.

## What changed

- `.github/workflows/release.yml`: the Create GitHub Release `files:` globs now recurse — `release/**/*-setup.exe`, `release/**/*-setup.exe.sig`, `release/**/*-portable.zip`, `release/**/*.msi` (was top-level `release/*`). `release/latest.json` stays top-level.

## Why

v1.5.2 added `target/release/bundle/msi/*.msi` to the `upload-artifact` paths. `actions/upload-artifact@v4` roots an artifact at the common ancestor of all matched paths, so adding the `msi/` sibling moved the root from `bundle/nsis` up to `bundle`. On download the files land in `release/nsis/` and `release/msi/` instead of flat in `release/`, and the top-level `release/*-setup.exe` glob matched nothing. The `Locate` step already uses recursive `find`, so the `latest.json` url and signature were correct — only the asset upload was affected.

## Testing

- Verified the broken run (26668900467) Create GitHub Release log: `Pattern 'release/*-setup.exe' does not match any files` for exe/sig/portable; only `latest.json` uploaded.
- Compared assets: v1.5.1 has 4 assets (setup.exe 5.0 MB, .sig, portable.zip 6.5 MB, latest.json); v1.5.2 had only latest.json.
- After merge: retag v1.5.2 on the fixed HEAD, re-run Release, confirm all four assets attach.
