### PR TITLE
release: v1.6.5 — background-update daemon, anti-cheat apply guard, security hardening

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ PLAN.md
 spec.md
 SPEC.md
 *.handoff.md
+
+# Manifest signing private key — NEVER commit
+secrets/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to DLSSync are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.5] - 2026-06-03
+
+DLSSync can keep your DLLs current on its own now — a background daemon that scans on a schedule, sits in the tray, and warns you before you touch a game that can ban you for it.
+
+### Added
+
+- Background updates. Turn it on and DLSSync rescans your library on a schedule (every 1 to 168 hours) even with the window closed, shows how many games have updates ready in the tray, and raises a Windows notification when something is waiting. It can close to the tray instead of quitting, start with Windows minimized, and apply everything in one click from the tray, the notification, or the Library header. Optional auto-apply always skips anti-cheat games and makes a backup first. Off by default.
+- A ban-risk warning at the moment you apply. Games protected by EAC, BattlEye, or VAC now show a risk chip next to Apply and ask for one explicit confirmation before any DLL is replaced — the warning lands at the apply step, not buried in a panel.
+- Manifest signature verification (Ed25519) against a key baked into the app. Verification ships now; fail-closed enforcement is staged for a later release, once the signed manifest is live across the CDN.
+
+### Changed
+
+- Notification logos come from the component being updated, not a guess at the wording — so a DLSSync release no longer shows up wearing NVIDIA's logo, and an FSR or XeSS update wears the right one.
+- The close-to-tray and start-with-Windows switches moved into the new Background updates section; the Performance section keeps the efficiency (EcoQoS) toggle.
+- In release builds the catalog URL can no longer be redirected by an environment variable.
+
+### Fixed
+
+- Duplicate driver notifications are gone — dedup is enforced in the database instead of racing in memory — and the ones that had piled up are pruned the next time you launch. Apply notifications also stop being swallowed after the first one per game.
+- Authenticode checks validate the whole certificate chain for revocation, falling back only when the machine is offline.
+- ZIP extraction is bounded by the bytes actually written rather than a size the archive claims, a single failed download no longer poisons that file's cache for the rest of the session, a cancelled apply stops sooner, and a failed item in a batch now reports which one.
+- Updated the test runner to clear a security advisory.
+
 ## [1.6.4] - 2026-06-02
 
 A visual overhaul. The game detail panel, the library filters, and the About, Settings, and Backups pages were rebuilt, the whole app reads correctly in light mode, and notifications stop repeating themselves and start telling you something worth reading.
@@ -115,6 +138,7 @@ of the Arc desktop package, and install progress no longer breaks when you switc
 - AMD opens its official download page instead of a constructed installer URL. The direct `.exe` is gated behind a license prompt and its filename changes per release, so a fabricated link was unreliable; version and changelog detection are unchanged.
 - Vendor installer exit codes are reported with a readable message. Intel's "no compatible device" (exit code 8) now explains the GPU may be OEM-locked or need a different driver branch, pointing to the manufacturer or Windows Update.
 
+[1.6.5]: https://github.com/xt0n1-t3ch/DLSSync/releases/tag/v1.6.5
 [1.6.4]: https://github.com/xt0n1-t3ch/DLSSync/releases/tag/v1.6.4
 [1.6.3]: https://github.com/xt0n1-t3ch/DLSSync/releases/tag/v1.6.3
 [1.6.2]: https://github.com/xt0n1-t3ch/DLSSync/releases/tag/v1.6.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "anticheat-detect"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "jwalk",
  "memchr",
@@ -352,7 +352,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "backup-store"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "chrono",
  "rusqlite",
@@ -374,6 +374,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bit-set"
@@ -720,6 +726,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "cookie"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -899,6 +911,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -969,6 +1008,16 @@ name = "deadpool-runtime"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
 
 [[package]]
 name = "deranged"
@@ -1094,11 +1143,13 @@ dependencies = [
 
 [[package]]
 name = "dll-catalog"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "bytes",
  "chrono",
+ "ed25519-dalek",
  "futures-util",
+ "hex",
  "md-5",
  "once_cell",
  "parking_lot",
@@ -1117,7 +1168,7 @@ dependencies = [
 
 [[package]]
 name = "dll-scanner"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "jwalk",
  "once_cell",
@@ -1154,7 +1205,7 @@ dependencies = [
 
 [[package]]
 name = "dlssync"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "anticheat-detect",
  "anyhow",
@@ -1236,7 +1287,7 @@ dependencies = [
 
 [[package]]
 name = "driver-catalog"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1252,7 +1303,7 @@ dependencies = [
 
 [[package]]
 name = "driver-install"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "dll-catalog",
  "futures-util",
@@ -1309,6 +1360,30 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "either"
@@ -1458,6 +1533,12 @@ checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "field-offset"
@@ -2558,7 +2639,7 @@ dependencies = [
 
 [[package]]
 name = "launcher-scan"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "serde",
  "serde_json",
@@ -2695,12 +2776,13 @@ dependencies = [
 
 [[package]]
 name = "manifest-builder"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "anyhow",
  "chrono",
  "clap",
  "dll-catalog",
+ "ed25519-dalek",
  "hex",
  "reqwest 0.12.28",
  "serde",
@@ -2880,7 +2962,7 @@ dependencies = [
 
 [[package]]
 name = "notifications-store"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "chrono",
  "rusqlite",
@@ -2972,7 +3054,7 @@ dependencies = [
 
 [[package]]
 name = "nvapi-drs"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "serde",
  "windows-sys 0.59.0",
@@ -3335,12 +3417,13 @@ checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "pe-version"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "pelite",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "tracing",
  "windows-sys 0.59.0",
 ]
 
@@ -3448,6 +3531,16 @@ dependencies = [
  "atomic-waker",
  "fastrand",
  "futures-io",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
 ]
 
 [[package]]
@@ -3724,7 +3817,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -3734,7 +3827,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -4470,6 +4572,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4565,6 +4676,16 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]
@@ -4705,7 +4826,7 @@ dependencies = [
 
 [[package]]
 name = "system-drivers"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "serde",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["src-tauri", "crates/*"]
 
 [workspace.package]
-version = "1.6.4"
+version = "1.6.5"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/xt0n1-t3ch/DLSSync"
@@ -26,6 +26,8 @@ tokio-util = "0.7"
 async-trait = "0.1"
 sha2 = "0.10"
 md-5 = "0.10"
+ed25519-dalek = "2.1"
+hex = "0.4"
 blake3 = "1.5"
 pelite = "0.10"
 memchr = "2.7"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <!-- keep-comment: SEO + LLM/GEO keyword block harvested by GitHub search, Google, and AI crawlers (GPTBot, OAI-SearchBot, ChatGPT-User, PerplexityBot, ClaudeBot, Google-Extended). Invisible to README readers.
-  DLSSync is an all-in-one updater for PC gaming graphics libraries AND drivers — not just DLSS.
-  Graphics: DLSS updater, DLSS swapper alternative, DLSS Updater, update DLSS DLL, DLSS 4, DLSS Frame Generation, DLSS Ray Reconstruction, NVIDIA Streamline, NVIDIA Reflex, AMD FSR, FSR 3, FSR Frame Generation, Intel XeSS, XeSS Frame Generation, XeLL, Microsoft DirectStorage, upscaling, frame generation, RTX, GeForce, Radeon, Intel Arc.
+  DLSSync is an all-in-one auto-updater for PC gaming graphics libraries AND drivers — not just DLSS.
+  Graphics: auto-update DLSS FSR XeSS Streamline, DLSS updater, DLSS swapper alternative, DLSS Updater alternative, Recol alternative, update DLSS DLL automatically, DLSS 4, DLSS Frame Generation, DLSS Ray Reconstruction, NVIDIA Streamline set updater, NVIDIA Reflex, AMD FSR, FSR 3, FSR Frame Generation, Intel XeSS, XeSS Frame Generation, XeLL, Microsoft DirectStorage, upscaling, frame generation, RTX, GeForce, Radeon, Intel Arc, DLSS Enabler compatible, Streamline coherence update.
   Drivers: GPU driver updater, NVIDIA driver update, AMD Adrenalin update, Intel Arc driver update, Windows device driver updater, audio/network/chipset/Bluetooth/storage driver update.
-  Standout: lightweight, fast, Rust, Tauri 2, secure by default, SHA-256 hash verified, Authenticode vendor-signed, automatic backups, snapshots, one-click rollback, zero telemetry, no admin, Windows portable, open source, Apache-2.0.
+  Standout: background daemon, runs in tray, autostart on Windows login, lightweight, fast, Rust, Tauri 2, secure by default, SHA-256 hash verified, Authenticode vendor-signed, automatic backups, snapshots, one-click rollback, zero telemetry, no admin, Windows portable, open source, Apache-2.0.
 -->
 
 <p align="center">
@@ -12,8 +12,8 @@
 </p>
 
 <p align="center">
-  <b>The all-in-one updater for PC gaming graphics and drivers.</b><br/>
-  DLSSync keeps NVIDIA DLSS, AMD FSR, Intel XeSS, Frame Generation, Reflex, Streamline, Ray Reconstruction and Microsoft DirectStorage DLLs in sync with each vendor's latest release — and updates your NVIDIA, AMD and Intel GPU drivers plus other Windows device drivers, too. Lightweight, secure by default, every change reversible. Zero telemetry, open-source.
+  <b>Auto-update DLSS, FSR, XeSS &amp; Streamline across all your games — plus GPU and Windows drivers — from one place.</b><br/>
+  DLSSync sits in the tray, starts with Windows, and keeps NVIDIA DLSS, AMD FSR, Intel XeSS, Frame Generation, Reflex, Streamline, Ray Reconstruction and Microsoft DirectStorage DLLs current across every launcher you use. It detects your games, checks for newer vendor releases, and applies updates with signature verification and a one-click rollback if anything goes wrong. GPU and Windows device drivers too. Zero telemetry, open-source, no admin required.
 </p>
 
 <p align="center">
@@ -45,6 +45,8 @@
   <a href="#what-is-dlssync">What is DLSSync</a>
   &nbsp;·&nbsp;
   <a href="#why">Why DLSSync</a>
+  &nbsp;·&nbsp;
+  <a href="#safety">Safety &amp; trust</a>
   &nbsp;·&nbsp;
   <a href="#features">Features</a>
   &nbsp;·&nbsp;
@@ -119,23 +121,35 @@ Most tools swap one DLL family. DLSSync keeps your whole graphics stack — and 
       <th align="center">DLSSync</th>
       <th align="center">DLSS&nbsp;Swapper</th>
       <th align="center">DLSS&nbsp;Updater</th>
+      <th align="center">Recol</th>
+      <th align="center">DLSS&nbsp;Enabler</th>
     </tr>
   </thead>
   <tbody>
-    <tr><td>Update DLSS, FSR &amp; XeSS DLLs</td><td align="center">✅</td><td align="center">✅</td><td align="center">✅</td></tr>
-    <tr><td>Frame Generation &amp; Ray Reconstruction DLLs</td><td align="center">✅</td><td align="center">✅</td><td align="center">✅</td></tr>
-    <tr><td>NVIDIA Streamline set (<code>sl.*</code>) as one atomic, version-locked update</td><td align="center">✅</td><td align="center">❌</td><td align="center">➖</td></tr>
-    <tr><td>Update NVIDIA / AMD / Intel <b>GPU drivers</b></td><td align="center">✅</td><td align="center">❌</td><td align="center">❌</td></tr>
-    <tr><td>Update other <b>Windows device drivers</b> (audio, network, chipset…)</td><td align="center">✅</td><td align="center">❌</td><td align="center">❌</td></tr>
-    <tr><td>SHA-256 <b>+ Authenticode</b> publisher gate before every write</td><td align="center">✅</td><td align="center">➖</td><td align="center">➖</td></tr>
-    <tr><td>Automatic backup + one-click rollback</td><td align="center">✅</td><td align="center">✅</td><td align="center">✅</td></tr>
-    <tr><td>Single signed native binary — no Python or .NET runtime</td><td align="center">✅ <sub>(Rust)</sub></td><td align="center">❌ <sub>(.NET)</sub></td><td align="center">❌ <sub>(Python)</sub></td></tr>
-    <tr><td>Per-user install, no admin required</td><td align="center">✅</td><td align="center">✅</td><td align="center">➖</td></tr>
-    <tr><td>Zero telemetry · open-source</td><td align="center">✅</td><td align="center">✅</td><td align="center">✅</td></tr>
+    <tr><td>Update DLSS, FSR &amp; XeSS DLLs</td><td align="center">✅</td><td align="center">✅</td><td align="center">✅</td><td align="center">✅</td><td align="center">➖</td></tr>
+    <tr><td>Frame Generation &amp; Ray Reconstruction DLLs</td><td align="center">✅</td><td align="center">✅</td><td align="center">✅</td><td align="center">✅</td><td align="center">➖</td></tr>
+    <tr><td>NVIDIA Streamline set (<code>sl.*</code>) as one atomic, version-locked update</td><td align="center">✅</td><td align="center">❌</td><td align="center">➖</td><td align="center">❌</td><td align="center">➖</td></tr>
+    <tr><td>Auto-detect all launchers (Steam, Epic, GOG, Ubisoft, EA, Xbox, Battle.net)</td><td align="center">✅</td><td align="center">✅</td><td align="center">➖</td><td align="center">➖</td><td align="center">❌</td></tr>
+    <tr><td>Background daemon — tray, autostart, updates without opening the app</td><td align="center">✅</td><td align="center">❌</td><td align="center">➖</td><td align="center">❌</td><td align="center">❌</td></tr>
+    <tr><td>Update NVIDIA / AMD / Intel <b>GPU drivers</b></td><td align="center">✅</td><td align="center">❌</td><td align="center">❌</td><td align="center">❌</td><td align="center">❌</td></tr>
+    <tr><td>Update other <b>Windows device drivers</b> (audio, network, chipset…)</td><td align="center">✅</td><td align="center">❌</td><td align="center">❌</td><td align="center">❌</td><td align="center">❌</td></tr>
+    <tr><td>SHA-256 <b>+ Authenticode</b> publisher gate before every write</td><td align="center">✅</td><td align="center">➖</td><td align="center">➖</td><td align="center">➖</td><td align="center">➖</td></tr>
+    <tr><td>Automatic backup + one-click rollback</td><td align="center">✅</td><td align="center">✅</td><td align="center">✅</td><td align="center">➖</td><td align="center">❌</td></tr>
+    <tr><td>Single signed native binary — no Python or .NET runtime</td><td align="center">✅ <sub>(Rust)</sub></td><td align="center">❌ <sub>(.NET)</sub></td><td align="center">❌ <sub>(Python)</sub></td><td align="center">➖</td><td align="center">➖</td></tr>
+    <tr><td>Per-user install, no admin required</td><td align="center">✅</td><td align="center">✅</td><td align="center">➖</td><td align="center">✅</td><td align="center">➖</td></tr>
+    <tr><td>Zero telemetry · open-source</td><td align="center">✅</td><td align="center">✅</td><td align="center">✅</td><td align="center">➖</td><td align="center">❌</td></tr>
   </tbody>
 </table>
 
-<sub>✅ yes · ➖ partial / varies · ❌ no. Competitor columns reflect publicly documented features as of May 2026 — corrections welcome via an <a href="https://github.com/xt0n1-t3ch/DLSSync/issues">issue</a>. DLSS Swapper and DLSS Updater are excellent, focused tools; <a href="https://github.com/optiscaler/OptiScaler">OptiScaler</a> solves a different problem (injecting and translating upscalers across GPUs) and pairs well with DLSSync.</sub>
+<sub>✅ yes · ➖ partial / varies · ❌ no. Competitor columns reflect publicly documented features as of June 2026 — corrections welcome via an <a href="https://github.com/xt0n1-t3ch/DLSSync/issues">issue</a>. DLSS Swapper and DLSS Updater are excellent, focused tools; Recol is a newer DLL manager worth watching; DLSS Enabler hooks the loader to unlock DLSS in unsupported titles — a different job that pairs well with DLSSync. <a href="https://github.com/optiscaler/OptiScaler">OptiScaler</a> solves yet another problem (injecting and translating upscalers across GPUs) and works alongside DLSSync too.</sub>
+
+---
+
+<h2 id="safety"><img src="./.github/assets/icons/shield.svg" width="26" align="center" alt=""/> &nbsp;Safety &amp; trust</h2>
+
+Every DLL DLSSync writes is fetched directly from the vendor's own release infrastructure — NVIDIA's GitHub SDK releases, Intel's NuGet packages, AMD's and Microsoft's official CDN endpoints. The app never re-hosts, repackages or patches a binary. Nothing goes into your game folder until it passes a SHA-256 hash check against the published catalog **and** an Authenticode publisher check that verifies the signer is the real NVIDIA, AMD, Intel or Microsoft certificate.
+
+The catalog itself is a public, auditable JSON file tracked in its own Git repository. Every entry carries the expected hash; you can verify any entry manually with `certutil -hashfile <dll> SHA256`. The app ships as an Apache 2.0 open-source project — every line of the update logic is readable in this repository.
 
 ---
 

--- a/crates/backup-store/src/lib.rs
+++ b/crates/backup-store/src/lib.rs
@@ -9,6 +9,8 @@ pub enum BackupError {
     Sqlite(#[from] rusqlite::Error),
     #[error("not found: {0}")]
     NotFound(String),
+    #[error("invalid column identifier: {0}")]
+    InvalidColumn(String),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -284,10 +286,24 @@ fn path_str(p: &Path) -> String {
     p.to_string_lossy().into_owned()
 }
 
+/// A SQLite identifier safe to interpolate into DDL: only the characters that
+/// cannot break out of an `ALTER TABLE ... ADD COLUMN <name>` clause. `column`
+/// must always be a static literal at the call sites; this is defense-in-depth
+/// against that invariant ever being violated.
+fn is_safe_column_ident(column: &str) -> bool {
+    !column.is_empty()
+        && column
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'_')
+}
+
 /// PRAGMA-guarded additive migration: add `column` to the `backups` table when an
 /// older install's DB predates it. Mirrors the notifications-store `link` column
 /// migration so existing backups upgrade in place.
 fn ensure_column(conn: &rusqlite::Connection, column: &str, decl: &str) -> Result<(), BackupError> {
+    if !is_safe_column_ident(column) {
+        return Err(BackupError::InvalidColumn(column.to_string()));
+    }
     let mut present = false;
     {
         let mut stmt = conn.prepare("PRAGMA table_info(backups)")?;
@@ -409,6 +425,48 @@ mod tests {
             hardware_id: None,
             driver_provider: None,
         }
+    }
+
+    #[test]
+    fn safe_column_ident_accepts_real_columns_rejects_injection() {
+        assert!(is_safe_column_ident("backup_type"));
+        assert!(is_safe_column_ident("device_class"));
+        assert!(is_safe_column_ident("hardware_id"));
+        assert!(is_safe_column_ident("driver_provider"));
+        assert!(is_safe_column_ident("col123"));
+
+        assert!(!is_safe_column_ident(""));
+        assert!(!is_safe_column_ident("foo bar"));
+        assert!(!is_safe_column_ident("foo;DROP TABLE backups"));
+        assert!(!is_safe_column_ident("foo TEXT; --"));
+        assert!(!is_safe_column_ident("foo-bar"));
+        assert!(!is_safe_column_ident("\"foo\""));
+    }
+
+    #[test]
+    fn ensure_column_rejects_malicious_identifier() {
+        let dir = tempdir().unwrap();
+        let store = fresh_store(&dir);
+        let conn = store.conn().unwrap();
+        let res = ensure_column(&conn, "evil; DROP TABLE backups", "TEXT");
+        assert!(matches!(res, Err(BackupError::InvalidColumn(_))));
+    }
+
+    #[test]
+    fn ensure_column_adds_valid_column_idempotently() {
+        let dir = tempdir().unwrap();
+        let store = fresh_store(&dir);
+        let conn = store.conn().unwrap();
+        ensure_column(&conn, "extra_note", "TEXT").unwrap();
+        ensure_column(&conn, "extra_note", "TEXT").unwrap();
+        let present: bool = conn
+            .prepare("PRAGMA table_info(backups)")
+            .unwrap()
+            .query_map([], |row| row.get::<_, String>(1))
+            .unwrap()
+            .filter_map(Result::ok)
+            .any(|name| name == "extra_note");
+        assert!(present);
     }
 
     #[test]

--- a/crates/dll-catalog/Cargo.toml
+++ b/crates/dll-catalog/Cargo.toml
@@ -11,6 +11,8 @@ thiserror.workspace = true
 reqwest.workspace = true
 sha2.workspace = true
 md-5.workspace = true
+ed25519-dalek.workspace = true
+hex.workspace = true
 chrono.workspace = true
 tracing.workspace = true
 tokio = { workspace = true }

--- a/crates/dll-catalog/src/download.rs
+++ b/crates/dll-catalog/src/download.rs
@@ -92,6 +92,15 @@ impl DownloadCache {
         self.inner.lock().clear();
     }
 
+    fn forget(&self, url: &str, entry: &CacheEntry) {
+        let mut guard = self.inner.lock();
+        if let Some((existing, _)) = guard.get(url) {
+            if Arc::ptr_eq(existing, entry) {
+                guard.remove(url);
+            }
+        }
+    }
+
     pub fn len(&self) -> usize {
         self.inner.lock().len()
     }
@@ -121,7 +130,10 @@ pub async fn fetch_shared(
         .await;
     match result {
         Ok(bytes) => Ok(bytes.clone()),
-        Err(err) => Err(CatalogError::Cached(err.to_string())),
+        Err(err) => {
+            cache.forget(url, &entry);
+            Err(CatalogError::Cached(err.to_string()))
+        }
     }
 }
 
@@ -306,5 +318,49 @@ mod tests {
             let v = pseudo_jitter_ms(seed, "https://example.test/url");
             assert!(v < RETRY_JITTER_MAX_MS);
         }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn fetch_shared_does_not_cache_errors() {
+        let cache = DownloadCache::new();
+        let client = reqwest::Client::new();
+        let url = "http://127.0.0.1:1/never";
+        let opts = DownloadOptions {
+            max_retries: 1,
+            chunk_timeout: Duration::from_millis(200),
+            progress_tx: None,
+            cancel: None,
+        };
+        let first = fetch_shared(&cache, &client, url, opts.clone()).await;
+        assert!(first.is_err());
+        assert!(
+            cache.is_empty(),
+            "a failed download must not stay cached for the session"
+        );
+        let second = fetch_shared(&cache, &client, url, opts).await;
+        assert!(second.is_err());
+        assert!(cache.is_empty());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn forget_only_removes_matching_entry() {
+        let cache = DownloadCache::new();
+        let url = "https://example.test/a";
+        let original = cache.get_or_init(url);
+        cache.forget(url, &original);
+        assert!(cache.is_empty());
+
+        let original = cache.get_or_init(url);
+        let replacement = {
+            cache.inner.lock().remove(url);
+            cache.get_or_init(url)
+        };
+        assert!(!Arc::ptr_eq(&original, &replacement));
+        cache.forget(url, &original);
+        assert_eq!(
+            cache.len(),
+            1,
+            "forget must not evict a newer entry under the same url"
+        );
     }
 }

--- a/crates/dll-catalog/src/lib.rs
+++ b/crates/dll-catalog/src/lib.rs
@@ -46,6 +46,10 @@ pub enum CatalogError {
     Retries { attempts: u32, last: String },
     #[error("cached error: {0}")]
     Cached(String),
+    #[error("manifest signature missing — refusing untrusted manifest from {url}")]
+    MissingSignature { url: String },
+    #[error("manifest signature verification failed: {0}")]
+    Signature(String),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -205,8 +209,91 @@ pub const MANIFEST_ENV_VAR: &str = "DLSSYNC_MANIFEST_URL";
 
 const MANIFEST_RETRY_BACKOFF_MS: &[u64] = &[200, 800, 2000];
 
+/// Suffix appended to the manifest URL to locate its detached Ed25519
+/// signature. `manifest.json` → `manifest.json.sig`. The signature file holds
+/// the 64-byte raw Ed25519 signature, hex-encoded (with optional surrounding
+/// whitespace), computed over the exact bytes of `manifest.json`.
+const MANIFEST_SIGNATURE_SUFFIX: &str = ".sig";
+
+/// Production Ed25519 public verification key (32 bytes, hex) for the DLSSync
+/// manifest. The matching private key is provisioned out-of-band and never lives
+/// in the repo; the manifest pipeline signs `manifest.json` into
+/// `manifest.json.sig` with it. A release build verifies every manifest against
+/// this key and fails closed on a missing/invalid signature.
+pub const MANIFEST_PUBKEY_HEX: &str =
+    "e9dd0828f9ee5ecb72e0a811723a79c6e5373ca1c20bd5b255d68a2b3928fcd3";
+
+/// Master enforcement flag for manifest signature verification. Staged rollout:
+/// the verification path always runs and logs, but fail-closed enforcement stays
+/// OFF until the signed `manifest.json.sig` is published and confirmed propagated
+/// across the CDN — flipping this to `true` before then would reject every
+/// manifest on a CDN-propagation lag. Flip to `true` in a later release once the
+/// signed manifest is live everywhere.
+pub const ENFORCE_MANIFEST_SIGNATURE: bool = false;
+
+/// Whether signature enforcement is active for this build. Enforcement is on in
+/// release builds when `ENFORCE_MANIFEST_SIGNATURE` is set; debug builds skip it
+/// so local dev / tests against an unsigned manifest still work. The
+/// verification path itself always runs — only the fail-closed reaction is
+/// gated here.
+pub fn signature_enforced() -> bool {
+    ENFORCE_MANIFEST_SIGNATURE && !cfg!(debug_assertions)
+}
+
+/// The configured manifest URL.
+///
+/// In release builds this is always the hardcoded HTTPS CDN — the
+/// `DLSSYNC_MANIFEST_URL` env var is ignored so a pre-launch environment
+/// injection cannot redirect every catalog/integrity fetch to an attacker.
+/// In debug builds the env var is honored to support local manifest testing.
 pub fn manifest_url() -> String {
-    std::env::var(MANIFEST_ENV_VAR).unwrap_or_else(|_| DEFAULT_MANIFEST_URL.to_string())
+    #[cfg(debug_assertions)]
+    {
+        if let Ok(v) = std::env::var(MANIFEST_ENV_VAR) {
+            return v;
+        }
+    }
+    DEFAULT_MANIFEST_URL.to_string()
+}
+
+/// Derive the detached-signature URL for a given manifest URL.
+fn signature_url(manifest_url: &str) -> String {
+    format!("{manifest_url}{MANIFEST_SIGNATURE_SUFFIX}")
+}
+
+/// Verify a detached Ed25519 signature (hex-encoded, 64 raw bytes) over the
+/// exact `manifest_bytes`, against the baked-in public key. Returns the parsed
+/// reason string on any failure so the caller can surface it.
+fn verify_manifest_signature(manifest_bytes: &[u8], signature_hex: &str) -> Result<(), String> {
+    verify_with_pubkey(MANIFEST_PUBKEY_HEX, manifest_bytes, signature_hex)
+}
+
+/// Core Ed25519 detached-signature check, parameterized on the hex public key so
+/// the crypto path is testable against a known keypair without touching the
+/// baked-in placeholder key.
+fn verify_with_pubkey(
+    pubkey_hex: &str,
+    manifest_bytes: &[u8],
+    signature_hex: &str,
+) -> Result<(), String> {
+    use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+
+    let key_bytes: [u8; 32] = hex::decode(pubkey_hex)
+        .ok()
+        .and_then(|v| v.try_into().ok())
+        .ok_or_else(|| "public key is not 32 hex-encoded bytes".to_string())?;
+    let verifying_key =
+        VerifyingKey::from_bytes(&key_bytes).map_err(|e| format!("public key is invalid: {e}"))?;
+
+    let sig_bytes: [u8; 64] = hex::decode(signature_hex.trim())
+        .map_err(|e| format!("signature is not valid hex: {e}"))?
+        .try_into()
+        .map_err(|_| "signature is not 64 bytes".to_string())?;
+    let signature = Signature::from_bytes(&sig_bytes);
+
+    verifying_key
+        .verify(manifest_bytes, &signature)
+        .map_err(|e| format!("signature does not match manifest: {e}"))
 }
 
 impl Catalog {
@@ -320,8 +407,76 @@ async fn try_fetch(client: &reqwest::Client, url: &str) -> Result<Catalog, Catal
         .error_for_status()?
         .bytes()
         .await?;
+    enforce_manifest_signature(client, url, &bytes).await?;
     let c: Catalog = serde_json::from_slice(&bytes)?;
     Ok(c)
+}
+
+/// Fetch the detached signature for `url` and verify it over `manifest_bytes`.
+///
+/// Fail-closed when `signature_enforced()`: a missing signature yields
+/// `MissingSignature`, a present-but-invalid one yields `Signature`. When
+/// enforcement is off (debug builds) the verification still runs if a signature
+/// is reachable — a present-but-invalid signature is logged but tolerated, and
+/// a missing signature is ignored — so local/dev work against the not-yet-signed
+/// manifest is unaffected.
+async fn enforce_manifest_signature(
+    client: &reqwest::Client,
+    url: &str,
+    manifest_bytes: &[u8],
+) -> Result<(), CatalogError> {
+    let enforced = signature_enforced();
+    let sig_text = match fetch_signature(client, url).await {
+        Ok(Some(text)) => text,
+        Ok(None) => {
+            if enforced {
+                return Err(CatalogError::MissingSignature {
+                    url: url.to_string(),
+                });
+            }
+            tracing::warn!(
+                %url,
+                "manifest has no detached signature; verification skipped (enforcement off in debug)"
+            );
+            return Ok(());
+        }
+        Err(e) => {
+            if enforced {
+                return Err(CatalogError::Signature(format!(
+                    "could not fetch detached signature: {e}"
+                )));
+            }
+            tracing::warn!(%url, error = %e, "could not fetch manifest signature; verification skipped (enforcement off in debug)");
+            return Ok(());
+        }
+    };
+
+    match verify_manifest_signature(manifest_bytes, &sig_text) {
+        Ok(()) => Ok(()),
+        Err(reason) => {
+            if enforced {
+                Err(CatalogError::Signature(reason))
+            } else {
+                tracing::warn!(%url, %reason, "manifest signature did not verify; tolerated (enforcement off in debug)");
+                Ok(())
+            }
+        }
+    }
+}
+
+/// Fetch the detached signature text. `Ok(None)` means the signature resource is
+/// absent (HTTP 404/410); any other transport/HTTP failure is an error.
+async fn fetch_signature(
+    client: &reqwest::Client,
+    manifest_url: &str,
+) -> Result<Option<String>, reqwest::Error> {
+    let resp = client.get(signature_url(manifest_url)).send().await?;
+    let status = resp.status();
+    if status == reqwest::StatusCode::NOT_FOUND || status == reqwest::StatusCode::GONE {
+        return Ok(None);
+    }
+    let text = resp.error_for_status()?.text().await?;
+    Ok(Some(text))
 }
 
 pub async fn download_and_extract_dll(
@@ -393,6 +548,90 @@ mod tests {
             incompatible_games: vec![],
             anticheat: None,
         }
+    }
+
+    #[test]
+    fn manifest_url_falls_back_to_default_cdn() {
+        let url = manifest_url();
+        assert!(url.starts_with("https://"), "manifest URL must be https");
+    }
+
+    #[cfg(not(debug_assertions))]
+    #[test]
+    fn manifest_url_ignores_env_override_in_release() {
+        std::env::set_var(MANIFEST_ENV_VAR, "http://attacker.example/evil.json");
+        let url = manifest_url();
+        std::env::remove_var(MANIFEST_ENV_VAR);
+        assert_eq!(url, DEFAULT_MANIFEST_URL);
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    fn manifest_url_honors_env_override_in_debug() {
+        std::env::set_var(MANIFEST_ENV_VAR, "https://local.test/manifest.json");
+        let url = manifest_url();
+        std::env::remove_var(MANIFEST_ENV_VAR);
+        assert_eq!(url, "https://local.test/manifest.json");
+    }
+
+    #[test]
+    fn signature_url_appends_sig_suffix() {
+        assert_eq!(
+            signature_url("https://cdn.test/manifest.json"),
+            "https://cdn.test/manifest.json.sig"
+        );
+    }
+
+    #[test]
+    fn baked_in_pubkey_rejects_bogus_signature() {
+        let result = verify_manifest_signature(b"any-manifest-bytes", &"00".repeat(64));
+        assert!(
+            result.is_err(),
+            "a bogus all-zero signature must be rejected by the baked-in production key"
+        );
+    }
+
+    fn test_signing_key() -> ed25519_dalek::SigningKey {
+        ed25519_dalek::SigningKey::from_bytes(&[7u8; 32])
+    }
+
+    #[test]
+    fn valid_signature_over_exact_bytes_verifies() {
+        use ed25519_dalek::Signer;
+        let sk = test_signing_key();
+        let pubkey_hex = hex::encode(sk.verifying_key().to_bytes());
+        let manifest = br#"{"schema_version":2}"#;
+        let sig_hex = hex::encode(sk.sign(manifest).to_bytes());
+        assert!(verify_with_pubkey(&pubkey_hex, manifest, &sig_hex).is_ok());
+        assert!(verify_with_pubkey(&pubkey_hex, manifest, &format!("  {sig_hex}\n")).is_ok());
+    }
+
+    #[test]
+    fn signature_over_tampered_bytes_is_rejected() {
+        use ed25519_dalek::Signer;
+        let sk = test_signing_key();
+        let pubkey_hex = hex::encode(sk.verifying_key().to_bytes());
+        let sig_hex = hex::encode(sk.sign(br#"{"schema_version":2}"#).to_bytes());
+        assert!(verify_with_pubkey(&pubkey_hex, br#"{"schema_version":3}"#, &sig_hex).is_err());
+    }
+
+    #[test]
+    fn malformed_signature_inputs_are_rejected() {
+        let sk = test_signing_key();
+        let pubkey_hex = hex::encode(sk.verifying_key().to_bytes());
+        let manifest = b"data";
+        assert!(verify_with_pubkey(&pubkey_hex, manifest, "not-hex!!").is_err());
+        assert!(verify_with_pubkey(&pubkey_hex, manifest, "abcd").is_err());
+        assert!(verify_with_pubkey("zz", manifest, &"00".repeat(64)).is_err());
+        assert!(verify_with_pubkey(&"aa".repeat(31), manifest, &"00".repeat(64)).is_err());
+    }
+
+    #[test]
+    fn signature_enforcement_tracks_flag_and_build() {
+        assert_eq!(
+            signature_enforced(),
+            ENFORCE_MANIFEST_SIGNATURE && !cfg!(debug_assertions)
+        );
     }
 
     #[test]

--- a/crates/dll-catalog/src/zip.rs
+++ b/crates/dll-catalog/src/zip.rs
@@ -1,6 +1,6 @@
 use crate::hash::{hash_file_with, HashAlgo};
 use crate::{CatalogError, Release};
-use std::io::Cursor;
+use std::io::{self, Cursor, Write};
 use std::path::{Path, PathBuf};
 
 pub const MAX_UNCOMPRESSED_ENTRY_BYTES: u64 = 200 * 1024 * 1024;
@@ -78,8 +78,20 @@ pub fn extract_dll_from_bytes(
             ))
         })?;
         let mut entry = zip.by_index(target)?;
-        let mut out = std::fs::File::create(&out_path)?;
-        std::io::copy(&mut entry, &mut out)?;
+        let out = std::fs::File::create(&out_path)?;
+        let mut limited = LimitedWriter::new(out, MAX_UNCOMPRESSED_ENTRY_BYTES);
+        if let Err(e) = std::io::copy(&mut entry, &mut limited) {
+            let _ = std::fs::remove_file(&out_path);
+            if limited.exceeded {
+                return Err(CatalogError::Unsafe(format!(
+                    "zip entry '{}' wrote more than the size cap ({} bytes) — declared header was {}",
+                    release.zip_entry.as_deref().unwrap_or(&release.filename),
+                    MAX_UNCOMPRESSED_ENTRY_BYTES,
+                    entry.size()
+                )));
+            }
+            return Err(CatalogError::Io(e));
+        }
     } else {
         std::fs::write(&out_path, bytes)?;
     }
@@ -94,6 +106,47 @@ pub fn extract_dll_from_bytes(
     }
 
     Ok(out_path)
+}
+
+/// Wraps a writer and caps the actual bytes written at `limit`, independent of
+/// any declared central-directory size. A crafted zip can under-report an
+/// entry's uncompressed size in the header, so the header check alone is not a
+/// real bound — this enforces the cap on the bytes that genuinely stream out.
+struct LimitedWriter<W> {
+    inner: W,
+    written: u64,
+    limit: u64,
+    exceeded: bool,
+}
+
+impl<W: Write> LimitedWriter<W> {
+    fn new(inner: W, limit: u64) -> Self {
+        Self {
+            inner,
+            written: 0,
+            limit,
+            exceeded: false,
+        }
+    }
+}
+
+impl<W: Write> Write for LimitedWriter<W> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let projected = self.written.saturating_add(buf.len() as u64);
+        if projected > self.limit {
+            self.exceeded = true;
+            return Err(io::Error::other(
+                "uncompressed zip entry exceeds the maximum allowed size",
+            ));
+        }
+        let n = self.inner.write(buf)?;
+        self.written = self.written.saturating_add(n as u64);
+        Ok(n)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.inner.flush()
+    }
 }
 
 fn normalize_zip_path(p: &Path) -> String {
@@ -404,6 +457,37 @@ mod tests {
         let err = extract_dll_from_bytes(&zip_bytes, &release, dir.path()).unwrap_err();
         assert!(matches!(err, CatalogError::Integrity { .. }));
         assert!(!dir.path().join("nvngx_dlss.dll").exists());
+    }
+
+    #[test]
+    fn limited_writer_allows_up_to_limit() {
+        let mut sink = Vec::new();
+        let mut w = LimitedWriter::new(&mut sink, 8);
+        assert!(w.write_all(b"12345678").is_ok());
+        assert_eq!(w.written, 8);
+        assert!(!w.exceeded);
+        assert_eq!(sink, b"12345678");
+    }
+
+    #[test]
+    fn limited_writer_rejects_when_actual_bytes_exceed_cap_regardless_of_header() {
+        let mut sink = Vec::new();
+        let mut w = LimitedWriter::new(&mut sink, 4);
+        let err = w.write_all(b"12345").unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::Other);
+        assert!(w.exceeded);
+        assert!(sink.len() <= 4, "no bytes beyond the cap may be written");
+    }
+
+    #[test]
+    fn limited_writer_caps_mid_stream_when_a_later_chunk_overflows() {
+        let mut sink = Vec::new();
+        let mut w = LimitedWriter::new(&mut sink, 6);
+        assert_eq!(w.write(b"abc").unwrap(), 3);
+        let err = w.write(b"defg").unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::Other);
+        assert!(w.exceeded);
+        assert_eq!(sink, b"abc");
     }
 
     #[test]

--- a/crates/manifest-builder/Cargo.toml
+++ b/crates/manifest-builder/Cargo.toml
@@ -14,6 +14,7 @@ anyhow = { workspace = true }
 chrono = { workspace = true }
 clap = { version = "4", features = ["derive"] }
 dll-catalog = { path = "../dll-catalog" }
+ed25519-dalek = { workspace = true }
 hex = "0.4"
 reqwest = { workspace = true }
 serde = { workspace = true }

--- a/crates/manifest-builder/src/main.rs
+++ b/crates/manifest-builder/src/main.rs
@@ -312,7 +312,7 @@ async fn main() -> Result<()> {
         std::fs::create_dir_all(parent)?;
     }
     let body = serde_json::to_vec_pretty(&catalog)?;
-    std::fs::write(&cli.out, body)?;
+    std::fs::write(&cli.out, &body)?;
     let total: usize = catalog
         .vendors
         .values()
@@ -320,7 +320,84 @@ async fn main() -> Result<()> {
         .map(|f| f.releases.len())
         .sum();
     tracing::info!(path = %cli.out.display(), releases = total, "wrote manifest");
+
+    match std::env::var(SIGNING_KEY_ENV) {
+        Ok(key_hex) => {
+            let sig_path = sign_manifest(&cli.out, &body, key_hex.trim())?;
+            tracing::info!(path = %sig_path.display(), "wrote detached Ed25519 manifest signature");
+        }
+        Err(_) => {
+            tracing::warn!(
+                env = SIGNING_KEY_ENV,
+                "manifest written UNSIGNED — set the signing key env to emit manifest.json.sig (release builds enforce signatures)"
+            );
+        }
+    }
     Ok(())
+}
+
+/// Env var holding the 32-byte Ed25519 signing seed (hex) used to sign the
+/// generated manifest. Kept out of the repo; provisioned at manifest-build time.
+const SIGNING_KEY_ENV: &str = "DLSSYNC_MANIFEST_SIGNING_KEY";
+
+/// Sign the exact manifest bytes with the Ed25519 seed and write a detached
+/// hex-encoded signature next to the manifest (`<out>.sig`), matching the suffix
+/// and format that `dll-catalog` verifies against the baked-in public key.
+fn sign_manifest(out: &std::path::Path, body: &[u8], key_hex: &str) -> Result<std::path::PathBuf> {
+    let sig_hex = sign_bytes(key_hex, body)?;
+    let mut sig_os = out.as_os_str().to_owned();
+    sig_os.push(".sig");
+    let sig_path = std::path::PathBuf::from(sig_os);
+    std::fs::write(&sig_path, sig_hex)?;
+    Ok(sig_path)
+}
+
+/// Produce the hex-encoded 64-byte detached Ed25519 signature over `body`.
+fn sign_bytes(key_hex: &str, body: &[u8]) -> Result<String> {
+    use ed25519_dalek::{Signer, SigningKey};
+    let seed = hex::decode(key_hex).context("DLSSYNC_MANIFEST_SIGNING_KEY is not valid hex")?;
+    let seed: [u8; 32] = seed
+        .as_slice()
+        .try_into()
+        .context("DLSSYNC_MANIFEST_SIGNING_KEY must be a 32-byte (64 hex char) Ed25519 seed")?;
+    Ok(hex::encode(
+        SigningKey::from_bytes(&seed).sign(body).to_bytes(),
+    ))
+}
+
+#[cfg(test)]
+mod signing_tests {
+    use super::sign_bytes;
+    use ed25519_dalek::{SigningKey, Verifier};
+
+    #[test]
+    fn sign_bytes_roundtrips_against_its_public_key() {
+        let seed = [9u8; 32];
+        let key_hex = hex::encode(seed);
+        let body = br#"{"schema_version":2}"#;
+        let sig_hex = sign_bytes(&key_hex, body).unwrap();
+        let sig_bytes: [u8; 64] = hex::decode(&sig_hex)
+            .unwrap()
+            .as_slice()
+            .try_into()
+            .unwrap();
+        let vk = SigningKey::from_bytes(&seed).verifying_key();
+        assert!(vk
+            .verify(body, &ed25519_dalek::Signature::from_bytes(&sig_bytes))
+            .is_ok());
+        assert!(vk
+            .verify(
+                br#"{"schema_version":3}"#,
+                &ed25519_dalek::Signature::from_bytes(&sig_bytes)
+            )
+            .is_err());
+    }
+
+    #[test]
+    fn sign_bytes_rejects_malformed_seed() {
+        assert!(sign_bytes("not-hex", b"x").is_err());
+        assert!(sign_bytes(&"aa".repeat(31), b"x").is_err());
+    }
 }
 
 const ANTICHEAT_DATASET: &str =

--- a/crates/notifications-store/src/lib.rs
+++ b/crates/notifications-store/src/lib.rs
@@ -5,6 +5,21 @@ pub const MAX_NOTIFICATIONS: usize = 200;
 pub const DEFAULT_LIST_LIMIT: u32 = 100;
 pub const NOTIFICATION_PUSHED_EVENT: &str = "notification:pushed";
 
+const DEDUP_INDEX_DDL: &str = "CREATE UNIQUE INDEX IF NOT EXISTS idx_notif_dedup
+     ON notifications(kind, title)
+     WHERE dismissed_at IS NULL
+       AND kind NOT IN ('apply_success', 'apply_failure', 'apply_cancelled');";
+
+const DEDUP_PRUNE_DDL: &str = "DELETE FROM notifications
+     WHERE dismissed_at IS NULL
+       AND kind NOT IN ('apply_success', 'apply_failure', 'apply_cancelled')
+       AND rowid NOT IN (
+         SELECT MAX(rowid) FROM notifications
+         WHERE dismissed_at IS NULL
+           AND kind NOT IN ('apply_success', 'apply_failure', 'apply_cancelled')
+         GROUP BY kind, title
+       );";
+
 #[derive(Debug, thiserror::Error)]
 pub enum NotificationsError {
     #[error("io: {0}")]
@@ -48,6 +63,13 @@ impl NotificationKind {
         }
     }
 
+    pub fn is_dedup_exempt(self) -> bool {
+        matches!(
+            self,
+            Self::ApplySuccess | Self::ApplyFailure | Self::ApplyCancelled
+        )
+    }
+
     fn parse(value: &str) -> Result<Self, rusqlite::Error> {
         match value {
             "apply_success" => Ok(Self::ApplySuccess),
@@ -80,6 +102,8 @@ pub struct NotificationEntry {
     pub error_class: Option<String>,
     #[serde(default)]
     pub link: Option<String>,
+    #[serde(default)]
+    pub vendor: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -120,22 +144,26 @@ impl NotificationsStore {
                 apply_id      TEXT,
                 game_id       TEXT,
                 error_class   TEXT,
-                link          TEXT
+                link          TEXT,
+                vendor        TEXT
             );
             CREATE INDEX IF NOT EXISTS idx_notif_created ON notifications(created_at DESC);
             CREATE INDEX IF NOT EXISTS idx_notif_unread  ON notifications(read_at) WHERE read_at IS NULL;",
         )?;
         ensure_column(&conn, "link")?;
+        ensure_column(&conn, "vendor")?;
+        conn.execute_batch(DEDUP_PRUNE_DDL)?;
+        conn.execute_batch(DEDUP_INDEX_DDL)?;
         Ok(())
     }
 
-    pub fn insert(&self, entry: &NotificationEntry) -> Result<usize, NotificationsError> {
+    pub fn insert(&self, entry: &NotificationEntry) -> Result<bool, NotificationsError> {
         let conn = self.conn()?;
-        conn.execute(
-            "INSERT INTO notifications
+        let inserted = conn.execute(
+            "INSERT OR IGNORE INTO notifications
                 (id, kind, title, body, created_at, read_at, dismissed_at,
-                 apply_id, game_id, error_class, link)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
+                 apply_id, game_id, error_class, link, vendor)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
             rusqlite::params![
                 entry.id,
                 entry.kind.as_str(),
@@ -148,9 +176,14 @@ impl NotificationsStore {
                 entry.game_id,
                 entry.error_class,
                 entry.link,
+                entry.vendor,
             ],
         )?;
-        self.evict_to_cap_with(&conn)
+        if inserted == 0 {
+            return Ok(false);
+        }
+        self.evict_to_cap_with(&conn)?;
+        Ok(true)
     }
 
     fn evict_to_cap_with(&self, conn: &rusqlite::Connection) -> Result<usize, NotificationsError> {
@@ -181,13 +214,13 @@ impl NotificationsStore {
         let limit = filter.limit.unwrap_or(DEFAULT_LIST_LIMIT) as i64;
         let sql = if include_dismissed {
             "SELECT id, kind, title, body, created_at, read_at, dismissed_at,
-                    apply_id, game_id, error_class, link
+                    apply_id, game_id, error_class, link, vendor
              FROM notifications
              ORDER BY created_at DESC
              LIMIT ?1"
         } else {
             "SELECT id, kind, title, body, created_at, read_at, dismissed_at,
-                    apply_id, game_id, error_class, link
+                    apply_id, game_id, error_class, link, vendor
              FROM notifications
              WHERE dismissed_at IS NULL
              ORDER BY created_at DESC
@@ -288,6 +321,7 @@ fn row_to_entry(row: &rusqlite::Row<'_>) -> Result<NotificationEntry, rusqlite::
         game_id: row.get(8)?,
         error_class: row.get(9)?,
         link: row.get(10)?,
+        vendor: row.get(11)?,
     })
 }
 
@@ -297,7 +331,17 @@ fn parse_iso(value: &str) -> Result<chrono::DateTime<chrono::Utc>, rusqlite::Err
         .map_err(|_| rusqlite::Error::InvalidQuery)
 }
 
+fn is_safe_identifier(value: &str) -> bool {
+    !value.is_empty()
+        && value
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'_')
+}
+
 fn ensure_column(conn: &rusqlite::Connection, column: &str) -> Result<(), NotificationsError> {
+    if !is_safe_identifier(column) {
+        return Err(NotificationsError::Sqlite(rusqlite::Error::InvalidQuery));
+    }
     let mut stmt = conn.prepare("PRAGMA table_info(notifications)")?;
     let existing: Vec<String> = stmt
         .query_map([], |row| row.get::<_, String>(1))?
@@ -335,6 +379,7 @@ mod tests {
             game_id: Some(format!("steam-{title}")),
             error_class: None,
             link: None,
+            vendor: None,
         }
     }
 
@@ -437,6 +482,101 @@ mod tests {
             listed[0].link.as_deref(),
             Some("https://github.com/xt0n1-t3ch/DLSSync/releases/tag/v1.5.0")
         );
+    }
+
+    #[test]
+    fn insert_and_list_preserves_vendor() {
+        let dir = tempdir().unwrap();
+        let store = fresh_store(&dir);
+        let mut e = make_entry(NotificationKind::ApplySuccess, "cyberpunk");
+        e.vendor = Some("nvidia".into());
+        store.insert(&e).unwrap();
+        let listed = store.list(&ListFilter::default()).unwrap();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].vendor.as_deref(), Some("nvidia"));
+    }
+
+    #[test]
+    fn legacy_db_with_duplicate_rows_prunes_then_builds_dedup_index() {
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("Cache").join("notifications.db");
+        std::fs::create_dir_all(db_path.parent().unwrap()).unwrap();
+        let legacy = rusqlite::Connection::open(&db_path).unwrap();
+        legacy
+            .execute_batch(
+                "CREATE TABLE notifications (
+                    id TEXT PRIMARY KEY, kind TEXT NOT NULL, title TEXT NOT NULL, body TEXT,
+                    created_at TEXT NOT NULL, read_at TEXT, dismissed_at TEXT,
+                    apply_id TEXT, game_id TEXT, error_class TEXT, link TEXT, vendor TEXT
+                );",
+            )
+            .unwrap();
+        let now = chrono::Utc::now();
+        for i in 0..3 {
+            legacy
+                .execute(
+                    "INSERT INTO notifications (id, kind, title, created_at)
+                     VALUES (?1, 'driver_update_available', 'GPU driver 999', ?2)",
+                    rusqlite::params![
+                        format!("dup-{i}"),
+                        (now - chrono::Duration::seconds((3 - i) as i64)).to_rfc3339()
+                    ],
+                )
+                .unwrap();
+        }
+        drop(legacy);
+
+        let store = NotificationsStore::open(db_path).unwrap();
+        let listed = store.list(&ListFilter::default()).unwrap();
+        let dups: Vec<_> = listed
+            .iter()
+            .filter(|e| e.title == "GPU driver 999")
+            .collect();
+        assert_eq!(dups.len(), 1, "pre-existing duplicates pruned to one");
+
+        let again = make_entry(NotificationKind::DriverUpdateAvailable, "GPU driver 999");
+        assert!(
+            !store.insert(&again).unwrap(),
+            "the dedup index must be active after prune (duplicate insert ignored)"
+        );
+    }
+
+    #[test]
+    fn legacy_db_without_vendor_column_migrates_and_reads_none() {
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("Cache").join("notifications.db");
+        std::fs::create_dir_all(db_path.parent().unwrap()).unwrap();
+        let legacy = rusqlite::Connection::open(&db_path).unwrap();
+        legacy
+            .execute_batch(
+                "CREATE TABLE notifications (
+                    id TEXT PRIMARY KEY, kind TEXT NOT NULL, title TEXT NOT NULL, body TEXT,
+                    created_at TEXT NOT NULL, read_at TEXT, dismissed_at TEXT,
+                    apply_id TEXT, game_id TEXT, error_class TEXT, link TEXT
+                );",
+            )
+            .unwrap();
+        legacy
+            .execute(
+                "INSERT INTO notifications (id, kind, title, created_at)
+                 VALUES ('legacy-1', 'apply_success', 'old', ?1)",
+                rusqlite::params![chrono::Utc::now().to_rfc3339()],
+            )
+            .unwrap();
+        drop(legacy);
+
+        let store = NotificationsStore::open(db_path).unwrap();
+        let listed = store.list(&ListFilter::default()).unwrap();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].id, "legacy-1");
+        assert_eq!(listed[0].vendor, None);
+
+        let mut fresh = make_entry(NotificationKind::DriverUpdateAvailable, "post-migration");
+        fresh.vendor = Some("amd".into());
+        store.insert(&fresh).unwrap();
+        let after = store.list(&ListFilter::default()).unwrap();
+        let migrated = after.iter().find(|e| e.id == fresh.id).unwrap();
+        assert_eq!(migrated.vendor.as_deref(), Some("amd"));
     }
 
     #[test]
@@ -695,6 +835,119 @@ mod tests {
         let listed = store.list(&ListFilter::default()).unwrap();
         assert_eq!(listed[0].id, future.id);
         assert_eq!(listed[1].id, present.id);
+    }
+
+    #[test]
+    fn duplicate_non_apply_kind_same_title_is_ignored() {
+        let dir = tempdir().unwrap();
+        let store = fresh_store(&dir);
+        let first = make_entry(NotificationKind::DriverUpdateAvailable, "NVIDIA 561.09");
+        let second = make_entry(NotificationKind::DriverUpdateAvailable, "NVIDIA 561.09");
+        assert!(store.insert(&first).unwrap());
+        assert!(!store.insert(&second).unwrap());
+        let listed = store.list(&ListFilter::default()).unwrap();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].id, first.id);
+    }
+
+    #[test]
+    fn duplicate_dll_digest_same_title_is_ignored() {
+        let dir = tempdir().unwrap();
+        let store = fresh_store(&dir);
+        let a = make_entry(NotificationKind::DllUpdatesAvailable, "3 updates ready");
+        let b = make_entry(NotificationKind::DllUpdatesAvailable, "3 updates ready");
+        assert!(store.insert(&a).unwrap());
+        assert!(!store.insert(&b).unwrap());
+        assert_eq!(store.total_count().unwrap(), 1);
+    }
+
+    #[test]
+    fn apply_kinds_bypass_dedup_and_always_insert() {
+        let dir = tempdir().unwrap();
+        let store = fresh_store(&dir);
+        for kind in [
+            NotificationKind::ApplySuccess,
+            NotificationKind::ApplyFailure,
+            NotificationKind::ApplyCancelled,
+        ] {
+            let first = make_entry(kind, "Cyberpunk 2077");
+            let second = make_entry(kind, "Cyberpunk 2077");
+            assert!(store.insert(&first).unwrap());
+            assert!(
+                store.insert(&second).unwrap(),
+                "apply kind {kind:?} must not be deduped"
+            );
+        }
+        assert_eq!(store.total_count().unwrap(), 6);
+    }
+
+    #[test]
+    fn dedup_reinserts_after_dismiss_clears_partial_index() {
+        let dir = tempdir().unwrap();
+        let store = fresh_store(&dir);
+        let first = make_entry(NotificationKind::DriverUpdateAvailable, "NVIDIA 561.09");
+        assert!(store.insert(&first).unwrap());
+        store.dismiss(&first.id).unwrap();
+        let second = make_entry(NotificationKind::DriverUpdateAvailable, "NVIDIA 561.09");
+        assert!(
+            store.insert(&second).unwrap(),
+            "after dismiss the partial unique index no longer covers the row"
+        );
+        let with_dismissed = store
+            .list(&ListFilter {
+                include_dismissed: Some(true),
+                limit: None,
+            })
+            .unwrap();
+        assert_eq!(with_dismissed.len(), 2);
+    }
+
+    #[test]
+    fn dedup_distinguishes_by_kind_and_title() {
+        let dir = tempdir().unwrap();
+        let store = fresh_store(&dir);
+        assert!(store
+            .insert(&make_entry(NotificationKind::DriverUpdateAvailable, "A"))
+            .unwrap());
+        assert!(store
+            .insert(&make_entry(NotificationKind::DriverUpdateAvailable, "B"))
+            .unwrap());
+        assert!(store
+            .insert(&make_entry(NotificationKind::CatalogUpdateAvailable, "A"))
+            .unwrap());
+        assert_eq!(store.total_count().unwrap(), 3);
+    }
+
+    #[test]
+    fn ensure_column_rejects_unsafe_identifier() {
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("Cache").join("notifications.db");
+        std::fs::create_dir_all(db_path.parent().unwrap()).unwrap();
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.execute_batch("CREATE TABLE notifications (id TEXT PRIMARY KEY);")
+            .unwrap();
+        let res = ensure_column(&conn, "evil TEXT; DROP TABLE notifications; --");
+        assert!(matches!(
+            res,
+            Err(NotificationsError::Sqlite(rusqlite::Error::InvalidQuery))
+        ));
+        let still_there: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE name = 'notifications'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(still_there, 1);
+    }
+
+    #[test]
+    fn ensure_column_accepts_safe_identifier() {
+        let dir = tempdir().unwrap();
+        let store = fresh_store(&dir);
+        let conn = store.conn().unwrap();
+        assert!(ensure_column(&conn, "extra_meta").is_ok());
+        assert!(ensure_column(&conn, "extra_meta").is_ok());
     }
 
     #[test]

--- a/crates/pe-version/Cargo.toml
+++ b/crates/pe-version/Cargo.toml
@@ -9,6 +9,7 @@ pelite.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 thiserror.workspace = true
+tracing.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { workspace = true }

--- a/crates/pe-version/src/authenticode.rs
+++ b/crates/pe-version/src/authenticode.rs
@@ -8,6 +8,12 @@ pub struct AuthenticodeInfo {
     pub subject_dn: Option<String>,
     pub issuer_dn: Option<String>,
     pub status: String,
+    /// `true` when whole-chain revocation checking could not reach the CRL/OCSP
+    /// responders and trust was decided with revocation checking bypassed. The
+    /// signer cert may have been revoked without us being able to observe it, so
+    /// callers should treat `trusted` more cautiously when this is set.
+    #[serde(default)]
+    pub revocation_bypassed: bool,
 }
 
 #[cfg(windows)]
@@ -18,6 +24,7 @@ pub fn read_authenticode(path: &Path) -> Option<AuthenticodeInfo> {
         subject_dn: None,
         issuer_dn: None,
         status,
+        revocation_bypassed: false,
     }))
 }
 
@@ -38,16 +45,30 @@ mod win {
 
     const ENCODING: u32 = X509_ASN_ENCODING | PKCS_7_ASN_ENCODING;
 
-    /// Cryptographically verify the file's embedded Authenticode signature with
-    /// `WinVerifyTrust` (`WINTRUST_ACTION_GENERIC_VERIFY_V2`): the signed digest
-    /// must match the file and the signer certificate must chain to a trusted
-    /// root. Without this the embedded subject name is forgeable — any binary
-    /// can carry a self-signed cert claiming `CN = NVIDIA Corporation`. Online
-    /// revocation is skipped (`WTD_REVOKE_NONE`) to honor the offline / minimal-
-    /// outbound promise; the digest + chain trust are still enforced.
-    fn verify_trust(wide: &[u16]) -> bool {
+    /// `WinVerifyTrust` return codes (`LONG`) we special-case. `WinVerifyTrust`
+    /// surfaces a revocation-offline condition as `CERT_E_REVOCATION_FAILURE`;
+    /// the lower-level `CRYPT_E_*` codes can also bubble up depending on the
+    /// provider, so all three count as "could not reach the revocation servers".
+    const CERT_E_REVOCATION_FAILURE: i32 = 0x800B_010E_u32 as i32;
+    const CRYPT_E_REVOCATION_OFFLINE: i32 = 0x8009_2013_u32 as i32;
+    const CRYPT_E_NO_REVOCATION_CHECK: i32 = 0x8009_2012_u32 as i32;
+
+    fn is_revocation_offline(status: i32) -> bool {
+        matches!(
+            status,
+            CERT_E_REVOCATION_FAILURE | CRYPT_E_REVOCATION_OFFLINE | CRYPT_E_NO_REVOCATION_CHECK
+        )
+    }
+
+    /// Run `WinVerifyTrust` (`WINTRUST_ACTION_GENERIC_VERIFY_V2`) once with the
+    /// supplied revocation policy and return its raw `LONG` status (0 == trusted).
+    /// The signed digest must match the file and the signer certificate must
+    /// chain to a trusted root. Without this the embedded subject name is
+    /// forgeable — any binary can carry a self-signed cert claiming
+    /// `CN = NVIDIA Corporation`.
+    fn verify_trust_with(wide: &[u16], revocation_checks: u32) -> i32 {
         use windows_sys::Win32::Security::WinTrust::{
-            WinVerifyTrust, WINTRUST_DATA, WINTRUST_FILE_INFO, WTD_CHOICE_FILE, WTD_REVOKE_NONE,
+            WinVerifyTrust, WINTRUST_DATA, WINTRUST_FILE_INFO, WTD_CHOICE_FILE,
             WTD_STATEACTION_CLOSE, WTD_STATEACTION_VERIFY, WTD_UI_NONE,
         };
         // WINTRUST_ACTION_GENERIC_VERIFY_V2 {00AAC56B-CD44-11d0-8CC2-00C04FC295EE}
@@ -64,7 +85,7 @@ mod win {
         let mut data: WINTRUST_DATA = unsafe { std::mem::zeroed() };
         data.cbStruct = size_of::<WINTRUST_DATA>() as u32;
         data.dwUIChoice = WTD_UI_NONE;
-        data.fdwRevocationChecks = WTD_REVOKE_NONE;
+        data.fdwRevocationChecks = revocation_checks;
         data.dwUnionChoice = WTD_CHOICE_FILE;
         data.dwStateAction = WTD_STATEACTION_VERIFY;
         data.Anonymous.pFile = &mut file_info;
@@ -76,7 +97,37 @@ mod win {
         unsafe {
             WinVerifyTrust(null_mut(), &mut action, &mut data as *mut _ as *mut c_void);
         }
-        status == 0
+        status
+    }
+
+    /// Verify the embedded Authenticode signature requiring whole-chain
+    /// revocation checking (`WTD_REVOKE_WHOLECHAIN`) — a signer cert revoked by
+    /// the vendor is rejected. If the revocation responders are unreachable
+    /// (`is_revocation_offline`), fall back to a no-revocation verification
+    /// (`WTD_REVOKE_NONE`, digest + chain trust still enforced) so an offline
+    /// machine is not stranded, and report that the bypass happened. Any other
+    /// failure (revoked cert, bad digest, untrusted chain) is NOT bypassed.
+    /// Returns `(trusted, revocation_bypassed)`.
+    fn verify_trust(wide: &[u16], path: &Path) -> (bool, bool) {
+        use windows_sys::Win32::Security::WinTrust::{WTD_REVOKE_NONE, WTD_REVOKE_WHOLECHAIN};
+
+        let status = verify_trust_with(wide, WTD_REVOKE_WHOLECHAIN);
+        if status == 0 {
+            return (true, false);
+        }
+        if !is_revocation_offline(status) {
+            return (false, false);
+        }
+        let fallback = verify_trust_with(wide, WTD_REVOKE_NONE);
+        let trusted = fallback == 0;
+        tracing::warn!(
+            path = %path.display(),
+            wholechain_status = format_args!("0x{:08X}", status as u32),
+            no_revoke_trusted = trusted,
+            "Authenticode revocation servers unreachable; trust decided with \
+             revocation checking BYPASSED (cert could be revoked without our knowledge)"
+        );
+        (trusted, true)
     }
 
     pub fn read(path: &Path) -> Result<AuthenticodeInfo, String> {
@@ -85,7 +136,7 @@ mod win {
             .encode_wide()
             .chain(std::iter::once(0))
             .collect();
-        let trusted = verify_trust(&wide);
+        let (trusted, revocation_bypassed) = verify_trust(&wide, path);
 
         let mut encoding: u32 = 0;
         let mut content_type: u32 = 0;
@@ -169,11 +220,14 @@ mod win {
                 subject_cn,
                 subject_dn,
                 issuer_dn,
-                status: if trusted {
+                status: if trusted && revocation_bypassed {
+                    "Trusted (revocation check bypassed — offline)".to_string()
+                } else if trusted {
                     "Trusted".to_string()
                 } else {
                     "Signed (digest or chain not trusted)".to_string()
                 },
+                revocation_bypassed,
             })
         })();
 
@@ -224,6 +278,26 @@ mod win {
             0x80092004 => "CRYPT_E_NOT_FOUND",
             0x80092005 => "CRYPT_E_NO_KEY_PROPERTY",
             _ => "Win32 error",
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn revocation_offline_classifies_known_offline_codes() {
+            assert!(is_revocation_offline(CERT_E_REVOCATION_FAILURE));
+            assert!(is_revocation_offline(CRYPT_E_REVOCATION_OFFLINE));
+            assert!(is_revocation_offline(CRYPT_E_NO_REVOCATION_CHECK));
+        }
+
+        #[test]
+        fn revocation_offline_rejects_revoked_and_untrusted() {
+            assert!(!is_revocation_offline(0x800B_0111_u32 as i32));
+            assert!(!is_revocation_offline(0x8009_6010_u32 as i32));
+            assert!(!is_revocation_offline(0x800B_0109_u32 as i32));
+            assert!(!is_revocation_offline(0));
         }
     }
 }
@@ -281,6 +355,7 @@ mod tests {
             subject_dn: None,
             issuer_dn: None,
             status: "Signed".into(),
+            revocation_bypassed: false,
         };
         assert!(enforce_subject(&info, "nvidia").is_ok());
         assert!(enforce_subject(&info, "amd").is_err());
@@ -294,6 +369,7 @@ mod tests {
             subject_dn: None,
             issuer_dn: None,
             status: "NotSigned".into(),
+            revocation_bypassed: false,
         };
         assert!(enforce_subject(&info, "nvidia").is_err());
     }
@@ -306,6 +382,7 @@ mod tests {
             subject_dn: None,
             issuer_dn: None,
             status: "Signed".into(),
+            revocation_bypassed: false,
         };
         assert!(enforce_subject(&info, "nvidia").is_ok());
     }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dlssync-frontend",
   "private": true,
-  "version": "1.6.4",
+  "version": "1.6.5",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -20,13 +20,13 @@
     "@testing-library/svelte": "^5.3.1",
     "@testing-library/user-event": "^14.6.1",
     "@tsconfig/svelte": "^5.0.0",
-    "@vitest/coverage-v8": "^3",
+    "@vitest/coverage-v8": "^4.1.0",
     "happy-dom": "^20.9.0",
     "svelte": "^5.0.0",
     "svelte-check": "^4.0.0",
     "typescript": "^5.7.0",
     "vite": "^6.0.0",
-    "vitest": "^3.2.4"
+    "vitest": "^4.1.0"
   },
   "dependencies": {
     "@tauri-apps/api": "^2.0.0",

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -33,6 +33,7 @@
   } from "./lib/stores";
   import { activeArt, clearActiveArt } from "./lib/artContext";
   import { installApplyEventListeners } from "./lib/applyEvents";
+  import { installBackgroundScanListeners } from "./lib/backgroundScan";
   import {
     installDriverInstallListener,
     installSystemDriverListener,
@@ -77,6 +78,7 @@
     }
     document.documentElement.setAttribute("data-theme", theme);
     void installApplyEventListeners();
+    void installBackgroundScanListeners();
     void installDriverInstallListener();
     void installSystemDriverListener();
     void bootstrapCatalog();

--- a/frontend/src/components/GameDetailDrawer.svelte
+++ b/frontend/src/components/GameDetailDrawer.svelte
@@ -22,7 +22,7 @@
   } from "../lib/stores";
   import { dllRelation, targetVersion, recordUpdatable, isStreamlinePlugin } from "../lib/relation";
   import { addBlacklistEntry, removeBlacklistEntry, findGameExecutable, detectAnticheat, saveSettings, type AppSettings, type DllRecord, type AntiCheatReport } from "../lib/api";
-  import { hasAntiCheat, statusNote, warningMessage, severity } from "../lib/anticheat";
+  import { hasAntiCheat, statusNote, warningMessage, severity, detectedNames } from "../lib/anticheat";
   import DlssOverridePanel from "./DlssOverridePanel.svelte";
   import { dispatchApply, dispatchStreamlineSet, type ApplyTarget } from "../lib/applyController";
   import {
@@ -363,6 +363,26 @@
     return out;
   }
 
+  let acConfirming = $state(false);
+
+  $effect(() => {
+    if (gameId) acConfirming = false;
+  });
+
+  function requestApply(): void {
+    if (selectedCount === 0) return;
+    if (acActive && acSeverity === "danger" && !acConfirming) {
+      acConfirming = true;
+      return;
+    }
+    acConfirming = false;
+    void applySelected();
+  }
+
+  function cancelApplyConfirm(): void {
+    acConfirming = false;
+  }
+
   async function applySelected(): Promise<void> {
     if (!game) return;
     const items = selectedRecords();
@@ -499,6 +519,7 @@
   let acActive = $derived(hasAntiCheat(acReport));
   let acStatus = $derived(acReport ? statusNote(acReport) : null);
   let acSeverity = $derived(acReport ? severity(acReport) : "warning");
+  let acNames = $derived(acReport ? detectedNames(acReport) : "");
   let acLearnUrl = $derived(acReport?.source_url ?? EXTERNAL_URLS.anticheatFaq);
 </script>
 
@@ -935,13 +956,47 @@
             : $t("component.gameDrawer.streamlineSet.label", { count: streamlineSetMembers.length })}
         </button>
       {/if}
+      {#if acActive && selectedCount > 0}
+        <span
+          id="ac-apply-risk-note"
+          class="ac-apply-risk"
+          class:is-warning={acSeverity !== "danger"}
+          class:is-danger={acSeverity === "danger"}
+          role="note"
+          title={acNames ? $t("component.gameDrawer.anticheat.apply.chipTitle", { names: acNames }) : ""}
+        >
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+          <span>{acSeverity === "danger" ? $t("component.gameDrawer.anticheat.apply.chipBan") : $t("component.gameDrawer.anticheat.apply.chipRisk")}</span>
+        </span>
+      {/if}
+      {#if acConfirming}
+        <div class="ac-apply-confirm" role="alertdialog" aria-label={$t("component.gameDrawer.anticheat.apply.confirmAria")}>
+          <p class="ac-confirm-text">
+            {acNames
+              ? $t("component.gameDrawer.anticheat.apply.confirmBody", { names: acNames })
+              : $t("component.gameDrawer.anticheat.apply.confirmBodyGeneric")}
+          </p>
+          <div class="ac-confirm-actions">
+            <button class="btn btn-sm btn-ghost ac-confirm-cancel" onclick={cancelApplyConfirm}>
+              {$t("component.gameDrawer.anticheat.apply.confirmCancel")}
+            </button>
+            <button class="btn btn-sm btn-danger ac-confirm-proceed" onclick={requestApply}>
+              {$t("component.gameDrawer.anticheat.apply.confirmProceed")}
+            </button>
+          </div>
+        </div>
+      {/if}
       <button
         class="btn btn-primary halo is-update foot-apply"
         class:is-active={selectedCount > 0}
+        class:is-ac-danger={acActive && acSeverity === "danger"}
         disabled={selectedCount === 0}
-        onclick={applySelected}
+        aria-describedby={acActive && selectedCount > 0 ? "ac-apply-risk-note" : undefined}
+        onclick={requestApply}
       >
-        {$t("component.gameDrawer.applySelected", { count: selectedCount })}
+        {acConfirming
+          ? $t("component.gameDrawer.anticheat.apply.applyAnyway")
+          : $t("component.gameDrawer.applySelected", { count: selectedCount })}
       </button>
     </footer>
   </div>
@@ -1539,6 +1594,9 @@
     order: 9;
     justify-content: center;
   }
+  .drawer-foot .foot-apply.is-ac-danger {
+    box-shadow: 0 0 0 1px color-mix(in srgb, var(--danger) 55%, transparent);
+  }
   .drawer-foot .foot-streamline {
     flex: 1 1 100%;
     height: 40px;
@@ -1546,6 +1604,64 @@
     justify-content: center;
   }
   .ahead-chip { order: 7; padding: 4px var(--space-3); flex: 0 0 auto; }
+
+  .ac-apply-risk {
+    order: 6;
+    flex: 0 0 auto;
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    padding: 4px var(--space-3);
+    border-radius: var(--radius-full);
+    font-size: var(--fs-2xs);
+    font-weight: 700;
+    letter-spacing: var(--letter-wide);
+    text-transform: uppercase;
+    line-height: 1;
+  }
+  .ac-apply-risk svg { flex-shrink: 0; }
+  .ac-apply-risk.is-warning {
+    color: var(--warning);
+    background: var(--warning-dim);
+    border: 1px solid color-mix(in srgb, var(--warning) 45%, transparent);
+  }
+  .ac-apply-risk.is-danger {
+    color: var(--danger);
+    background: var(--danger-dim);
+    border: 1px solid color-mix(in srgb, var(--danger) 50%, transparent);
+  }
+
+  .ac-apply-confirm {
+    order: 5;
+    flex: 1 1 100%;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-2);
+    padding: var(--space-3) var(--space-4);
+    border-radius: var(--radius-md);
+    background: var(--danger-dim);
+    border: 1px solid var(--danger);
+    color: var(--danger);
+    animation: ac-confirm-in var(--dur-fast) var(--ease);
+  }
+  @keyframes ac-confirm-in {
+    from { opacity: 0; transform: translateY(4px); }
+    to { opacity: 1; transform: translateY(0); }
+  }
+  .ac-confirm-text {
+    flex: 1 1 200px;
+    min-width: 0;
+    font-size: var(--fs-sm);
+    line-height: var(--lh-snug);
+    overflow-wrap: anywhere;
+  }
+  .ac-confirm-actions { display: flex; gap: var(--space-2); flex: 0 0 auto; }
+
+  @media (prefers-reduced-motion: reduce) {
+    .ac-apply-confirm { animation: none; }
+  }
 
   .spinner {
     width: 14px;

--- a/frontend/src/components/NotificationsBell.svelte
+++ b/frontend/src/components/NotificationsBell.svelte
@@ -6,6 +6,7 @@
     markAllRead,
     dismiss,
     refreshNotifications,
+    vendorKeyForNotification,
     type NotificationEntry,
     type NotificationKind,
   } from "../lib/notifications";
@@ -141,15 +142,6 @@
     }
   }
 
-  function vendorKeyForEntry(entry: NotificationEntry): string | null {
-    const s = `${entry.title} ${entry.body ?? ""}`.toLowerCase();
-    if (/nvidia|dlss|reflex|streamline|geforce|\brtx\b|nvngx/.test(s)) return "nvidia";
-    if (/\bamd\b|\bfsr\b|fidelityfx|radeon/.test(s)) return "amd";
-    if (/intel|xess|\barc\b/.test(s)) return "intel";
-    if (/microsoft|directstorage/.test(s)) return "microsoft";
-    return null;
-  }
-
   function tintForKind(kind: NotificationKind): string {
     switch (kind) {
       case "apply_success": return "green";
@@ -180,7 +172,7 @@
         <div class="bell-panel-empty">{$t("component.notif.empty")}</div>
       {:else}
         {#each entries as entry (entry.id)}
-          {@const vendorKey = vendorKeyForEntry(entry)}
+          {@const vendorKey = vendorKeyForNotification(entry)}
           <div
             class="bell-item"
             class:bell-item-unread={entry.read_at == null}

--- a/frontend/src/components/PerformanceToggles.svelte
+++ b/frontend/src/components/PerformanceToggles.svelte
@@ -1,41 +1,20 @@
 <script lang="ts">
   import { onMount } from "svelte";
-  import { get } from "svelte/store";
-  import { showToast } from "../lib/stores";
-  import { t, locale, translate } from "../lib/i18n/index";
-  import { setCloseToTray, getCloseToTray, setEfficiencyMode } from "../lib/api";
+  import { t } from "../lib/i18n/index";
+  import { setEfficiencyMode } from "../lib/api";
   import Sparkles from "@lucide/svelte/icons/sparkles";
-  import Minimize2 from "@lucide/svelte/icons/minimize-2";
-  import Power from "@lucide/svelte/icons/power";
 
-  const AUTOSTART_ARGS = ["--minimized"];
   const PREF_KEYS = {
     efficiencyOnMinimize: "dlssync-pref-efficiency-on-minimize",
-    closeToTray: "dlssync-pref-close-to-tray",
   } as const;
 
-  let closeToTray = $state(true);
   let efficiencyOnMinimize = $state(true);
-  let autostartEnabled = $state(false);
-  let autostartReady = $state(false);
   let efficiencyApplied = $state(false);
 
   onMount(async () => {
     try {
-      closeToTray = await getCloseToTray();
-    } catch {
-      closeToTray = true;
-    }
-    try {
       efficiencyOnMinimize = localStorage.getItem(PREF_KEYS.efficiencyOnMinimize) !== "false";
     } catch {}
-    try {
-      const { isEnabled } = await import("@tauri-apps/plugin-autostart");
-      autostartEnabled = await isEnabled();
-      autostartReady = true;
-    } catch {
-      autostartReady = false;
-    }
     if (efficiencyOnMinimize) {
       await wireEfficiencyHooks();
     }
@@ -84,16 +63,6 @@
     } catch {}
   }
 
-  async function toggleCloseToTray(next: boolean): Promise<void> {
-    closeToTray = next;
-    try {
-      await setCloseToTray(next);
-      try { localStorage.setItem(PREF_KEYS.closeToTray, String(next)); } catch {}
-    } catch (err: unknown) {
-      showToast("danger", translate(get(locale), "component.perf.toast.closeToTrayFailed", { error: String(err) }));
-    }
-  }
-
   async function toggleEfficiency(next: boolean): Promise<void> {
     efficiencyOnMinimize = next;
     try { localStorage.setItem(PREF_KEYS.efficiencyOnMinimize, String(next)); } catch {}
@@ -104,40 +73,9 @@
     }
   }
 
-  async function toggleAutostart(next: boolean): Promise<void> {
-    if (!autostartReady) return;
-    autostartEnabled = next;
-    try {
-      const mod = await import("@tauri-apps/plugin-autostart");
-      if (next) {
-        await mod.enable();
-      } else {
-        await mod.disable();
-      }
-      const verified = await mod.isEnabled();
-      autostartEnabled = verified;
-    } catch (err: unknown) {
-      autostartEnabled = !next;
-      showToast("danger", translate(get(locale), "component.perf.toast.autostartFailed", { error: String(err) }));
-    }
-  }
 </script>
 
 <div class="perf-card">
-  <div class="perf-row">
-    <div class="perf-icon" aria-hidden="true">
-      <Minimize2 size={14} />
-    </div>
-    <div class="perf-meta">
-      <span class="perf-label">{$t("component.perf.closeToTray.label")}</span>
-      <span class="perf-sub">{$t("component.perf.closeToTray.sub")}</span>
-    </div>
-    <label class="toggle">
-      <input type="checkbox" checked={closeToTray} onchange={(e) => toggleCloseToTray((e.target as HTMLInputElement).checked)} />
-      <span class="toggle-slider"></span>
-    </label>
-  </div>
-
   <div class="perf-row">
     <div class="perf-icon" aria-hidden="true">
       <Sparkles size={14} />
@@ -151,23 +89,6 @@
     </div>
     <label class="toggle">
       <input type="checkbox" checked={efficiencyOnMinimize} onchange={(e) => toggleEfficiency((e.target as HTMLInputElement).checked)} />
-      <span class="toggle-slider"></span>
-    </label>
-  </div>
-
-  <div class="perf-row">
-    <div class="perf-icon" aria-hidden="true">
-      <Power size={14} />
-    </div>
-    <div class="perf-meta">
-      <span class="perf-label">
-        {$t("component.perf.autostart.label")}
-        {#if !autostartReady}<span class="chip chip-neutral small-pill">{$t("component.perf.autostart.unavailable")}</span>{/if}
-      </span>
-      <span class="perf-sub">{$t("component.perf.autostart.sub")} <span class="mono">{AUTOSTART_ARGS.join(" ")}</span>.</span>
-    </div>
-    <label class="toggle">
-      <input type="checkbox" checked={autostartEnabled} disabled={!autostartReady} onchange={(e) => toggleAutostart((e.target as HTMLInputElement).checked)} />
       <span class="toggle-slider"></span>
     </label>
   </div>
@@ -187,7 +108,6 @@
     align-items: center;
     padding: 14px 0;
   }
-  .perf-row + .perf-row { border-top: 1px solid var(--border); }
   .perf-icon {
     width: 32px;
     height: 32px;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -313,6 +313,32 @@ export interface NetworkConfig {
   chunk_timeout_secs: number;
 }
 
+/** Background-scan daemon settings. Mirrors the Rust `BackgroundConfig`
+ *  (commands/settings.rs) field-for-field in snake_case; every field is
+ *  `serde(default)` on the Rust side so legacy settings.json migrates cleanly. */
+export interface BackgroundConfig {
+  enabled: boolean;
+  /** Re-scan cadence; the scheduler clamps to 1..=168 when it reads it. */
+  interval_hours: number;
+  close_to_tray: boolean;
+  run_at_startup: boolean;
+  notify_os_toast: boolean;
+  auto_apply: boolean;
+}
+
+export const BACKGROUND_INTERVAL_MIN_HOURS = 1;
+export const BACKGROUND_INTERVAL_MAX_HOURS = 168;
+export const BACKGROUND_INTERVAL_DEFAULT_HOURS = 24;
+
+export const DEFAULT_BACKGROUND_CONFIG: BackgroundConfig = {
+  enabled: false,
+  interval_hours: BACKGROUND_INTERVAL_DEFAULT_HOURS,
+  close_to_tray: false,
+  run_at_startup: false,
+  notify_os_toast: true,
+  auto_apply: false,
+};
+
 export interface AppSettings {
   launcher_overrides: LauncherOverrides;
   update_prefs: UpdatePreferences;
@@ -325,6 +351,7 @@ export interface AppSettings {
   game_preferences: Record<string, GamePreference>;
   advanced: AdvancedConfig;
   network: NetworkConfig;
+  background: BackgroundConfig;
 }
 
 export interface ApplyRequest {
@@ -429,6 +456,11 @@ export const DOWNLOAD_PROGRESS_EVENT = "download_progress";
 export const APPLY_INFLIGHT_EVENT = "apply_inflight";
 export const TRAY_CHECK_UPDATE_EVENT = "tray://check-update";
 export const TRAY_SHOW_PROGRESS_EVENT = "tray://show-progress";
+
+/** Backend -> frontend: the background scheduler fired a scan tick. */
+export const BACKGROUND_SCAN_TICK_EVENT = "background:scan-tick";
+/** Backend -> frontend (tray "Apply all updates"): run the Apply-All flow. */
+export const BACKGROUND_APPLY_ALL_EVENT = "background:apply-all";
 
 export const DEFAULT_LAUNCHERS: LauncherKind[] = [
   "steam",
@@ -831,14 +863,6 @@ export async function buildIssueReport(context?: string): Promise<IssueReport> {
   return invoke("build_issue_report", { context });
 }
 
-export async function setCloseToTray(enable: boolean): Promise<void> {
-  return invoke("set_close_to_tray", { enable });
-}
-
-export async function getCloseToTray(): Promise<boolean> {
-  return invoke("get_close_to_tray");
-}
-
 export async function setEfficiencyMode(enable: boolean): Promise<void> {
   return invoke("set_efficiency_mode", { enable });
 }
@@ -849,4 +873,10 @@ export async function hideMainWindow(): Promise<void> {
 
 export async function showMainWindow(): Promise<void> {
   return invoke("show_main_window");
+}
+
+/** Set the tray tooltip/badge to the count of games with pending updates.
+ *  0 reverts the tray to its idle tooltip. */
+export async function traySetPending(count: number): Promise<void> {
+  return invoke("tray_set_pending", { count });
 }

--- a/frontend/src/lib/applyEvents.ts
+++ b/frontend/src/lib/applyEvents.ts
@@ -10,6 +10,7 @@ import {
   type InflightSnapshot,
 } from "./api";
 import { translate, locale } from "./i18n/index";
+import { vendorForFamily } from "./ux";
 import { activeApplies, downloadProgressByGroup, inflightCount, type ApplyTracker } from "./stores";
 import {
   installNotificationsListener,
@@ -63,6 +64,7 @@ function buildTerminalEntry(
     game_id: tracker.game_id,
     error_class: p.error_class ?? null,
     link: null,
+    vendor: family ? vendorForFamily(family) : null,
   };
 }
 

--- a/frontend/src/lib/backgroundScan.ts
+++ b/frontend/src/lib/backgroundScan.ts
@@ -1,0 +1,209 @@
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import { get } from "svelte/store";
+import {
+  BACKGROUND_SCAN_TICK_EVENT,
+  BACKGROUND_APPLY_ALL_EVENT,
+  detectAnticheat,
+  traySetPending,
+  type DetectedGame,
+} from "./api";
+import {
+  scanGames as scanGamesStore,
+  loadCatalog as loadCatalogStore,
+  scanInProgress,
+  inflightCount,
+  pendingDllUpdateDigest,
+  outdatedDllItems,
+  emitDllUpdatesDigest,
+  backgroundConfig,
+  triggerApplyAllOutdated,
+  applyModalOpen,
+  showToast,
+  type OutdatedDllItem,
+} from "./stores";
+import { dispatchApply, buildTargetFromRecord, type ApplyTarget } from "./applyController";
+import { hasAntiCheat } from "./anticheat";
+import { translate, locale } from "./i18n/index";
+
+/** Injection seam so the tick/apply-all handlers can be unit-tested without the
+ *  Tauri runtime. The defaults wire the real store/API functions. */
+export interface BackgroundDeps {
+  isScanning(): boolean;
+  isApplyInflight(): boolean;
+  scanGames(): Promise<void>;
+  loadCatalog(): Promise<void>;
+  emitDigest(): void;
+  pendingDigest(): { total: number; games: number };
+  outdatedItems(): OutdatedDllItem[];
+  config(): ReturnType<typeof backgroundConfig>;
+  setTrayPending(count: number): Promise<void>;
+  notifyToast(title: string, body: string): Promise<boolean>;
+  autoApply(items: OutdatedDllItem[]): Promise<void>;
+  triggerApplyAll(): void;
+}
+
+let toastPermissionResolved = false;
+let toastPermissionGranted = false;
+
+/** Request OS-notification permission once per session. Returns whether toasts
+ *  may be shown. A denial (or a missing plugin) is cached so we fall back to the
+ *  in-app digest without re-prompting. */
+async function ensureToastPermission(): Promise<boolean> {
+  if (toastPermissionResolved) return toastPermissionGranted;
+  toastPermissionResolved = true;
+  try {
+    const { isPermissionGranted, requestPermission } = await import(
+      "@tauri-apps/plugin-notification"
+    );
+    let granted = await isPermissionGranted();
+    if (!granted) {
+      granted = (await requestPermission()) === "granted";
+    }
+    toastPermissionGranted = granted;
+  } catch (err: unknown) {
+    console.warn("[dlssync] notification permission unavailable:", err);
+    toastPermissionGranted = false;
+  }
+  return toastPermissionGranted;
+}
+
+/** Fire a native Windows toast. Returns false (without throwing) when permission
+ *  was denied or the plugin is unavailable, so the caller can fall back. */
+async function fireNativeToast(title: string, body: string): Promise<boolean> {
+  if (!(await ensureToastPermission())) return false;
+  try {
+    const { sendNotification } = await import("@tauri-apps/plugin-notification");
+    sendNotification({ title, body });
+    return true;
+  } catch (err: unknown) {
+    console.warn("[dlssync] native toast failed:", err);
+    return false;
+  }
+}
+
+/** Default deps: drive the live stores/APIs. */
+function liveDeps(): BackgroundDeps {
+  return {
+    isScanning: () => get(scanInProgress),
+    isApplyInflight: () => get(inflightCount) > 0,
+    scanGames: () => scanGamesStore(),
+    loadCatalog: () => loadCatalogStore(),
+    emitDigest: () => emitDllUpdatesDigest(),
+    pendingDigest: () => pendingDllUpdateDigest(),
+    outdatedItems: () => outdatedDllItems(),
+    config: () => backgroundConfig(),
+    setTrayPending: (count) => traySetPending(count),
+    notifyToast: (title, body) => fireNativeToast(title, body),
+    autoApply: (items) => autoApplyExcludingAntiCheat(items),
+    triggerApplyAll: () => triggerApplyAllOutdated(),
+  };
+}
+
+/** Auto-apply every outdated DLL EXCEPT those in anti-cheat-flagged games. The
+ *  per-game anti-cheat probe reuses the exact API the game drawer uses; a probe
+ *  failure is treated as "not flagged" (the backend apply guards remain the hard
+ *  safety net). Backups/pins/Enabler/Streamline coherence are enforced by the
+ *  apply path. */
+export async function autoApplyExcludingAntiCheat(items: OutdatedDllItem[]): Promise<void> {
+  if (items.length === 0) return;
+  const byGame = new Map<string, DetectedGame>();
+  for (const it of items) byGame.set(it.game.id, it.game);
+  const blockedGameIds = new Set<string>();
+  for (const game of byGame.values()) {
+    try {
+      const report = await detectAnticheat(game.install_dir, game.app_id, game.name);
+      if (hasAntiCheat(report)) blockedGameIds.add(game.id);
+    } catch {
+    }
+  }
+  const allowed = items.filter((it) => !blockedGameIds.has(it.game.id));
+  if (allowed.length === 0) {
+    if (blockedGameIds.size > 0) {
+      showToast("info", translate(get(locale), "view.library.toast.autoApplyAllSkipped"));
+    }
+    return;
+  }
+  if (blockedGameIds.size > 0) {
+    showToast(
+      "info",
+      translate(get(locale), "view.library.toast.autoApplySkippedAnticheat", {
+        count: blockedGameIds.size,
+      }),
+    );
+  }
+  const targets: ApplyTarget[] = allowed.map((it) =>
+    buildTargetFromRecord(it.game, it.record, it.target),
+  );
+  await dispatchApply(targets, { showModal: () => applyModalOpen.set(true) });
+}
+
+/** Handle one background scan tick. Skips entirely when a scan is already running
+ *  or an apply is inflight (no concurrent scan/apply). Otherwise runs the proven
+ *  scan + catalog refresh flow (which emits the in-app digest), updates the tray
+ *  count, fires an OS toast when there are pending updates (falling back to the
+ *  in-app digest if permission is denied), and optionally auto-applies. */
+export async function handleScanTick(deps: BackgroundDeps = liveDeps()): Promise<void> {
+  const cfg = deps.config();
+  if (!cfg.enabled) return;
+  if (deps.isScanning() || deps.isApplyInflight()) return;
+
+  await deps.scanGames();
+  await deps.loadCatalog();
+
+  const { total, games } = deps.pendingDigest();
+  await deps.setTrayPending(games).catch((err) => {
+    console.warn("[dlssync] tray_set_pending failed:", err);
+  });
+
+  if (total <= 0) return;
+
+  const loc = get(locale);
+  const gamesPhrase = translate(loc, "notif.dll.digestGames", { count: games });
+  const title = translate(loc, "notif.background.toastTitle", { count: total });
+  const body = translate(loc, "notif.background.toastBody", { games: gamesPhrase });
+
+  if (cfg.notify_os_toast) {
+    const shown = await deps.notifyToast(title, body);
+    if (!shown) deps.emitDigest();
+  } else {
+    deps.emitDigest();
+  }
+
+  if (cfg.auto_apply) {
+    await deps.autoApply(deps.outdatedItems());
+  }
+}
+
+/** Handle the tray "Apply all updates" action — runs the same Apply-All flow the
+ *  Library header button uses (guard-gated by the apply path). */
+export function handleApplyAll(deps: BackgroundDeps = liveDeps()): void {
+  deps.triggerApplyAll();
+}
+
+let installed = false;
+let unlisteners: UnlistenFn[] = [];
+
+/** Install the daemon event listeners. Wired alongside the apply listeners in
+ *  App.svelte. Idempotent. */
+export async function installBackgroundScanListeners(): Promise<void> {
+  if (installed) return;
+  installed = true;
+  const u1 = await listen<void>(BACKGROUND_SCAN_TICK_EVENT, () => {
+    void handleScanTick();
+  });
+  const u2 = await listen<void>(BACKGROUND_APPLY_ALL_EVENT, () => {
+    handleApplyAll();
+  });
+  unlisteners = [u1, u2];
+}
+
+export async function uninstallBackgroundScanListeners(): Promise<void> {
+  for (const u of unlisteners) {
+    try {
+      u();
+    } catch {
+    }
+  }
+  unlisteners = [];
+  installed = false;
+}

--- a/frontend/src/lib/i18n/locales/_meta.json
+++ b/frontend/src/lib/i18n/locales/_meta.json
@@ -2690,13 +2690,13 @@
     "where": "frontend/src/views/Settings.svelte"
   },
   "view.settings.general.performance.title": {
-    "en": "Performance & startup",
-    "desc": "Section head — performance & startup",
+    "en": "Performance",
+    "desc": "Section head — performance (efficiency mode only after close-to-tray/autostart moved to Background section)",
     "where": "frontend/src/views/Settings.svelte"
   },
   "view.settings.general.performance.help": {
-    "en": "Footprint controls. With all three enabled, DLSSync sits in the tray with near-zero CPU between scheduled update checks.",
-    "desc": "Section help — performance & startup",
+    "en": "CPU and battery footprint. EcoQoS schedules DLSSync onto efficient cores while minimized, dropping its impact near zero.",
+    "desc": "Section help — performance. Describes only the Efficiency Mode toggle that remains here.",
     "where": "frontend/src/views/Settings.svelte"
   },
   "view.settings.general.updateBehavior.title": {
@@ -4134,6 +4134,51 @@
     "desc": "Tooltip on the anti-cheat Learn more button.",
     "where": "GameDetailDrawer.svelte"
   },
+  "component.gameDrawer.anticheat.apply.chipRisk": {
+    "en": "Anti-cheat",
+    "desc": "Short label on the apply-time risk chip for warning-severity anti-tamper/DRM games (e.g. Denuvo). Shown next to the Apply button.",
+    "where": "GameDetailDrawer.svelte apply footer"
+  },
+  "component.gameDrawer.anticheat.apply.chipBan": {
+    "en": "Ban risk",
+    "desc": "Short label on the apply-time risk chip for danger-severity online anti-cheat games (EAC/BattlEye/VAC). Shown next to the Apply button.",
+    "where": "GameDetailDrawer.svelte apply footer"
+  },
+  "component.gameDrawer.anticheat.apply.chipTitle": {
+    "en": "{names} detected — review before applying",
+    "desc": "Tooltip on the apply-time risk chip. {names} is a comma-joined list of detected anti-cheat / anti-tamper product names and is NOT translated.",
+    "where": "GameDetailDrawer.svelte apply footer"
+  },
+  "component.gameDrawer.anticheat.apply.applyAnyway": {
+    "en": "Apply anyway",
+    "desc": "Label the primary Apply button takes after the user has triggered the danger confirm step.",
+    "where": "GameDetailDrawer.svelte apply footer"
+  },
+  "component.gameDrawer.anticheat.apply.confirmAria": {
+    "en": "Confirm applying to an anti-cheat protected game",
+    "desc": "Accessible label for the inline danger confirmation row (role=alertdialog).",
+    "where": "GameDetailDrawer.svelte apply footer"
+  },
+  "component.gameDrawer.anticheat.apply.confirmBody": {
+    "en": "This game uses {names} — replacing DLLs can trigger a ban. Apply anyway?",
+    "desc": "Inline confirmation prompt shown before applying to a danger-severity anti-cheat game. {names} is the detected product name(s) and is NOT translated.",
+    "where": "GameDetailDrawer.svelte apply footer"
+  },
+  "component.gameDrawer.anticheat.apply.confirmBodyGeneric": {
+    "en": "This game uses anti-cheat — replacing DLLs can trigger a ban. Apply anyway?",
+    "desc": "Fallback confirmation prompt when no specific anti-cheat product name is available.",
+    "where": "GameDetailDrawer.svelte apply footer"
+  },
+  "component.gameDrawer.anticheat.apply.confirmProceed": {
+    "en": "Apply anyway",
+    "desc": "Button in the danger confirmation row that proceeds with the apply.",
+    "where": "GameDetailDrawer.svelte apply footer"
+  },
+  "component.gameDrawer.anticheat.apply.confirmCancel": {
+    "en": "Cancel",
+    "desc": "Button in the danger confirmation row that dismisses the confirm without applying.",
+    "where": "GameDetailDrawer.svelte apply footer"
+  },
   "component.gameDrawer.loading.scanning": {
     "en": "Scanning DLLs",
     "desc": "Loading-state text while the initial scan runs; followed by the folder name.",
@@ -5338,5 +5383,150 @@
     "en": "Starting…",
     "desc": "Transient progress message shown when a driver install begins.",
     "where": "lib/stores.ts startDriverInstall / startSystemDriverInstall"
+  },
+  "notif.background.toastTitle": {
+    "en": "{count} updates ready",
+    "desc": "Native toast title (background daemon), singular. {count} = total pending DLL updates.",
+    "where": "OS notification fired by the background scan tick."
+  },
+  "notif.background.toastBody": {
+    "en": "Across {games} - open DLSSync to apply",
+    "desc": "Native toast body. {games} = an already-pluralised games phrase. Keep DLSSync.",
+    "where": "OS notification fired by the background scan tick."
+  },
+  "view.library.applyAllCount": {
+    "en": "Apply all updates ({count})",
+    "desc": "Library header Apply-All button label, singular. {count} = total outdated DLLs across the library.",
+    "where": "Library header action button."
+  },
+  "view.library.applyAllTitle": {
+    "en": "Apply every detected update across the library",
+    "desc": "Tooltip on the Library header Apply-All button.",
+    "where": "Library header action button."
+  },
+  "view.library.toast.autoApplySkippedAnticheat": {
+    "en": "Auto-apply skipped {count} games with anti-cheat",
+    "desc": "Toast when auto-apply excludes anti-cheat-flagged games, singular. {count} = number of skipped games.",
+    "where": "Background auto-apply flow."
+  },
+  "view.library.toast.autoApplyAllSkipped": {
+    "en": "All pending updates are in anti-cheat games - auto-apply skipped them",
+    "desc": "Toast when every pending update is in an anti-cheat game and auto-apply applied nothing. Translate fully.",
+    "where": "Background auto-apply flow."
+  },
+  "tray.menu.show": {
+    "en": "Show DLSSync",
+    "desc": "Tray menu item: restore + focus the main window. Keep DLSSync.",
+    "where": "System-tray context menu."
+  },
+  "tray.menu.checkNow": {
+    "en": "Check for updates now",
+    "desc": "Tray menu item: trigger an immediate background scan tick. Translate fully.",
+    "where": "System-tray context menu."
+  },
+  "tray.menu.applyAll": {
+    "en": "Apply all updates",
+    "desc": "Tray menu item: run the Apply-All flow. Translate fully.",
+    "where": "System-tray context menu."
+  },
+  "tray.menu.quit": {
+    "en": "Quit",
+    "desc": "Tray menu item: fully exit the app. Translate fully.",
+    "where": "System-tray context menu."
+  },
+  "tray.tooltip.pending": {
+    "en": "DLSSync - {count} games have updates",
+    "desc": "Tray tooltip when games have pending updates, singular. Keep DLSSync. {count} = games with updates.",
+    "where": "System-tray icon tooltip."
+  },
+  "tray.tooltip.idle": {
+    "en": "DLSSync",
+    "desc": "Tray tooltip when nothing is pending - the bare brand. Keep identical in every language.",
+    "where": "System-tray icon tooltip."
+  },
+  "view.settings.general.background.title": {
+    "en": "Background updates",
+    "desc": "Settings section heading for the background-scan daemon. Translate fully.",
+    "where": "Settings > General."
+  },
+  "view.settings.general.background.badge": {
+    "en": "New",
+    "desc": "Small New badge next to the Background updates heading. Translate fully.",
+    "where": "Settings > General."
+  },
+  "view.settings.general.background.help": {
+    "en": "Let DLSSync keep watch in the background and tell you the moment a game has updates ready. Off by default.",
+    "desc": "Help line under the Background updates heading. Keep DLSSync.",
+    "where": "Settings > General."
+  },
+  "view.settings.general.background.enabled.label": {
+    "en": "Enable background scanning",
+    "desc": "Master toggle label for the daemon. Translate fully.",
+    "where": "Settings > General > Background updates."
+  },
+  "view.settings.general.background.enabled.sub": {
+    "en": "Rescan the library and refresh the catalog on a schedule, even when the window is hidden.",
+    "desc": "Sub-line for the daemon master toggle. Translate fully.",
+    "where": "Settings > General > Background updates."
+  },
+  "view.settings.general.background.interval.label": {
+    "en": "Scan every",
+    "desc": "Label for the scan-interval select. Translate fully.",
+    "where": "Settings > General > Background updates."
+  },
+  "view.settings.general.background.interval.sub": {
+    "en": "How often the background scan runs (1 to 168 hours).",
+    "desc": "Sub-line for the scan-interval select. Translate fully.",
+    "where": "Settings > General > Background updates."
+  },
+  "view.settings.general.background.interval.option": {
+    "en": "{count} hours",
+    "desc": "Scan-interval option label, singular. {count} = hours.",
+    "where": "Settings > General > Background updates interval select."
+  },
+  "view.settings.general.background.closeToTray.label": {
+    "en": "Close to tray instead of quitting",
+    "desc": "Daemon close-to-tray toggle label. Translate fully.",
+    "where": "Settings > General > Background updates."
+  },
+  "view.settings.general.background.closeToTray.sub": {
+    "en": "Clicking the window X hides DLSSync to the system tray. Quit from the tray menu to exit fully.",
+    "desc": "Sub-line for the close-to-tray toggle. Scanning-agnostic — useful on its own. Keep DLSSync.",
+    "where": "Settings > General > Background updates."
+  },
+  "view.settings.general.background.runAtStartup.label": {
+    "en": "Start with Windows (minimized to tray)",
+    "desc": "Run-at-startup toggle label. Keep Windows.",
+    "where": "Settings > General > Background updates."
+  },
+  "view.settings.general.background.runAtStartup.sub": {
+    "en": "Launch DLSSync hidden in the tray when Windows starts — no visible window until you open it.",
+    "desc": "Sub-line for the run-at-startup toggle. Scanning-agnostic — useful on its own. Keep DLSSync/Windows.",
+    "where": "Settings > General > Background updates."
+  },
+  "view.settings.general.background.notifyToast.label": {
+    "en": "Windows notification when updates are ready",
+    "desc": "Daemon OS-toast toggle label. Keep Windows.",
+    "where": "Settings > General > Background updates."
+  },
+  "view.settings.general.background.notifyToast.sub": {
+    "en": "Show a native Windows toast after a background scan finds pending updates. Falls back to the in-app bell if notifications are blocked.",
+    "desc": "Sub-line for the OS-toast toggle. Keep Windows.",
+    "where": "Settings > General > Background updates."
+  },
+  "view.settings.general.background.autoApply.label": {
+    "en": "Auto-apply updates",
+    "desc": "Daemon auto-apply toggle label. Translate fully.",
+    "where": "Settings > General > Background updates."
+  },
+  "view.settings.general.background.autoApply.badge": {
+    "en": "Advanced",
+    "desc": "Small badge marking auto-apply as an advanced opt-in. Translate fully.",
+    "where": "Settings > General > Background updates."
+  },
+  "view.settings.general.background.autoApply.sub": {
+    "en": "After each background scan, install every eligible update automatically. Anti-cheat games are always skipped and a backup is always made first.",
+    "desc": "Sub-line for the auto-apply toggle. Translate fully.",
+    "where": "Settings > General > Background updates."
   }
 }

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -121,8 +121,14 @@
         "rescanning": "Rescanning {name}",
         "folderAlreadyAdded": "Folder already added",
         "folderAdded": "Added {path}",
-        "folderPickerFailed": "Folder picker: {error}"
-      }
+        "folderPickerFailed": "Folder picker: {error}",
+        "autoApplySkippedAnticheat_one": "Auto-apply skipped {count} game with anti-cheat",
+        "autoApplySkippedAnticheat_other": "Auto-apply skipped {count} games with anti-cheat",
+        "autoApplyAllSkipped": "All pending updates are in anti-cheat games - auto-apply skipped them"
+      },
+      "applyAllCount_one": "Apply {count} update",
+      "applyAllCount_other": "Apply all updates ({count})",
+      "applyAllTitle": "Apply every detected update across the library"
     },
     "catalog": {
       "title": "Catalog",
@@ -424,8 +430,8 @@
           "sub": "Applies instantly across the whole app."
         },
         "performance": {
-          "title": "Performance & startup",
-          "help": "Footprint controls. With all three enabled, DLSSync sits in the tray with near-zero CPU between scheduled update checks."
+          "title": "Performance",
+          "help": "CPU and battery footprint. EcoQoS schedules DLSSync onto efficient cores while minimized, dropping its impact near zero."
         },
         "updateBehavior": {
           "title": "Update behavior",
@@ -436,6 +442,38 @@
           "help": "A small card that occasionally invites you to star, endorse or share DLSSync after a successful update. It never blocks anything.",
           "label": "Show the support card",
           "sub": "A gentle nudge bottom-left after an update lands. Turn it off here any time, or re-enable it later."
+        },
+        "background": {
+          "title": "Background updates",
+          "badge": "New",
+          "help": "Let DLSSync keep watch in the background and tell you the moment a game has updates ready. Off by default.",
+          "enabled": {
+            "label": "Enable background scanning",
+            "sub": "Rescan the library and refresh the catalog on a schedule, even when the window is hidden."
+          },
+          "interval": {
+            "label": "Scan every",
+            "sub": "How often the background scan runs (1 to 168 hours).",
+            "option_one": "{count} hour",
+            "option_other": "{count} hours"
+          },
+          "closeToTray": {
+            "label": "Close to tray instead of quitting",
+            "sub": "Clicking the window X hides DLSSync to the system tray. Quit from the tray menu to exit fully."
+          },
+          "runAtStartup": {
+            "label": "Start with Windows (minimized to tray)",
+            "sub": "Launch DLSSync hidden in the tray when Windows starts — no visible window until you open it."
+          },
+          "notifyToast": {
+            "label": "Windows notification when updates are ready",
+            "sub": "Show a native Windows toast after a background scan finds pending updates. Falls back to the in-app bell if notifications are blocked."
+          },
+          "autoApply": {
+            "label": "Auto-apply updates",
+            "badge": "Advanced",
+            "sub": "After each background scan, install every eligible update automatically. Anti-cheat games are always skipped and a backup is always made first."
+          }
         }
       },
       "feature": {
@@ -1373,7 +1411,18 @@
       },
       "anticheat": {
         "learnMore": "Learn more",
-        "learnMoreTitle": "Open the anti-cheat compatibility reference"
+        "learnMoreTitle": "Open the anti-cheat compatibility reference",
+        "apply": {
+          "chipRisk": "Anti-cheat",
+          "chipBan": "Ban risk",
+          "chipTitle": "{names} detected — review before applying",
+          "applyAnyway": "Apply anyway",
+          "confirmAria": "Confirm applying to an anti-cheat protected game",
+          "confirmBody": "This game uses {names} — replacing DLLs can trigger a ban. Apply anyway?",
+          "confirmBodyGeneric": "This game uses anti-cheat — replacing DLLs can trigger a ban. Apply anyway?",
+          "confirmProceed": "Apply anyway",
+          "confirmCancel": "Cancel"
+        }
       },
       "loading": {
         "scanning": "Scanning DLLs",
@@ -1686,6 +1735,11 @@
       "failureTitle": "{gameLabel} update failed",
       "cancelledTitle": "{gameLabel} update cancelled",
       "successBody": "{family} → {version}"
+    },
+    "background": {
+      "toastTitle_one": "{count} update ready",
+      "toastTitle_other": "{count} updates ready",
+      "toastBody": "Across {games} - open DLSSync to apply"
     }
   },
   "anticheat": {
@@ -1695,5 +1749,18 @@
     "tamperRisk": "{names} detected. Swapping a DLL or forcing a DLSS preset override may fail the game's tamper-protection signature check and prevent it from launching. Backups in DLSSync restore the originals instantly if that happens.",
     "drm": "{names} detected. This game's store DRM validates its files; a DLL swap is usually fine but can require a launcher integrity re-check. Backups in DLSSync restore the originals.",
     "linuxStatus": "Linux / Wine compatibility: {status}."
+  },
+  "tray": {
+    "menu": {
+      "show": "Show DLSSync",
+      "checkNow": "Check for updates now",
+      "applyAll": "Apply all updates",
+      "quit": "Quit"
+    },
+    "tooltip": {
+      "pending_one": "DLSSync - {count} game has updates",
+      "pending_other": "DLSSync - {count} games have updates",
+      "idle": "DLSSync"
+    }
   }
 }

--- a/frontend/src/lib/i18n/locales/es.json
+++ b/frontend/src/lib/i18n/locales/es.json
@@ -121,8 +121,14 @@
         "rescanning": "Reescaneando {name}",
         "folderAlreadyAdded": "La carpeta ya está añadida",
         "folderAdded": "Añadida {path}",
-        "folderPickerFailed": "Selector de carpetas: {error}"
-      }
+        "folderPickerFailed": "Selector de carpetas: {error}",
+        "autoApplySkippedAnticheat_one": "La aplicacion automatica omitio {count} juego con anti-cheat",
+        "autoApplySkippedAnticheat_other": "La aplicacion automatica omitio {count} juegos con anti-cheat",
+        "autoApplyAllSkipped": "Todas las actualizaciones pendientes estan en juegos con anti-cheat; la aplicacion automatica las omitio"
+      },
+      "applyAllCount_one": "Aplicar {count} actualizacion",
+      "applyAllCount_other": "Aplicar todas ({count})",
+      "applyAllTitle": "Aplica todas las actualizaciones detectadas en la biblioteca"
     },
     "catalog": {
       "title": "Catálogo",
@@ -424,8 +430,8 @@
           "sub": "Se aplica al instante en toda la aplicación."
         },
         "performance": {
-          "title": "Rendimiento e inicio",
-          "help": "Controles de consumo. Con las tres opciones activadas, DLSSync queda en la bandeja con un uso de CPU casi nulo entre comprobaciones programadas."
+          "title": "Rendimiento",
+          "help": "Consumo de CPU y batería. EcoQoS programa DLSSync en los núcleos eficientes mientras está minimizado, reduciendo su impacto casi a cero."
         },
         "updateBehavior": {
           "title": "Comportamiento de actualización",
@@ -436,6 +442,38 @@
           "help": "Una pequeña tarjeta que de vez en cuando te invita a destacar, recomendar o compartir DLSSync tras una actualización correcta. Nunca bloquea nada.",
           "label": "Mostrar la tarjeta de apoyo",
           "sub": "Un recordatorio discreto abajo a la izquierda cuando se aplica una actualización. Desactívalo aquí cuando quieras, o vuelve a activarlo más tarde."
+        },
+        "background": {
+          "title": "Actualizaciones en segundo plano",
+          "badge": "Nuevo",
+          "help": "Deja que DLSSync vigile en segundo plano y te avise en cuanto un juego tenga actualizaciones listas. Desactivado por defecto.",
+          "enabled": {
+            "label": "Activar el escaneo en segundo plano",
+            "sub": "Vuelve a escanear la biblioteca y actualiza el catalogo de forma programada, incluso con la ventana oculta."
+          },
+          "interval": {
+            "label": "Escanear cada",
+            "sub": "Con que frecuencia se ejecuta el escaneo en segundo plano (de 1 a 168 horas).",
+            "option_one": "{count} hora",
+            "option_other": "{count} horas"
+          },
+          "closeToTray": {
+            "label": "Cerrar a la bandeja en vez de salir",
+            "sub": "Al pulsar la X de la ventana, DLSSync se oculta en la bandeja del sistema. Sal por completo desde el menu de la bandeja."
+          },
+          "runAtStartup": {
+            "label": "Iniciar con Windows (minimizado en la bandeja)",
+            "sub": "Inicia DLSSync oculto en la bandeja al arrancar Windows, sin ventana visible hasta que lo abras."
+          },
+          "notifyToast": {
+            "label": "Notificacion de Windows cuando haya actualizaciones",
+            "sub": "Muestra una notificacion nativa de Windows cuando un escaneo en segundo plano encuentra actualizaciones pendientes. Si estan bloqueadas, recurre a la campana de la app."
+          },
+          "autoApply": {
+            "label": "Aplicar actualizaciones automaticamente",
+            "badge": "Avanzado",
+            "sub": "Tras cada escaneo en segundo plano, instala automaticamente todas las actualizaciones aptas. Los juegos con anti-cheat siempre se omiten y siempre se crea una copia de seguridad antes."
+          }
         }
       },
       "feature": {
@@ -1373,7 +1411,18 @@
       },
       "anticheat": {
         "learnMore": "Más información",
-        "learnMoreTitle": "Abrir la referencia de compatibilidad anti-trampas"
+        "learnMoreTitle": "Abrir la referencia de compatibilidad anti-trampas",
+        "apply": {
+          "chipRisk": "Anti-trampas",
+          "chipBan": "Riesgo de baneo",
+          "chipTitle": "Se detectó {names} — revísalo antes de aplicar",
+          "applyAnyway": "Aplicar de todos modos",
+          "confirmAria": "Confirmar la aplicación en un juego protegido por anti-trampas",
+          "confirmBody": "Este juego usa {names} — reemplazar las DLL puede provocar un baneo. ¿Aplicar de todos modos?",
+          "confirmBodyGeneric": "Este juego usa anti-trampas — reemplazar las DLL puede provocar un baneo. ¿Aplicar de todos modos?",
+          "confirmProceed": "Aplicar de todos modos",
+          "confirmCancel": "Cancelar"
+        }
       },
       "loading": {
         "scanning": "Escaneando DLL",
@@ -1686,6 +1735,11 @@
       "failureTitle": "Error al actualizar {gameLabel}",
       "cancelledTitle": "Actualización de {gameLabel} cancelada",
       "successBody": "{family} → {version}"
+    },
+    "background": {
+      "toastTitle_one": "{count} actualizacion lista",
+      "toastTitle_other": "{count} actualizaciones listas",
+      "toastBody": "En {games} - abre DLSSync para aplicar"
     }
   },
   "anticheat": {
@@ -1695,5 +1749,18 @@
     "tamperRisk": "Se detectó {names}. Intercambiar una DLL o forzar una anulación de preset DLSS puede fallar la verificación de firma de protección anti-manipulación del juego e impedir que inicie. Las copias de seguridad de DLSSync restauran los originales al instante si eso ocurre.",
     "drm": "Se detectó {names}. El DRM de la tienda de este juego valida sus archivos; un intercambio de DLL suele estar bien pero puede requerir una nueva verificación de integridad del lanzador. Las copias de seguridad de DLSSync restauran los originales.",
     "linuxStatus": "Compatibilidad con Linux / Wine: {status}."
+  },
+  "tray": {
+    "menu": {
+      "show": "Mostrar DLSSync",
+      "checkNow": "Buscar actualizaciones ahora",
+      "applyAll": "Aplicar todas las actualizaciones",
+      "quit": "Salir"
+    },
+    "tooltip": {
+      "pending_one": "DLSSync - {count} juego tiene actualizaciones",
+      "pending_other": "DLSSync - {count} juegos tienen actualizaciones",
+      "idle": "DLSSync"
+    }
   }
 }

--- a/frontend/src/lib/notifications.ts
+++ b/frontend/src/lib/notifications.ts
@@ -1,6 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { writable, type Writable } from "svelte/store";
+import { resolveBrandKey } from "./brands";
 
 export const NOTIFICATION_PUSHED_EVENT = "notification:pushed";
 
@@ -21,7 +22,7 @@ export function makeNotificationEntry(
   kind: NotificationKind,
   title: string,
   body: string | null = null,
-  extras?: Partial<Pick<NotificationEntry, "apply_id" | "game_id" | "error_class" | "link">>,
+  extras?: Partial<Pick<NotificationEntry, "apply_id" | "game_id" | "error_class" | "link" | "vendor">>,
 ): NotificationEntry {
   return {
     id: crypto.randomUUID(),
@@ -35,6 +36,7 @@ export function makeNotificationEntry(
     game_id: extras?.game_id ?? null,
     error_class: extras?.error_class ?? null,
     link: extras?.link ?? null,
+    vendor: extras?.vendor ?? null,
   };
 }
 
@@ -50,6 +52,33 @@ export interface NotificationEntry {
   game_id: string | null;
   error_class: string | null;
   link: string | null;
+  vendor: string | null;
+}
+
+const FEATURE_VENDOR_TOKENS: ReadonlyArray<readonly [RegExp, string]> = [
+  [/\bdlss\b|\bstreamline\b|\breflex\b|\bnvngx\b/, "nvidia"],
+  [/\bfsr\b|\bfidelityfx\b/, "amd"],
+  [/\bxess\b|\bxell\b/, "intel"],
+  [/\bdirectstorage\b/, "microsoft"],
+];
+
+const NON_VENDOR_KINDS: ReadonlySet<NotificationKind> = new Set([
+  "app_update_available",
+  "scan_failed",
+  "catalog_refresh_failed",
+]);
+
+export function vendorKeyForNotification(entry: NotificationEntry): string | null {
+  if (entry.vendor) return entry.vendor;
+  if (NON_VENDOR_KINDS.has(entry.kind)) return null;
+  const text = `${entry.title} ${entry.body ?? ""}`;
+  const byName = resolveBrandKey(text);
+  if (byName) return byName;
+  const lowered = text.toLowerCase();
+  for (const [matcher, key] of FEATURE_VENDOR_TOKENS) {
+    if (matcher.test(lowered)) return key;
+  }
+  return null;
 }
 
 export interface ListFilter {

--- a/frontend/src/lib/stores.ts
+++ b/frontend/src/lib/stores.ts
@@ -31,9 +31,12 @@ import {
   type SystemDeviceGroup,
   type SystemDriverUpdate,
   type SystemDriverProgress,
+  type BackgroundConfig,
+  DEFAULT_BACKGROUND_CONFIG,
 } from "./api";
 import { sortDriverReports, hasDriverUpdate, driverPageUrl } from "./drivers";
 import { vendorLabel, familyLabel, familyShort, type UpdateStatus } from "./labels";
+import { vendorForFamily } from "./ux";
 import {
   buildShasByVendor,
   gameStatusFromRecords,
@@ -92,6 +95,7 @@ function emitCatalogUpdateNotifications(
       "catalog_update_available",
       translate(loc, "notif.catalog.available", { label, version: d.newVersion }),
       translate(loc, "notif.catalog.wasVersion", { version: d.oldVersion }),
+      { vendor: vendorForFamily(d.family) },
     );
     pushNotification(entry).catch((err) =>
       console.warn("[dlssync] push catalog-update notification failed:", err),
@@ -124,7 +128,7 @@ function emitDriverUpdateNotifications(reports: DriverStatusReport[]): void {
       "driver_update_available",
       translate(loc, "notif.driver.title", { version, model: report.device.model }),
       translate(loc, "notif.driver.body", { vendor: vendorLabel(report.device.vendor) }),
-      { link: driverPageUrl(report) },
+      { link: driverPageUrl(report), vendor: report.device.vendor === "other" ? null : report.device.vendor },
     );
     pushNotification(entry).catch((err) =>
       console.warn("[dlssync] push driver-update notification failed:", err),
@@ -386,11 +390,20 @@ export const outdatedGameCount: Readable<number> = derived(
     $games.reduce((n, g) => (!$hidden.has(g.id) && $statuses[g.id] === "outdated" ? n + 1 : n), 0),
 );
 
-/** Total pending DLL updates and the number of distinct games carrying at least
- *  one, computed from the same primitives the Library hero uses
- *  (`outdatedDllsAcrossLibrary`): outdated, updatable, pinned-aware records with a
- *  resolvable target. Reused by the proactive digest notification. */
-export function pendingDllUpdateDigest(): { total: number; games: number } {
+/** One outdated, updatable, pinned-aware DLL record with a resolved target
+ *  version, paired with its owning game. The single source of truth for the
+ *  Library hero "Apply all", the proactive digest, and the background daemon. */
+export interface OutdatedDllItem {
+  game: DetectedGame;
+  record: DllRecord;
+  target: string;
+}
+
+/** Every outdated DLL across the visible library that is eligible to apply —
+ *  honoring hidden games, per-game disabled families, update-pref gating, and
+ *  pins. Centralized here so the Library view, the digest, and the background
+ *  scheduler all derive the Apply-All batch identically. */
+export function outdatedDllItems(): OutdatedDllItem[] {
   const $games = get(games);
   const $hidden = get(hiddenIds);
   const $statuses = get(gameStatuses);
@@ -398,29 +411,34 @@ export function pendingDllUpdateDigest(): { total: number; games: number } {
   const $ctx = get(relationContext);
   const $settings = get(settings);
   const prefs = $settings?.update_prefs ?? null;
-  let total = 0;
-  let gamesWithUpdates = 0;
+  const out: OutdatedDllItem[] = [];
   for (const game of $games) {
     if ($hidden.has(game.id)) continue;
     if ($statuses[game.id] !== "outdated") continue;
     const records = $dlls[game.id] ?? [];
     const disabled = $settings?.game_preferences[game.id]?.disabled_families ?? [];
     const pinned = $settings?.game_preferences[game.id]?.pinned_versions ?? {};
-    let gameCount = 0;
     for (const r of records) {
       if (disabled.includes(r.family)) continue;
       if (!recordUpdatable(r, prefs)) continue;
       const pin = pinned[`${r.family}|${r.path}`] ?? null;
       if (dllRelation(r, $ctx, pin) !== "outdated") continue;
-      if (!targetVersion(r, $ctx, pin)) continue;
-      gameCount += 1;
-    }
-    if (gameCount > 0) {
-      total += gameCount;
-      gamesWithUpdates += 1;
+      const target = targetVersion(r, $ctx, pin);
+      if (!target) continue;
+      out.push({ game, record: r, target });
     }
   }
-  return { total, games: gamesWithUpdates };
+  return out;
+}
+
+/** Total pending DLL updates and the number of distinct games carrying at least
+ *  one. Derived from `outdatedDllItems` so the count and the Apply-All batch can
+ *  never drift. Reused by the proactive digest notification and the daemon. */
+export function pendingDllUpdateDigest(): { total: number; games: number } {
+  const items = outdatedDllItems();
+  const gameIds = new Set<string>();
+  for (const it of items) gameIds.add(it.game.id);
+  return { total: items.length, games: gameIds.size };
 }
 
 /** Push ONE proactive digest ("N updates ready in M games") when the library has
@@ -921,13 +939,27 @@ export const dockItems: Readable<DockItem[]> = derived(
   },
 );
 
+/** Backstop the nested `background` block when an older backend returns settings
+ *  without it (the Rust struct serde-defaults it, but a stale in-memory shape or
+ *  a test stub may omit it). Keeps `$settings.background.*` reads total. */
+function withBackgroundDefaults(s: AppSettings): AppSettings {
+  return { ...s, background: { ...DEFAULT_BACKGROUND_CONFIG, ...(s.background ?? {}) } };
+}
+
 export async function loadSettings(): Promise<void> {
   try {
     const result = await getSettings();
-    settings.set(result);
+    settings.set(withBackgroundDefaults(result));
   } catch (err: unknown) {
     showToast("danger", translate(get(locale), "toast.settingsLoadFailed", { msg: formatError(err) }));
   }
+}
+
+/** Read the effective background config (always defaulted), even before any
+ *  settings have loaded. Used by the daemon tick handler. */
+export function backgroundConfig(): BackgroundConfig {
+  const s = get(settings);
+  return { ...DEFAULT_BACKGROUND_CONFIG, ...(s?.background ?? {}) };
 }
 
 export async function persistSettings(next: AppSettings): Promise<void> {

--- a/frontend/src/views/Library.svelte
+++ b/frontend/src/views/Library.svelte
@@ -22,10 +22,10 @@
     rescanGame,
     manifestUpdatedAt,
     requestApplyAllOutdated,
+    outdatedDllItems,
     type StatusFilter,
   } from "../lib/stores";
-  import { dllRelation, targetVersion, recordUpdatable } from "../lib/relation";
-  import { addBlacklistEntry, removeBlacklistEntry, type DllRecord } from "../lib/api";
+  import { addBlacklistEntry, removeBlacklistEntry } from "../lib/api";
   import type { DetectedGame, LibraryViewMode, LibraryDensity, LibrarySort } from "../lib/api";
   import {
     LIBRARY_VIEW_MODES,
@@ -46,28 +46,18 @@
   import { t, locale, translate } from "../lib/i18n/index";
   import { get } from "svelte/store";
 
-  function outdatedDllsAcrossLibrary(): { game: DetectedGame; record: DllRecord; target: string }[] {
-    const out: { game: DetectedGame; record: DllRecord; target: string }[] = [];
-    for (const game of $games) {
-      if ($hiddenIds.has(game.id)) continue;
-      if ($gameStatuses[game.id] !== "outdated") continue;
-      const records = $gameDlls[game.id] ?? [];
-      const disabled = $settings?.game_preferences[game.id]?.disabled_families ?? [];
-      const pinned = $settings?.game_preferences[game.id]?.pinned_versions ?? {};
-      for (const r of records) {
-        if (disabled.includes(r.family)) continue;
-        if (!recordUpdatable(r, $settings?.update_prefs ?? null)) continue;
-        const pin = pinned[`${r.family}|${r.path}`] ?? null;
-        if (dllRelation(r, $relationContext, pin) !== "outdated") continue;
-        const target = targetVersion(r, $relationContext, pin);
-        if (!target) continue;
-        out.push({ game, record: r, target });
-      }
-    }
-    return out;
-  }
-
-  let outdatedItems = $derived(outdatedDllsAcrossLibrary());
+  // Derive from the centralized `outdatedDllItems()` (shared with the daemon and
+  // the digest). Touch the source stores so Svelte tracks them, since the helper
+  // reads via `get(...)` internally.
+  let outdatedItems = $derived.by(() => {
+    void $games;
+    void $gameDlls;
+    void $gameStatuses;
+    void $relationContext;
+    void $settings;
+    void $hiddenIds;
+    return outdatedDllItems();
+  });
   let outdatedTotal = $derived(outdatedItems.length);
   let outdatedBreakdown = $derived.by(() => {
     const counts: Record<FamilyGroup, number> = { dlss: 0, fsr: 0, xess: 0, advanced: 0 };
@@ -77,7 +67,7 @@
   });
 
   async function updateAllOutdated(): Promise<void> {
-    const items = outdatedDllsAcrossLibrary();
+    const items = outdatedDllItems();
     if (items.length === 0) {
       showToast("info", translate(get(locale), "view.library.toast.allUpToDate"));
       return;
@@ -364,6 +354,16 @@
     </p>
   </div>
   <div class="header-actions">
+    {#if outdatedTotal > 0}
+      <button
+        class="btn btn-apply-all"
+        onclick={updateAllOutdated}
+        title={$t("view.library.applyAllTitle")}
+      >
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20 6 9 17l-5-5"/></svg>
+        {$t("view.library.applyAllCount", { count: outdatedTotal })}
+      </button>
+    {/if}
     <button class="btn btn-ghost" onclick={addCustomFolder}>
       <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/><line x1="12" y1="11" x2="12" y2="17"/><line x1="9" y1="14" x2="15" y2="14"/></svg>
       {$t("view.library.addFolder")}
@@ -598,6 +598,17 @@
   }
   .view-header > div:first-child { flex: 1 1 240px; min-width: 0; }
   .header-actions { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; flex-shrink: 0; }
+  .btn-apply-all {
+    background: var(--accent);
+    color: var(--accent-fg);
+    border-color: transparent;
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+    transition: background var(--dur-fast) var(--ease);
+  }
+  .btn-apply-all:hover { background: var(--accent-hover); }
+  .btn-apply-all:focus-visible { outline: none; box-shadow: var(--shadow-ring); }
   .filter-toolbar {
     position: sticky;
     top: var(--space-2);

--- a/frontend/src/views/Settings.svelte
+++ b/frontend/src/views/Settings.svelte
@@ -19,7 +19,8 @@
     openPath,
     getAppPaths,
   } from "../lib/api";
-  import type { AppSettings, UpdatePreferences, LauncherOverrides, AdvancedConfig, NetworkConfig, SgdbConfig, AppPathsDto } from "../lib/api";
+  import type { AppSettings, UpdatePreferences, LauncherOverrides, AdvancedConfig, NetworkConfig, SgdbConfig, AppPathsDto, BackgroundConfig } from "../lib/api";
+  import { BACKGROUND_INTERVAL_MIN_HOURS, BACKGROUND_INTERVAL_MAX_HOURS } from "../lib/api";
   import { LAUNCHER_BRANDS, LAUNCHER_BRAND_ORDER, type LauncherBrandKey } from "../lib/launcherLogos";
   import { resetNudgeSession } from "../lib/community";
   import BrandMark from "../components/BrandMark.svelte";
@@ -167,6 +168,41 @@
       ...$settings,
       update_prefs: { ...$settings.update_prefs, [key]: value },
     });
+  }
+
+  function updateBackground<K extends keyof BackgroundConfig>(key: K, value: BackgroundConfig[K]): void {
+    if (!$settings) return;
+    void persistSettings({
+      ...$settings,
+      background: { ...$settings.background, [key]: value },
+    });
+  }
+
+  /** The daemon's "run at Windows startup" pref persists into settings AND drives
+   *  the autostart plugin (same enable/disable pattern as PerformanceToggles), so
+   *  the OS registration always matches the stored preference. */
+  async function setRunAtStartup(next: boolean): Promise<void> {
+    updateBackground("run_at_startup", next);
+    try {
+      const mod = await import("@tauri-apps/plugin-autostart");
+      if (next) {
+        await mod.enable();
+      } else {
+        await mod.disable();
+      }
+      const verified = await mod.isEnabled();
+      if (verified !== next) updateBackground("run_at_startup", verified);
+    } catch (err: unknown) {
+      updateBackground("run_at_startup", !next);
+      showToast("danger", translate(get(locale), "component.perf.toast.autostartFailed", { error: String(err) }));
+    }
+  }
+
+  const INTERVAL_PRESETS = [1, 6, 12, 24, 48, 72, 168] as const;
+
+  function clampInterval(value: number): number {
+    if (!Number.isFinite(value)) return 24;
+    return Math.max(BACKGROUND_INTERVAL_MIN_HOURS, Math.min(BACKGROUND_INTERVAL_MAX_HOURS, Math.round(value)));
   }
 
   function updateOverride<K extends keyof LauncherOverrides>(key: K, value: LauncherOverrides[K]): void {
@@ -467,6 +503,113 @@
               </label>
             </div>
           {/each}
+        </div>
+
+        <header class="section-head section-head-gap">
+          <h2 class="section-title-h">
+            {$t("view.settings.general.background.title")}
+            <span class="chip chip-update small-pill">{$t("view.settings.general.background.badge")}</span>
+          </h2>
+          <p class="section-help">{$t("view.settings.general.background.help")}</p>
+        </header>
+        <div class="card">
+          <div class="row">
+            <div class="row-text">
+              <div class="row-label">{$t("view.settings.general.background.enabled.label")}</div>
+              <div class="row-sub">{$t("view.settings.general.background.enabled.sub")}</div>
+            </div>
+            <label class="toggle">
+              <input
+                type="checkbox"
+                checked={$settings.background.enabled}
+                onchange={(e) => updateBackground("enabled", (e.target as HTMLInputElement).checked)}
+              />
+              <span class="toggle-slider"></span>
+            </label>
+          </div>
+
+          <div class="row row-divider" class:row-disabled={!$settings.background.enabled}>
+            <div class="row-text">
+              <label class="row-label" for="bg-interval">{$t("view.settings.general.background.interval.label")}</label>
+              <div class="row-sub">{$t("view.settings.general.background.interval.sub")}</div>
+            </div>
+            <select
+              id="bg-interval"
+              class="sort-select interval-select"
+              value={String(clampInterval($settings.background.interval_hours))}
+              disabled={!$settings.background.enabled}
+              onchange={(e) => updateBackground("interval_hours", clampInterval(Number((e.currentTarget as HTMLSelectElement).value)))}
+            >
+              {#each INTERVAL_PRESETS as hrs (hrs)}
+                <option value={String(hrs)}>{$t("view.settings.general.background.interval.option", { count: hrs })}</option>
+              {/each}
+            </select>
+          </div>
+
+          <div class="row row-divider">
+            <div class="row-text">
+              <div class="row-label">{$t("view.settings.general.background.closeToTray.label")}</div>
+              <div class="row-sub">{$t("view.settings.general.background.closeToTray.sub")}</div>
+            </div>
+            <label class="toggle">
+              <input
+                type="checkbox"
+                checked={$settings.background.close_to_tray}
+                onchange={(e) => updateBackground("close_to_tray", (e.target as HTMLInputElement).checked)}
+              />
+              <span class="toggle-slider"></span>
+            </label>
+          </div>
+
+          <div class="row row-divider">
+            <div class="row-text">
+              <div class="row-label">{$t("view.settings.general.background.runAtStartup.label")}</div>
+              <div class="row-sub">{$t("view.settings.general.background.runAtStartup.sub")}</div>
+            </div>
+            <label class="toggle">
+              <input
+                type="checkbox"
+                checked={$settings.background.run_at_startup}
+                onchange={(e) => void setRunAtStartup((e.target as HTMLInputElement).checked)}
+              />
+              <span class="toggle-slider"></span>
+            </label>
+          </div>
+
+          <div class="row row-divider" class:row-disabled={!$settings.background.enabled}>
+            <div class="row-text">
+              <div class="row-label">{$t("view.settings.general.background.notifyToast.label")}</div>
+              <div class="row-sub">{$t("view.settings.general.background.notifyToast.sub")}</div>
+            </div>
+            <label class="toggle">
+              <input
+                type="checkbox"
+                checked={$settings.background.notify_os_toast}
+                disabled={!$settings.background.enabled}
+                onchange={(e) => updateBackground("notify_os_toast", (e.target as HTMLInputElement).checked)}
+              />
+              <span class="toggle-slider"></span>
+            </label>
+          </div>
+
+          <div class="row row-divider" class:row-disabled={!$settings.background.enabled}>
+            <div class="row-text">
+              <div class="row-label">
+                {$t("view.settings.general.background.autoApply.label")}
+                <span class="chip chip-warning small-pill">{$t("view.settings.general.background.autoApply.badge")}</span>
+              </div>
+              <div class="row-sub">{$t("view.settings.general.background.autoApply.sub")}</div>
+            </div>
+            <label class="toggle">
+              <input
+                type="checkbox"
+                checked={$settings.background.auto_apply}
+                disabled={!$settings.background.enabled}
+                onchange={(e) => updateBackground("auto_apply", (e.target as HTMLInputElement).checked)}
+              />
+              <span class="toggle-slider"></span>
+            </label>
+          </div>
         </div>
 
         <header class="section-head section-head-gap">
@@ -1037,6 +1180,27 @@
     .art-row { grid-template-columns: 1fr; gap: var(--space-2); }
   }
   .row-divider { border-top: 1px solid var(--border); }
+  .row-disabled { opacity: 0.5; }
+  .row-disabled .row-label,
+  .row-disabled .row-sub { color: var(--text-muted); }
+  .interval-select {
+    height: 36px;
+    padding: 0 var(--space-3);
+    border-radius: var(--radius-sm);
+    background: var(--bg-input);
+    border: 1px solid var(--border);
+    color: var(--text-primary);
+    font-size: var(--fs-sm);
+    font-family: inherit;
+    font-variant-numeric: tabular-nums;
+    cursor: pointer;
+    min-width: 9rem;
+    flex-shrink: 0;
+    transition: border-color var(--dur-fast) var(--ease), box-shadow var(--dur-fast) var(--ease);
+  }
+  .interval-select:hover:not(:disabled) { border-color: var(--border-hover); }
+  .interval-select:focus-visible { outline: none; border-color: var(--accent); box-shadow: var(--shadow-ring); }
+  .interval-select:disabled { cursor: not-allowed; }
   .inline-num {
     width: 88px;
     padding: var(--space-2) var(--space-3);
@@ -1284,6 +1448,6 @@
   @media (prefers-reduced-motion: reduce) {
     .side-tab, .side-tab-icon, .side-tab-rail, .inline-num, .files-disclosure,
     .files-disclosure .chev, .folder-input-wrap, .path-row, .path-action,
-    .path-remove, .path-input-row input, .add-path-pill { transition: none; }
+    .path-remove, .path-input-row input, .add-path-pill, .interval-select { transition: none; }
   }
 </style>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dlssync",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "private": true,
   "scripts": {
     "dev": "tauri dev",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,7 +68,7 @@ importers:
         version: 6.9.1
       '@testing-library/svelte':
         specifier: ^5.3.1
-        version: 5.3.1(svelte@5.55.8)(vite@6.4.2(@types/node@25.9.1))(vitest@3.2.4(@types/node@25.9.1)(happy-dom@20.9.0))
+        version: 5.3.1(svelte@5.55.8)(vite@6.4.2(@types/node@25.9.1))(vitest@4.1.8(@types/node@25.9.1)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(vite@6.4.2(@types/node@25.9.1)))
       '@testing-library/user-event':
         specifier: ^14.6.1
         version: 14.6.1(@testing-library/dom@10.4.1)
@@ -76,8 +76,8 @@ importers:
         specifier: ^5.0.0
         version: 5.0.8
       '@vitest/coverage-v8':
-        specifier: ^3
-        version: 3.2.4(vitest@3.2.4(@types/node@25.9.1)(happy-dom@20.9.0))
+        specifier: ^4.1.0
+        version: 4.1.8(vitest@4.1.8)
       happy-dom:
         specifier: ^20.9.0
         version: 20.9.0
@@ -94,17 +94,13 @@ importers:
         specifier: ^6.0.0
         version: 6.4.2(@types/node@25.9.1)
       vitest:
-        specifier: ^3.2.4
-        version: 3.2.4(@types/node@25.9.1)(happy-dom@20.9.0)
+        specifier: ^4.1.0
+        version: 4.1.8(@types/node@25.9.1)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(vite@6.4.2(@types/node@25.9.1))
 
 packages:
 
   '@adobe/css-tools@4.5.0':
     resolution: {integrity: sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==}
-
-  '@ampproject/remapping@2.3.0':
-    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
-    engines: {node: '>=6.0.0'}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -297,14 +293,6 @@ packages:
   '@fontsource/geist@5.2.9':
     resolution: {integrity: sha512-6QMur8g+3/9Uvfv/5chLJGBc9bYVzWijFrWEl0uZnitxp6wEPqKCJd9/GBlOk4dg/QSe96a3TUKEgmscFpE+4g==}
 
-  '@isaacs/cliui@8.0.2':
-    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
-    engines: {node: '>=12'}
-
-  '@istanbuljs/schema@0.1.6':
-    resolution: {integrity: sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==}
-    engines: {node: '>=8'}
-
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -325,10 +313,6 @@ packages:
     resolution: {integrity: sha512-AvvPJnaWxeiNkAljI5MsSEc84yHPLMaWQIAJOcbX7k9au/f9ITS7cxTTQiautDiOFKVOXiYdZ+d6mtl88J+Kbg==}
     peerDependencies:
       svelte: ^5
-
-  '@pkgjs/parseargs@0.11.0':
-    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
-    engines: {node: '>=14'}
 
   '@rollup/rollup-android-arm-eabi@4.60.4':
     resolution: {integrity: sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==}
@@ -454,6 +438,9 @@ packages:
     resolution: {integrity: sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==}
     cpu: [x64]
     os: [win32]
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
   '@sveltejs/acorn-typescript@1.0.10':
     resolution: {integrity: sha512-4WfKk68eTih+MiJD4fSbxN7E8kVBmTMPWHUPYjvl2N0rMs53YLTT8/YjKU5Dtnz5LqDjl7LEw4U7lXR2W3J5WA==}
@@ -642,43 +629,43 @@ packages:
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
-  '@vitest/coverage-v8@3.2.4':
-    resolution: {integrity: sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==}
+  '@vitest/coverage-v8@4.1.8':
+    resolution: {integrity: sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==}
     peerDependencies:
-      '@vitest/browser': 3.2.4
-      vitest: 3.2.4
+      '@vitest/browser': 4.1.8
+      vitest: 4.1.8
     peerDependenciesMeta:
       '@vitest/browser':
         optional: true
 
-  '@vitest/expect@3.2.4':
-    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+  '@vitest/expect@4.1.8':
+    resolution: {integrity: sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==}
 
-  '@vitest/mocker@3.2.4':
-    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+  '@vitest/mocker@4.1.8':
+    resolution: {integrity: sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==}
     peerDependencies:
       msw: ^2.4.9
-      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       msw:
         optional: true
       vite:
         optional: true
 
-  '@vitest/pretty-format@3.2.4':
-    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+  '@vitest/pretty-format@4.1.8':
+    resolution: {integrity: sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==}
 
-  '@vitest/runner@3.2.4':
-    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+  '@vitest/runner@4.1.8':
+    resolution: {integrity: sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==}
 
-  '@vitest/snapshot@3.2.4':
-    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+  '@vitest/snapshot@4.1.8':
+    resolution: {integrity: sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==}
 
-  '@vitest/spy@3.2.4':
-    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+  '@vitest/spy@4.1.8':
+    resolution: {integrity: sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==}
 
-  '@vitest/utils@3.2.4':
-    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+  '@vitest/utils@4.1.8':
+    resolution: {integrity: sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==}
 
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
@@ -689,21 +676,9 @@ packages:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
 
-  ansi-regex@6.2.2:
-    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
-    engines: {node: '>=12'}
-
-  ansi-styles@4.3.0:
-    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
-    engines: {node: '>=8'}
-
   ansi-styles@5.2.0:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
-
-  ansi-styles@6.2.3:
-    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
-    engines: {node: '>=12'}
 
   aria-query@5.3.0:
     resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
@@ -716,38 +691,16 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
-  ast-v8-to-istanbul@0.3.12:
-    resolution: {integrity: sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==}
+  ast-v8-to-istanbul@1.0.3:
+    resolution: {integrity: sha512-jCMQ6ZylLPudp0CDfBmQBZUsrh1/8psbmu9ibeVWKuHWD0YrH9YABwlKu5kVEFoT0GCQQW9Z/SxfuEbbkGQCRg==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
 
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-
-  balanced-match@4.0.4:
-    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
-    engines: {node: 18 || 20 || >=22}
-
-  brace-expansion@2.1.0:
-    resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
-
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
-    engines: {node: 18 || 20 || >=22}
-
-  cac@6.7.14:
-    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
-    engines: {node: '>=8'}
-
-  chai@5.3.3:
-    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
-
-  check-error@2.1.3:
-    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
-    engines: {node: '>= 16'}
 
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
@@ -757,16 +710,8 @@ packages:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
-  color-convert@2.0.1:
-    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
-    engines: {node: '>=7.0.0'}
-
-  color-name@1.1.4:
-    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
-
-  cross-spawn@7.0.6:
-    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
-    engines: {node: '>= 8'}
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   css.escape@1.5.1:
     resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
@@ -779,10 +724,6 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
-
-  deep-eql@5.0.2:
-    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
-    engines: {node: '>=6'}
 
   deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
@@ -801,21 +742,12 @@ packages:
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
-  eastasianwidth@0.2.0:
-    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
-
-  emoji-regex@8.0.0:
-    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
-
-  emoji-regex@9.2.2:
-    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
-
   entities@7.0.1:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
 
-  es-module-lexer@1.7.0:
-    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
 
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
@@ -849,19 +781,10 @@ packages:
       picomatch:
         optional: true
 
-  foreground-child@3.3.1:
-    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
-    engines: {node: '>=14'}
-
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
-
-  glob@10.5.0:
-    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
-    hasBin: true
 
   happy-dom@20.9.0:
     resolution: {integrity: sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ==}
@@ -878,15 +801,8 @@ packages:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
 
-  is-fullwidth-code-point@3.0.0:
-    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
-    engines: {node: '>=8'}
-
   is-reference@3.0.3:
     resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
-
-  isexe@2.0.0:
-    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
@@ -896,25 +812,15 @@ packages:
     resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
     engines: {node: '>=10'}
 
-  istanbul-lib-source-maps@5.0.6:
-    resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
-    engines: {node: '>=10'}
-
   istanbul-reports@3.2.0:
     resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
     engines: {node: '>=8'}
-
-  jackspeak@3.4.3:
-    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
-
-  js-tokens@9.0.1:
-    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
@@ -923,12 +829,6 @@ packages:
   locate-character@3.0.0:
     resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
 
-  loupe@3.2.1:
-    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
-
-  lru-cache@10.4.3:
-    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
-
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
@@ -936,8 +836,8 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
-  magicast@0.3.5:
-    resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
+  magicast@0.5.3:
+    resolution: {integrity: sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==}
 
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
@@ -946,18 +846,6 @@ packages:
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
-
-  minimatch@10.2.5:
-    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
-    engines: {node: 18 || 20 || >=22}
-
-  minimatch@9.0.9:
-    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
-    engines: {node: '>=16 || 14 >=14.17'}
-
-  minipass@7.1.3:
-    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
-    engines: {node: '>=16 || 14 >=14.17'}
 
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -971,23 +859,11 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  package-json-from-dist@1.0.1:
-    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
-
-  path-key@3.1.1:
-    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
-    engines: {node: '>=8'}
-
-  path-scurry@1.11.1:
-    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
-    engines: {node: '>=16 || 14 >=14.18'}
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
-
-  pathval@2.0.1:
-    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
-    engines: {node: '>= 14.16'}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -1029,20 +905,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  shebang-command@2.0.0:
-    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
-    engines: {node: '>=8'}
-
-  shebang-regex@3.0.0:
-    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
-    engines: {node: '>=8'}
-
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
-
-  signal-exit@4.1.0:
-    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
-    engines: {node: '>=14'}
 
   simple-icons@16.21.0:
     resolution: {integrity: sha512-kH6LEx5yvBGVNaVrHnZ7D17G16CmmHiI8DD7MwIwgnWmDFTiFu4PhFZLNdV6bMGr61qbHMMTXLoo/T6C25dMGA==}
@@ -1055,31 +919,12 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
-  std-env@3.10.0:
-    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
-
-  string-width@4.2.3:
-    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
-    engines: {node: '>=8'}
-
-  string-width@5.1.2:
-    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
-    engines: {node: '>=12'}
-
-  strip-ansi@6.0.1:
-    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
-    engines: {node: '>=8'}
-
-  strip-ansi@7.2.0:
-    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
-    engines: {node: '>=12'}
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   strip-indent@3.0.0:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
     engines: {node: '>=8'}
-
-  strip-literal@3.1.0:
-    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
 
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -1097,30 +942,19 @@ packages:
     resolution: {integrity: sha512-4D6lyrMHmDaZalQOEBMCWCCidyZjSnec14/oPn0k627G6goxcck9xqMwz1tFLlQz+ZFvtTTHfFOlUayuAz0z6Q==}
     engines: {node: '>=18'}
 
-  test-exclude@7.0.2:
-    resolution: {integrity: sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==}
-    engines: {node: '>=18'}
-
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
-  tinyexec@0.3.2:
-    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
 
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
 
-  tinypool@1.1.1:
-    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-
-  tinyrainbow@2.0.0:
-    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
-    engines: {node: '>=14.0.0'}
-
-  tinyspy@4.0.4:
-    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
   typescript@5.9.3:
@@ -1130,11 +964,6 @@ packages:
 
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
-
-  vite-node@3.2.4:
-    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
-    hasBin: true
 
   vite@6.4.2:
     resolution: {integrity: sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==}
@@ -1184,26 +1013,39 @@ packages:
       vite:
         optional: true
 
-  vitest@3.2.4:
-    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+  vitest@4.1.8:
+    resolution: {integrity: sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
-      '@types/debug': ^4.1.12
-      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
-      '@vitest/browser': 3.2.4
-      '@vitest/ui': 3.2.4
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.8
+      '@vitest/browser-preview': 4.1.8
+      '@vitest/browser-webdriverio': 4.1.8
+      '@vitest/coverage-istanbul': 4.1.8
+      '@vitest/coverage-v8': 4.1.8
+      '@vitest/ui': 4.1.8
       happy-dom: '*'
       jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
-      '@types/debug':
+      '@opentelemetry/api':
         optional: true
       '@types/node':
         optional: true
-      '@vitest/browser':
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
         optional: true
       '@vitest/ui':
         optional: true
@@ -1216,23 +1058,10 @@ packages:
     resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
     engines: {node: '>=12'}
 
-  which@2.0.2:
-    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
-    engines: {node: '>= 8'}
-    hasBin: true
-
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
-
-  wrap-ansi@7.0.0:
-    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
-    engines: {node: '>=10'}
-
-  wrap-ansi@8.1.0:
-    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
-    engines: {node: '>=12'}
 
   ws@8.21.0:
     resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
@@ -1252,11 +1081,6 @@ packages:
 snapshots:
 
   '@adobe/css-tools@4.5.0': {}
-
-  '@ampproject/remapping@2.3.0':
-    dependencies:
-      '@jridgewell/gen-mapping': 0.3.13
-      '@jridgewell/trace-mapping': 0.3.31
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -1363,17 +1187,6 @@ snapshots:
 
   '@fontsource/geist@5.2.9': {}
 
-  '@isaacs/cliui@8.0.2':
-    dependencies:
-      string-width: 5.1.2
-      string-width-cjs: string-width@4.2.3
-      strip-ansi: 7.2.0
-      strip-ansi-cjs: strip-ansi@6.0.1
-      wrap-ansi: 8.1.0
-      wrap-ansi-cjs: wrap-ansi@7.0.0
-
-  '@istanbuljs/schema@0.1.6': {}
-
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -1396,9 +1209,6 @@ snapshots:
   '@lucide/svelte@1.16.0(svelte@5.55.8)':
     dependencies:
       svelte: 5.55.8
-
-  '@pkgjs/parseargs@0.11.0':
-    optional: true
 
   '@rollup/rollup-android-arm-eabi@4.60.4':
     optional: true
@@ -1474,6 +1284,8 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.60.4':
     optional: true
+
+  '@standard-schema/spec@1.1.0': {}
 
   '@sveltejs/acorn-typescript@1.0.10(acorn@8.16.0)':
     dependencies:
@@ -1614,14 +1426,14 @@ snapshots:
     dependencies:
       svelte: 5.55.8
 
-  '@testing-library/svelte@5.3.1(svelte@5.55.8)(vite@6.4.2(@types/node@25.9.1))(vitest@3.2.4(@types/node@25.9.1)(happy-dom@20.9.0))':
+  '@testing-library/svelte@5.3.1(svelte@5.55.8)(vite@6.4.2(@types/node@25.9.1))(vitest@4.1.8(@types/node@25.9.1)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(vite@6.4.2(@types/node@25.9.1)))':
     dependencies:
       '@testing-library/dom': 10.4.1
       '@testing-library/svelte-core': 1.0.0(svelte@5.55.8)
       svelte: 5.55.8
     optionalDependencies:
       vite: 6.4.2(@types/node@25.9.1)
-      vitest: 3.2.4(@types/node@25.9.1)(happy-dom@20.9.0)
+      vitest: 4.1.8(@types/node@25.9.1)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(vite@6.4.2(@types/node@25.9.1))
 
   '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
     dependencies:
@@ -1654,80 +1466,66 @@ snapshots:
     dependencies:
       '@types/node': 25.9.1
 
-  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/node@25.9.1)(happy-dom@20.9.0))':
+  '@vitest/coverage-v8@4.1.8(vitest@4.1.8)':
     dependencies:
-      '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
-      ast-v8-to-istanbul: 0.3.12
-      debug: 4.4.3
+      '@vitest/utils': 4.1.8
+      ast-v8-to-istanbul: 1.0.3
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
-      istanbul-lib-source-maps: 5.0.6
       istanbul-reports: 3.2.0
-      magic-string: 0.30.21
-      magicast: 0.3.5
-      std-env: 3.10.0
-      test-exclude: 7.0.2
-      tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/node@25.9.1)(happy-dom@20.9.0)
-    transitivePeerDependencies:
-      - supports-color
+      magicast: 0.5.3
+      obug: 2.1.1
+      std-env: 4.1.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.8(@types/node@25.9.1)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(vite@6.4.2(@types/node@25.9.1))
 
-  '@vitest/expect@3.2.4':
+  '@vitest/expect@4.1.8':
     dependencies:
+      '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 3.2.4
-      '@vitest/utils': 3.2.4
-      chai: 5.3.3
-      tinyrainbow: 2.0.0
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
 
-  '@vitest/mocker@3.2.4(vite@6.4.2(@types/node@25.9.1))':
+  '@vitest/mocker@4.1.8(vite@6.4.2(@types/node@25.9.1))':
     dependencies:
-      '@vitest/spy': 3.2.4
+      '@vitest/spy': 4.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       vite: 6.4.2(@types/node@25.9.1)
 
-  '@vitest/pretty-format@3.2.4':
+  '@vitest/pretty-format@4.1.8':
     dependencies:
-      tinyrainbow: 2.0.0
+      tinyrainbow: 3.1.0
 
-  '@vitest/runner@3.2.4':
+  '@vitest/runner@4.1.8':
     dependencies:
-      '@vitest/utils': 3.2.4
+      '@vitest/utils': 4.1.8
       pathe: 2.0.3
-      strip-literal: 3.1.0
 
-  '@vitest/snapshot@3.2.4':
+  '@vitest/snapshot@4.1.8':
     dependencies:
-      '@vitest/pretty-format': 3.2.4
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/utils': 4.1.8
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@3.2.4':
-    dependencies:
-      tinyspy: 4.0.4
+  '@vitest/spy@4.1.8': {}
 
-  '@vitest/utils@3.2.4':
+  '@vitest/utils@4.1.8':
     dependencies:
-      '@vitest/pretty-format': 3.2.4
-      loupe: 3.2.1
-      tinyrainbow: 2.0.0
+      '@vitest/pretty-format': 4.1.8
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   acorn@8.16.0: {}
 
   ansi-regex@5.0.1: {}
 
-  ansi-regex@6.2.2: {}
-
-  ansi-styles@4.3.0:
-    dependencies:
-      color-convert: 2.0.1
-
   ansi-styles@5.2.0: {}
-
-  ansi-styles@6.2.3: {}
 
   aria-query@5.3.0:
     dependencies:
@@ -1737,7 +1535,7 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
-  ast-v8-to-istanbul@0.3.12:
+  ast-v8-to-istanbul@1.0.3:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       estree-walker: 3.0.3
@@ -1745,29 +1543,7 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
-  balanced-match@1.0.2: {}
-
-  balanced-match@4.0.4: {}
-
-  brace-expansion@2.1.0:
-    dependencies:
-      balanced-match: 1.0.2
-
-  brace-expansion@5.0.6:
-    dependencies:
-      balanced-match: 4.0.4
-
-  cac@6.7.14: {}
-
-  chai@5.3.3:
-    dependencies:
-      assertion-error: 2.0.1
-      check-error: 2.1.3
-      deep-eql: 5.0.2
-      loupe: 3.2.1
-      pathval: 2.0.1
-
-  check-error@2.1.3: {}
+  chai@6.2.2: {}
 
   chokidar@4.0.3:
     dependencies:
@@ -1775,25 +1551,13 @@ snapshots:
 
   clsx@2.1.1: {}
 
-  color-convert@2.0.1:
-    dependencies:
-      color-name: 1.1.4
-
-  color-name@1.1.4: {}
-
-  cross-spawn@7.0.6:
-    dependencies:
-      path-key: 3.1.1
-      shebang-command: 2.0.0
-      which: 2.0.2
+  convert-source-map@2.0.0: {}
 
   css.escape@1.5.1: {}
 
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
-
-  deep-eql@5.0.2: {}
 
   deepmerge@4.3.1: {}
 
@@ -1805,15 +1569,9 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
-  eastasianwidth@0.2.0: {}
-
-  emoji-regex@8.0.0: {}
-
-  emoji-regex@9.2.2: {}
-
   entities@7.0.1: {}
 
-  es-module-lexer@1.7.0: {}
+  es-module-lexer@2.1.0: {}
 
   esbuild@0.25.12:
     optionalDependencies:
@@ -1860,22 +1618,8 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
-  foreground-child@3.3.1:
-    dependencies:
-      cross-spawn: 7.0.6
-      signal-exit: 4.1.0
-
   fsevents@2.3.3:
     optional: true
-
-  glob@10.5.0:
-    dependencies:
-      foreground-child: 3.3.1
-      jackspeak: 3.4.3
-      minimatch: 9.0.9
-      minipass: 7.1.3
-      package-json-from-dist: 1.0.1
-      path-scurry: 1.11.1
 
   happy-dom@20.9.0:
     dependencies:
@@ -1895,13 +1639,9 @@ snapshots:
 
   indent-string@4.0.0: {}
 
-  is-fullwidth-code-point@3.0.0: {}
-
   is-reference@3.0.3:
     dependencies:
       '@types/estree': 1.0.9
-
-  isexe@2.0.0: {}
 
   istanbul-lib-coverage@3.2.2: {}
 
@@ -1911,38 +1651,18 @@ snapshots:
       make-dir: 4.0.0
       supports-color: 7.2.0
 
-  istanbul-lib-source-maps@5.0.6:
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.31
-      debug: 4.4.3
-      istanbul-lib-coverage: 3.2.2
-    transitivePeerDependencies:
-      - supports-color
-
   istanbul-reports@3.2.0:
     dependencies:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.1
 
-  jackspeak@3.4.3:
-    dependencies:
-      '@isaacs/cliui': 8.0.2
-    optionalDependencies:
-      '@pkgjs/parseargs': 0.11.0
-
   js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
 
-  js-tokens@9.0.1: {}
-
   kleur@4.1.5: {}
 
   locate-character@3.0.0: {}
-
-  loupe@3.2.1: {}
-
-  lru-cache@10.4.3: {}
 
   lz-string@1.5.0: {}
 
@@ -1950,7 +1670,7 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  magicast@0.3.5:
+  magicast@0.5.3:
     dependencies:
       '@babel/parser': 7.29.3
       '@babel/types': 7.29.0
@@ -1962,34 +1682,15 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  minimatch@10.2.5:
-    dependencies:
-      brace-expansion: 5.0.6
-
-  minimatch@9.0.9:
-    dependencies:
-      brace-expansion: 2.1.0
-
-  minipass@7.1.3: {}
-
   mri@1.2.0: {}
 
   ms@2.1.3: {}
 
   nanoid@3.3.12: {}
 
-  package-json-from-dist@1.0.1: {}
-
-  path-key@3.1.1: {}
-
-  path-scurry@1.11.1:
-    dependencies:
-      lru-cache: 10.4.3
-      minipass: 7.1.3
+  obug@2.1.1: {}
 
   pathe@2.0.3: {}
-
-  pathval@2.0.1: {}
 
   picocolors@1.1.1: {}
 
@@ -2053,15 +1754,7 @@ snapshots:
 
   semver@7.8.1: {}
 
-  shebang-command@2.0.0:
-    dependencies:
-      shebang-regex: 3.0.0
-
-  shebang-regex@3.0.0: {}
-
   siginfo@2.0.0: {}
-
-  signal-exit@4.1.0: {}
 
   simple-icons@16.21.0: {}
 
@@ -2069,35 +1762,11 @@ snapshots:
 
   stackback@0.0.2: {}
 
-  std-env@3.10.0: {}
-
-  string-width@4.2.3:
-    dependencies:
-      emoji-regex: 8.0.0
-      is-fullwidth-code-point: 3.0.0
-      strip-ansi: 6.0.1
-
-  string-width@5.1.2:
-    dependencies:
-      eastasianwidth: 0.2.0
-      emoji-regex: 9.2.2
-      strip-ansi: 7.2.0
-
-  strip-ansi@6.0.1:
-    dependencies:
-      ansi-regex: 5.0.1
-
-  strip-ansi@7.2.0:
-    dependencies:
-      ansi-regex: 6.2.2
+  std-env@4.1.0: {}
 
   strip-indent@3.0.0:
     dependencies:
       min-indent: 1.0.1
-
-  strip-literal@3.1.0:
-    dependencies:
-      js-tokens: 9.0.1
 
   supports-color@7.2.0:
     dependencies:
@@ -2136,51 +1805,20 @@ snapshots:
     transitivePeerDependencies:
       - '@typescript-eslint/types'
 
-  test-exclude@7.0.2:
-    dependencies:
-      '@istanbuljs/schema': 0.1.6
-      glob: 10.5.0
-      minimatch: 10.2.5
-
   tinybench@2.9.0: {}
 
-  tinyexec@0.3.2: {}
+  tinyexec@1.2.4: {}
 
   tinyglobby@0.2.16:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
-  tinypool@1.1.1: {}
-
-  tinyrainbow@2.0.0: {}
-
-  tinyspy@4.0.4: {}
+  tinyrainbow@3.1.0: {}
 
   typescript@5.9.3: {}
 
   undici-types@7.24.6: {}
-
-  vite-node@3.2.4(@types/node@25.9.1):
-    dependencies:
-      cac: 6.7.14
-      debug: 4.4.3
-      es-module-lexer: 1.7.0
-      pathe: 2.0.3
-      vite: 6.4.2(@types/node@25.9.1)
-    transitivePeerDependencies:
-      - '@types/node'
-      - jiti
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
 
   vite@6.4.2(@types/node@25.9.1):
     dependencies:
@@ -2198,70 +1836,41 @@ snapshots:
     optionalDependencies:
       vite: 6.4.2(@types/node@25.9.1)
 
-  vitest@3.2.4(@types/node@25.9.1)(happy-dom@20.9.0):
+  vitest@4.1.8(@types/node@25.9.1)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(vite@6.4.2(@types/node@25.9.1)):
     dependencies:
-      '@types/chai': 5.2.3
-      '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@6.4.2(@types/node@25.9.1))
-      '@vitest/pretty-format': 3.2.4
-      '@vitest/runner': 3.2.4
-      '@vitest/snapshot': 3.2.4
-      '@vitest/spy': 3.2.4
-      '@vitest/utils': 3.2.4
-      chai: 5.3.3
-      debug: 4.4.3
+      '@vitest/expect': 4.1.8
+      '@vitest/mocker': 4.1.8(vite@6.4.2(@types/node@25.9.1))
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/runner': 4.1.8
+      '@vitest/snapshot': 4.1.8
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
+      es-module-lexer: 2.1.0
       expect-type: 1.3.0
       magic-string: 0.30.21
+      obug: 2.1.1
       pathe: 2.0.3
       picomatch: 4.0.4
-      std-env: 3.10.0
+      std-env: 4.1.0
       tinybench: 2.9.0
-      tinyexec: 0.3.2
+      tinyexec: 1.2.4
       tinyglobby: 0.2.16
-      tinypool: 1.1.1
-      tinyrainbow: 2.0.0
+      tinyrainbow: 3.1.0
       vite: 6.4.2(@types/node@25.9.1)
-      vite-node: 3.2.4(@types/node@25.9.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.9.1
+      '@vitest/coverage-v8': 4.1.8(vitest@4.1.8)
       happy-dom: 20.9.0
     transitivePeerDependencies:
-      - jiti
-      - less
-      - lightningcss
       - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
 
   whatwg-mimetype@3.0.0: {}
-
-  which@2.0.2:
-    dependencies:
-      isexe: 2.0.0
 
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
-
-  wrap-ansi@7.0.0:
-    dependencies:
-      ansi-styles: 4.3.0
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-
-  wrap-ansi@8.1.0:
-    dependencies:
-      ansi-styles: 6.2.3
-      string-width: 5.1.2
-      strip-ansi: 7.2.0
 
   ws@8.21.0: {}
 

--- a/src-tauri/src/commands/apply.rs
+++ b/src-tauri/src/commands/apply.rs
@@ -170,6 +170,7 @@ pub async fn apply_update_batch(
         let state_c = state.inner().clone_handles();
         let sem = semaphore.clone();
         let tokens_c = tokens.clone();
+        let apply_ids_for_group: Vec<String> = items.iter().map(|r| r.apply_id.clone()).collect();
         let task = tokio::spawn(async move {
             let _permit = sem.acquire_owned().await.ok();
             let mut group_outcomes = Vec::with_capacity(items.len());
@@ -179,21 +180,21 @@ pub async fn apply_update_batch(
                     .cloned()
                     .unwrap_or_else(CancellationToken::new);
                 let outcome = apply_single_item(&handle_c, &state_c, &item, token).await;
-                group_outcomes.push(outcome);
+                group_outcomes.push((item.apply_id.clone(), outcome));
             }
             group_outcomes
         });
-        group_tasks.push(task);
+        group_tasks.push((apply_ids_for_group, task));
     }
     let mut outcomes = Vec::with_capacity(request.items.len());
-    for task in group_tasks {
+    for (group_apply_ids, task) in group_tasks {
         match task.await {
             Ok(group_outcomes) => {
-                for o in group_outcomes {
+                for (apply_id, o) in group_outcomes {
                     match o {
                         Ok(out) => outcomes.push(out),
                         Err(e) => outcomes.push(ApplyOutcome {
-                            apply_id: String::new(),
+                            apply_id,
                             success: false,
                             backup_id: None,
                             previous_version: None,
@@ -203,14 +204,18 @@ pub async fn apply_update_batch(
                     }
                 }
             }
-            Err(join_err) => outcomes.push(ApplyOutcome {
-                apply_id: String::new(),
-                success: false,
-                backup_id: None,
-                previous_version: None,
-                new_version: None,
-                error: Some(format!("task join failed: {join_err}")),
-            }),
+            Err(join_err) => {
+                for apply_id in group_apply_ids {
+                    outcomes.push(ApplyOutcome {
+                        apply_id,
+                        success: false,
+                        backup_id: None,
+                        previous_version: None,
+                        new_version: None,
+                        error: Some(format!("task join failed: {join_err}")),
+                    });
+                }
+            }
         }
     }
     for r in &request.items {
@@ -504,6 +509,10 @@ pub(crate) async fn apply_single_item(
             return Ok(failure_outcome(request, &group_id, err));
         }
     };
+    if cancel.is_cancelled() {
+        ctx.cancelled();
+        return Ok(failure_outcome(request, &group_id, "cancelled".into()));
+    }
     if let Err(e) = std::fs::copy(&dll_path, &backup_path) {
         ctx.fail("Backup copy failed", e.to_string(), Some("backup"));
         return Ok(failure_outcome(request, &group_id, e.to_string()));
@@ -544,6 +553,10 @@ pub(crate) async fn apply_single_item(
             ctx.fail("Symlink detected", err.clone(), Some("permission"));
             return Ok(failure_outcome(request, &group_id, err));
         }
+    }
+    if cancel.is_cancelled() {
+        ctx.cancelled();
+        return Ok(failure_outcome(request, &group_id, "cancelled".into()));
     }
     if let Err(e) = atomic_replace(&staged_dll, &dll_path) {
         let os = e.raw_os_error().unwrap_or(0);

--- a/src-tauri/src/commands/background.rs
+++ b/src-tauri/src/commands/background.rs
@@ -1,0 +1,6 @@
+use tauri::AppHandle;
+
+#[tauri::command]
+pub fn tray_set_pending(handle: AppHandle, count: u32) {
+    crate::tray::update_pending_count(&handle, count);
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod advanced;
 pub mod anticheat;
 pub mod apply;
+pub mod background;
 pub mod backup;
 pub mod catalog;
 pub mod diagnostics;

--- a/src-tauri/src/commands/notifications.rs
+++ b/src-tauri/src/commands/notifications.rs
@@ -51,19 +51,14 @@ pub async fn push_notification(
     app: AppHandle,
     entry: NotificationEntry,
 ) -> AppResult<()> {
-    {
+    let inserted = {
         let guard = state.notifications.read();
         let store = store_required(&guard)?;
-        let existing = store.list(&ListFilter::default())?;
-        let duplicate = existing
-            .iter()
-            .any(|e| e.kind == entry.kind && e.title == entry.title);
-        if duplicate {
-            return Ok(());
-        }
-        store.insert(&entry)?;
+        store.insert(&entry)?
+    };
+    if inserted {
+        let _ = app.emit(NOTIFICATION_PUSHED_EVENT, &entry);
     }
-    let _ = app.emit(NOTIFICATION_PUSHED_EVENT, &entry);
     Ok(())
 }
 
@@ -100,6 +95,7 @@ mod tests {
             game_id: Some(format!("steam-{title}")),
             error_class: None,
             link: None,
+            vendor: None,
         }
     }
 

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -235,6 +235,50 @@ impl Default for NetworkConfig {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BackgroundConfig {
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default = "default_background_interval_hours")]
+    pub interval_hours: u32,
+    #[serde(default)]
+    pub close_to_tray: bool,
+    #[serde(default)]
+    pub run_at_startup: bool,
+    #[serde(default = "default_true")]
+    pub notify_os_toast: bool,
+    #[serde(default)]
+    pub auto_apply: bool,
+}
+
+pub const DEFAULT_BACKGROUND_INTERVAL_HOURS: u32 = 24;
+pub const MIN_BACKGROUND_INTERVAL_HOURS: u32 = 1;
+pub const MAX_BACKGROUND_INTERVAL_HOURS: u32 = 168;
+
+fn default_background_interval_hours() -> u32 {
+    DEFAULT_BACKGROUND_INTERVAL_HOURS
+}
+
+impl Default for BackgroundConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            interval_hours: DEFAULT_BACKGROUND_INTERVAL_HOURS,
+            close_to_tray: false,
+            run_at_startup: false,
+            notify_os_toast: true,
+            auto_apply: false,
+        }
+    }
+}
+
+impl BackgroundConfig {
+    pub fn effective_interval_hours(&self) -> u32 {
+        self.interval_hours
+            .clamp(MIN_BACKGROUND_INTERVAL_HOURS, MAX_BACKGROUND_INTERVAL_HOURS)
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct AppSettings {
     #[serde(default)]
@@ -259,6 +303,8 @@ pub struct AppSettings {
     pub advanced: AdvancedConfig,
     #[serde(default)]
     pub network: NetworkConfig,
+    #[serde(default)]
+    pub background: BackgroundConfig,
 }
 
 impl AppSettings {
@@ -448,5 +494,102 @@ mod ui_prefs_tests {
             back.command_palette_recent,
             vec!["action.apply_all_outdated"]
         );
+    }
+}
+
+#[cfg(test)]
+mod background_config_tests {
+    use super::*;
+
+    #[test]
+    fn default_background_config_is_disabled_with_safe_defaults() {
+        let cfg = BackgroundConfig::default();
+        assert!(!cfg.enabled);
+        assert_eq!(cfg.interval_hours, DEFAULT_BACKGROUND_INTERVAL_HOURS);
+        assert!(!cfg.close_to_tray);
+        assert!(!cfg.run_at_startup);
+        assert!(cfg.notify_os_toast);
+        assert!(!cfg.auto_apply);
+    }
+
+    #[test]
+    fn legacy_settings_without_background_migrates_to_defaults() {
+        let legacy = r#"{
+            "blacklist": ["game-1"],
+            "ignored": []
+        }"#;
+        let settings: AppSettings = serde_json::from_str(legacy).expect("legacy parse");
+        let bg = &settings.background;
+        assert!(!bg.enabled);
+        assert_eq!(bg.interval_hours, DEFAULT_BACKGROUND_INTERVAL_HOURS);
+        assert!(!bg.close_to_tray);
+        assert!(!bg.run_at_startup);
+        assert!(bg.notify_os_toast);
+        assert!(!bg.auto_apply);
+        assert_eq!(settings.blacklist, vec!["game-1"]);
+    }
+
+    #[test]
+    fn partial_background_object_fills_missing_fields_with_defaults() {
+        let partial = r#"{ "enabled": true, "auto_apply": true }"#;
+        let cfg: BackgroundConfig = serde_json::from_str(partial).expect("partial parse");
+        assert!(cfg.enabled);
+        assert!(cfg.auto_apply);
+        assert_eq!(cfg.interval_hours, DEFAULT_BACKGROUND_INTERVAL_HOURS);
+        assert!(cfg.notify_os_toast);
+        assert!(!cfg.close_to_tray);
+    }
+
+    #[test]
+    fn effective_interval_clamps_below_minimum() {
+        let cfg = BackgroundConfig {
+            interval_hours: 0,
+            ..Default::default()
+        };
+        assert_eq!(
+            cfg.effective_interval_hours(),
+            MIN_BACKGROUND_INTERVAL_HOURS
+        );
+    }
+
+    #[test]
+    fn effective_interval_clamps_above_maximum() {
+        let cfg = BackgroundConfig {
+            interval_hours: 10_000,
+            ..Default::default()
+        };
+        assert_eq!(
+            cfg.effective_interval_hours(),
+            MAX_BACKGROUND_INTERVAL_HOURS
+        );
+    }
+
+    #[test]
+    fn effective_interval_passes_through_in_range() {
+        let cfg = BackgroundConfig {
+            interval_hours: 12,
+            ..Default::default()
+        };
+        assert_eq!(cfg.effective_interval_hours(), 12);
+    }
+
+    #[test]
+    fn background_config_round_trips_through_json() {
+        let cfg = BackgroundConfig {
+            enabled: true,
+            interval_hours: 48,
+            close_to_tray: true,
+            run_at_startup: true,
+            notify_os_toast: false,
+            auto_apply: true,
+        };
+        let json = serde_json::to_string(&cfg).expect("serialize");
+        let back: BackgroundConfig = serde_json::from_str(&json).expect("deserialize");
+        assert!(back.enabled);
+        assert_eq!(back.interval_hours, 48);
+        assert!(back.close_to_tray);
+        assert!(back.run_at_startup);
+        assert!(!back.notify_os_toast);
+        assert!(back.auto_apply);
     }
 }

--- a/src-tauri/src/commands/streamline_set.rs
+++ b/src-tauri/src/commands/streamline_set.rs
@@ -118,6 +118,16 @@ fn rollback_all(handles: &StateHandles, backup_ids: &[String]) -> bool {
     for id in backup_ids {
         match store.get(id) {
             Ok(entry) => {
+                if !backup_path_under_root(&entry.backup_path, &store.root_dir) {
+                    tracing::warn!(
+                        backup_id = %id,
+                        backup_path = %entry.backup_path.display(),
+                        root = %store.root_dir.display(),
+                        "rollback skipped: backup path escapes the backup store root"
+                    );
+                    all_restored = false;
+                    continue;
+                }
                 if std::fs::copy(&entry.backup_path, &entry.original_path).is_err() {
                     all_restored = false;
                 }
@@ -126,6 +136,14 @@ fn rollback_all(handles: &StateHandles, backup_ids: &[String]) -> bool {
         }
     }
     all_restored
+}
+
+/// A backup may only be restored from inside the backup store root. The DB-stored
+/// `backup_path` is otherwise an unvalidated copy SOURCE, so a tampered row could
+/// point the restore at an arbitrary file. `None`/non-`starts_with` paths are
+/// rejected.
+fn backup_path_under_root(backup_path: &std::path::Path, root: &std::path::Path) -> bool {
+    backup_path.starts_with(root)
 }
 
 #[cfg(test)]
@@ -150,5 +168,29 @@ mod tests {
         let v210 = "https://github.com/NVIDIA-RTX/Streamline/releases/download/v2.10.3/sdk.zip";
         let reason = coherence_error(&urls(&[v211, v211, v210])).unwrap();
         assert!(reason.contains("version-locked"));
+    }
+
+    #[test]
+    fn backup_path_inside_root_is_restorable() {
+        let root = std::path::Path::new("/data/DLSSync/Backups");
+        let inside = std::path::Path::new("/data/DLSSync/Backups/Cyberpunk/2026/sl.dlss_g.dll");
+        assert!(backup_path_under_root(inside, root));
+    }
+
+    #[test]
+    fn backup_path_outside_root_is_rejected() {
+        let root = std::path::Path::new("/data/DLSSync/Backups");
+        assert!(!backup_path_under_root(
+            std::path::Path::new("/etc/passwd"),
+            root
+        ));
+        assert!(!backup_path_under_root(
+            std::path::Path::new("/data/DLSSync/Other/sl.dlss_g.dll"),
+            root
+        ));
+        assert!(!backup_path_under_root(
+            std::path::Path::new("/data/DLSSync/BackupsEvil/x.dll"),
+            root
+        ));
     }
 }

--- a/src-tauri/src/commands/ui_prefs.rs
+++ b/src-tauri/src/commands/ui_prefs.rs
@@ -1,17 +1,5 @@
 use crate::efficiency;
-use crate::tray::TrayPrefs;
-use tauri::{AppHandle, Manager, State};
-
-#[tauri::command]
-pub fn set_close_to_tray(prefs: State<'_, TrayPrefs>, enable: bool) -> Result<(), String> {
-    prefs.set_close_to_tray(enable);
-    Ok(())
-}
-
-#[tauri::command]
-pub fn get_close_to_tray(prefs: State<'_, TrayPrefs>) -> bool {
-    prefs.close_to_tray()
-}
+use tauri::{AppHandle, Manager};
 
 #[tauri::command]
 pub fn set_efficiency_mode(enable: bool) -> Result<(), String> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -162,6 +162,40 @@ fn run_wua_install_child(
     exit
 }
 
+const BACKGROUND_INITIAL_DELAY_SECS: u64 = 60;
+const SECS_PER_HOUR: u64 = 60 * 60;
+
+/// Backend scan scheduler. A `tokio` interval drives the cadence; each tick the
+/// loop re-reads `settings.background` (so interval/enabled changes apply without
+/// a restart) and, when the daemon is enabled and no apply is inflight, emits
+/// `background:scan-tick` for the frontend to run the existing scan/digest flow.
+fn spawn_background_scheduler(handle: tauri::AppHandle) {
+    use tauri::{Emitter, Manager};
+
+    tauri::async_runtime::spawn(async move {
+        let state = handle.state::<state::AppState>();
+        tokio::time::sleep(tokio::time::Duration::from_secs(
+            BACKGROUND_INITIAL_DELAY_SECS,
+        ))
+        .await;
+
+        loop {
+            let background = state.settings.read().background.clone();
+            let wait_secs = background.effective_interval_hours() as u64 * SECS_PER_HOUR;
+
+            if background.enabled {
+                if state.apply_registry.in_flight() > 0 {
+                    tracing::debug!("background scan tick skipped: apply inflight");
+                } else if let Err(e) = handle.emit(tray::EVENT_BACKGROUND_SCAN_TICK, ()) {
+                    tracing::warn!(error = %e, "background scan tick emit failed");
+                }
+            }
+
+            tokio::time::sleep(tokio::time::Duration::from_secs(wait_secs)).await;
+        }
+    });
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     #[cfg(windows)]
@@ -194,13 +228,17 @@ pub fn run() {
             Some(vec!["--minimized"]),
         ))
         .manage(state::AppState::new())
-        .manage(tray::TrayPrefs::new(true))
         .on_window_event(|window, event| {
             if let tauri::WindowEvent::CloseRequested { api, .. } = event {
                 use tauri::Manager;
                 let app = window.app_handle();
-                let prefs = app.state::<tray::TrayPrefs>();
-                if prefs.close_to_tray() {
+                let close_to_tray = app
+                    .state::<state::AppState>()
+                    .settings
+                    .read()
+                    .background
+                    .close_to_tray;
+                if close_to_tray {
                     let _ = window.hide();
                     api.prevent_close();
                 }
@@ -308,6 +346,14 @@ pub fn run() {
                 tracing::warn!(error = %e, "tray icon install failed");
             }
 
+            if std::env::args().any(|a| a == "--minimized") {
+                if let Some(w) = app.get_webview_window("main") {
+                    let _ = w.hide();
+                }
+            }
+
+            spawn_background_scheduler(app.handle().clone());
+
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
@@ -363,8 +409,7 @@ pub fn run() {
             commands::dlss_profile::find_game_executable,
             commands::runtime::runtime_mode,
             commands::runtime::open_devtools,
-            commands::ui_prefs::set_close_to_tray,
-            commands::ui_prefs::get_close_to_tray,
+            commands::background::tray_set_pending,
             commands::ui_prefs::set_efficiency_mode,
             commands::ui_prefs::hide_main_window,
             commands::ui_prefs::show_main_window,

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -1,5 +1,3 @@
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
 use tauri::menu::{Menu, MenuItem};
 use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};
 use tauri::{AppHandle, Emitter, Manager, Runtime};
@@ -10,29 +8,23 @@ pub const MENU_SHOW: &str = "tray.show";
 pub const MENU_HIDE: &str = "tray.hide";
 pub const MENU_PROGRESS: &str = "tray.progress";
 pub const MENU_CHECK_UPDATE: &str = "tray.check_update";
+pub const MENU_CHECK_NOW: &str = "tray.check_now";
+pub const MENU_APPLY_ALL: &str = "tray.apply_all";
 pub const MENU_QUIT: &str = "tray.quit";
 
 pub const TRAY_EVENT_CHECK_UPDATE: &str = "tray://check-update";
 pub const TRAY_EVENT_SHOW_PROGRESS: &str = "tray://show-progress";
 
+pub const EVENT_BACKGROUND_SCAN_TICK: &str = "background:scan-tick";
+pub const EVENT_BACKGROUND_APPLY_ALL: &str = "background:apply-all";
+
 pub const TRAY_TOOLTIP_IDLE: &str = "DLSSync";
 
-#[derive(Default)]
-pub struct TrayPrefs {
-    pub close_to_tray: Arc<AtomicBool>,
-}
-
-impl TrayPrefs {
-    pub fn new(default_close_to_tray: bool) -> Self {
-        Self {
-            close_to_tray: Arc::new(AtomicBool::new(default_close_to_tray)),
-        }
-    }
-    pub fn close_to_tray(&self) -> bool {
-        self.close_to_tray.load(Ordering::Relaxed)
-    }
-    pub fn set_close_to_tray(&self, value: bool) {
-        self.close_to_tray.store(value, Ordering::Relaxed);
+pub fn pending_tooltip(n: u32) -> String {
+    if n == 0 {
+        TRAY_TOOLTIP_IDLE.to_string()
+    } else {
+        format!("DLSSync — {n} games have updates")
     }
 }
 
@@ -47,8 +39,16 @@ pub fn install<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
         true,
         None::<&str>,
     )?;
+    let check_now = MenuItem::with_id(app, MENU_CHECK_NOW, "Check now", true, None::<&str>)?;
+    let apply_all =
+        MenuItem::with_id(app, MENU_APPLY_ALL, "Apply all updates", true, None::<&str>)?;
     let quit = MenuItem::with_id(app, MENU_QUIT, "Quit", true, None::<&str>)?;
-    let menu = Menu::with_items(app, &[&show, &hide, &progress, &check, &quit])?;
+    let menu = Menu::with_items(
+        app,
+        &[
+            &show, &hide, &progress, &check, &check_now, &apply_all, &quit,
+        ],
+    )?;
 
     let _tray = TrayIconBuilder::with_id(TRAY_ID)
         .tooltip(TRAY_TOOLTIP_IDLE)
@@ -75,6 +75,12 @@ pub fn install<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
             MENU_CHECK_UPDATE => {
                 show_main_window(app);
                 let _ = app.emit(TRAY_EVENT_CHECK_UPDATE, ());
+            }
+            MENU_CHECK_NOW => {
+                let _ = app.emit(EVENT_BACKGROUND_SCAN_TICK, ());
+            }
+            MENU_APPLY_ALL => {
+                let _ = app.emit(EVENT_BACKGROUND_APPLY_ALL, ());
             }
             MENU_QUIT => {
                 app.exit(0);
@@ -108,10 +114,33 @@ pub fn update_inflight<R: Runtime>(app: &AppHandle<R>, in_flight: usize) {
     let _ = tray.set_tooltip(Some(tooltip));
 }
 
+pub fn update_pending_count<R: Runtime>(app: &AppHandle<R>, n: u32) {
+    let Some(tray) = app.tray_by_id(TRAY_ID) else {
+        return;
+    };
+    let _ = tray.set_tooltip(Some(pending_tooltip(n)));
+}
+
 fn show_main_window<R: Runtime>(app: &AppHandle<R>) {
     if let Some(w) = app.get_webview_window("main") {
         let _ = w.show();
         let _ = w.unminimize();
         let _ = w.set_focus();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pending_tooltip_idle_when_zero() {
+        assert_eq!(pending_tooltip(0), TRAY_TOOLTIP_IDLE);
+    }
+
+    #[test]
+    fn pending_tooltip_reports_count() {
+        assert_eq!(pending_tooltip(1), "DLSSync — 1 games have updates");
+        assert_eq!(pending_tooltip(7), "DLSSync — 7 games have updates");
     }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "DLSSync",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "identifier": "io.github.xt0n1-t3ch.dlssync",
   "build": {
     "beforeBuildCommand": "pnpm -w run prebuild:kill && pnpm --filter dlssync-frontend build",

--- a/tests/components/NotificationsBell.test.ts
+++ b/tests/components/NotificationsBell.test.ts
@@ -67,6 +67,40 @@ describe("NotificationsBell popup (rendered)", () => {
     expect(container.querySelectorAll(".bell-item-badge[data-tint]").length).toBe(0);
   });
 
+  it("never shows a vendor logo for the app's own update (title 'DLSSync' must not match nvidia via 'dlss')", async () => {
+    notifications.set([
+      makeNotificationEntry("app_update_available", "DLSSync v1.6.4 available", "A visual overhaul of the game detail panel."),
+    ]);
+    const { container } = render(NotificationsBell, { props: { open: true, onClose: vi.fn() } });
+    await tick();
+    expect(container.querySelectorAll(".bell-item-logo").length).toBe(0);
+    expect(container.querySelector(".bell-item-badge[data-tint]")?.getAttribute("data-tint")).toBe("blue");
+  });
+
+  it("shows a vendor logo for any vendor-bound kind, with the structured vendor winning over text", async () => {
+    notifications.set([
+      makeNotificationEntry("apply_success", "Updated Cyberpunk 2077", "NVIDIA DLSS applied", { vendor: "amd" }),
+      makeNotificationEntry("apply_success", "Updated Horizon", "DLSS Frame Generation 310.6"),
+      makeNotificationEntry("backup_restored", "Restored RTX preset backup"),
+    ]);
+    const { container } = render(NotificationsBell, { props: { open: true, onClose: vi.fn() } });
+    await tick();
+    expect(container.querySelectorAll(".bell-item-logo").length).toBe(3);
+    expect(container.querySelectorAll(".bell-item-badge[data-tint]").length).toBe(0);
+  });
+
+  it("never shows a vendor logo for app/scan/refresh kinds even when the text names a vendor", async () => {
+    notifications.set([
+      makeNotificationEntry("scan_failed", "Library scan failed", "NVIDIA driver enumeration error"),
+      makeNotificationEntry("catalog_refresh_failed", "Catalog refresh failed", "RTX manifest unreachable"),
+      makeNotificationEntry("dll_updates_available", "8 updates ready in 1 game", "Open the Library to apply them"),
+    ]);
+    const { container } = render(NotificationsBell, { props: { open: true, onClose: vi.fn() } });
+    await tick();
+    expect(container.querySelectorAll(".bell-item-logo").length).toBe(0);
+    expect(container.querySelectorAll(".bell-item-badge[data-tint]").length).toBe(3);
+  });
+
   it("renders external link actions: release entry gets GitHub + Nexus, driver entry gets one", async () => {
     notifications.set([
       makeNotificationEntry("app_update_available", "DLSSync v1.6.0 available", "Fixed XeSS", {

--- a/tests/components/anticheatApplyRisk.test.ts
+++ b/tests/components/anticheatApplyRisk.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { resolve, dirname } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const root = resolve(here, "../../frontend/src");
+const drawer = readFileSync(resolve(root, "components/GameDetailDrawer.svelte"), "utf8");
+const enCatalog = JSON.parse(readFileSync(resolve(root, "lib/i18n/locales/en.json"), "utf8"));
+const esCatalog = JSON.parse(readFileSync(resolve(root, "lib/i18n/locales/es.json"), "utf8"));
+
+function ruleBody(css: string, selector: string): string {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const re = new RegExp(`${escaped}\\s*\\{([^}]*)\\}`);
+  return re.exec(css)?.[1] ?? "";
+}
+
+describe("GameDetailDrawer — apply-time anti-cheat risk (the differentiator)", () => {
+  it("surfaces a stable ac-apply-risk element gated on acActive at the apply footer", () => {
+    expect(drawer).toMatch(/class="ac-apply-risk"/);
+    expect(drawer).toMatch(/\{#if acActive && selectedCount > 0\}[\s\S]*?ac-apply-risk/);
+  });
+
+  it("colors the apply-time risk chip by severity using --warning / --danger tokens", () => {
+    expect(drawer).toMatch(/class:is-warning=\{acSeverity !== "danger"\}/);
+    expect(drawer).toMatch(/class:is-danger=\{acSeverity === "danger"\}/);
+    const warn = ruleBody(drawer, ".ac-apply-risk.is-warning");
+    expect(warn).toMatch(/var\(--warning\)/);
+    const danger = ruleBody(drawer, ".ac-apply-risk.is-danger");
+    expect(danger).toMatch(/var\(--danger\)/);
+  });
+
+  it("the apply button dispatches through requestApply (the danger gate), not applySelected directly", () => {
+    expect(drawer).toMatch(/class="btn btn-primary halo is-update foot-apply"[\s\S]*?onclick=\{requestApply\}/);
+    expect(drawer).not.toMatch(/foot-apply"[\s\S]*?onclick=\{applySelected\}/);
+  });
+
+  it("danger severity requires an explicit confirm before the apply dispatches", () => {
+    expect(drawer).toMatch(
+      /if \(acActive && acSeverity === "danger" && !acConfirming\) \{\s*acConfirming = true;\s*return;\s*\}/,
+    );
+    expect(drawer).toMatch(/void applySelected\(\);/);
+  });
+
+  it("renders a stable ac-apply-confirm affordance with an accessible alertdialog role", () => {
+    expect(drawer).toMatch(/\{#if acConfirming\}[\s\S]*?class="ac-apply-confirm"/);
+    expect(drawer).toMatch(/class="ac-apply-confirm" role="alertdialog"/);
+  });
+
+  it("the confirm offers an explicit proceed (apply anyway) and a cancel — never hard-blocks", () => {
+    expect(drawer).toMatch(/class="btn btn-sm btn-danger ac-confirm-proceed"\s*onclick=\{requestApply\}/);
+    expect(drawer).toMatch(/class="btn btn-sm btn-ghost ac-confirm-cancel"\s*onclick=\{cancelApplyConfirm\}/);
+    expect(drawer).toMatch(/function cancelApplyConfirm\(\): void \{\s*acConfirming = false;\s*\}/);
+  });
+
+  it("warning severity (e.g. Denuvo) only shows the chip and never enters the confirm gate", () => {
+    expect(drawer).toMatch(/acSeverity === "danger" && !acConfirming/);
+    expect(drawer).not.toMatch(/acSeverity !== "danger" && !acConfirming/);
+  });
+
+  it("respects reduced-motion for the confirm reveal", () => {
+    expect(drawer).toMatch(/@media \(prefers-reduced-motion: reduce\)[\s\S]*?\.ac-apply-confirm \{ animation: none/);
+  });
+
+  it("resets the confirm state when switching games", () => {
+    expect(drawer).toMatch(/\$effect\(\(\) => \{\s*if \(gameId\) acConfirming = false;\s*\}\);/);
+  });
+});
+
+describe("anti-cheat apply-risk i18n parity", () => {
+  const en = enCatalog.component.gameDrawer.anticheat.apply;
+  const es = esCatalog.component.gameDrawer.anticheat.apply;
+
+  it("EN defines every apply-time anti-cheat string", () => {
+    for (const k of [
+      "chipRisk",
+      "chipBan",
+      "chipTitle",
+      "applyAnyway",
+      "confirmAria",
+      "confirmBody",
+      "confirmBodyGeneric",
+      "confirmProceed",
+      "confirmCancel",
+    ]) {
+      expect(typeof en[k], `en ${k}`).toBe("string");
+      expect(en[k].length, `en ${k} non-empty`).toBeGreaterThan(0);
+    }
+  });
+
+  it("ES mirrors the EN keys and keeps the {names} placeholder where EN has it", () => {
+    expect(Object.keys(es).sort()).toEqual(Object.keys(en).sort());
+    expect(es.confirmBody).toContain("{names}");
+    expect(es.chipTitle).toContain("{names}");
+  });
+
+  it("the danger confirm copy warns about a ban in both locales", () => {
+    expect(en.confirmBody.toLowerCase()).toContain("ban");
+    expect(es.confirmBody.toLowerCase()).toContain("baneo");
+  });
+});

--- a/tests/components/backgroundSettings.test.ts
+++ b/tests/components/backgroundSettings.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { tick } from "svelte";
+import { render, fireEvent, cleanup } from "@testing-library/svelte";
+import { DEFAULT_BACKGROUND_CONFIG, type AppSettings } from "@/lib/api";
+
+function fullSettings(over: Partial<AppSettings> = {}): AppSettings {
+  return {
+    launcher_overrides: { steam: [], epic: [], gog: [], ubisoft: [], ea_desktop: [], xbox: [], battlenet: [], custom: [] },
+    update_prefs: {
+      update_dlss: true,
+      update_dlss_fg: true,
+      update_dlss_rr: true,
+      update_streamline: false,
+      update_reflex: true,
+      update_xess: true,
+      update_fsr: true,
+      update_direct_storage: true,
+      create_backups: true,
+      auto_apply_all_on_rescan: false,
+    },
+    ui_prefs: {
+      theme: "dark",
+      sidebar_collapsed: false,
+      grid_density: "comfy",
+      sort_order: "default",
+      launcher_filter: "all",
+      status_filter: "all",
+      library_view_mode: "grid",
+      library_density: "comfy",
+      library_sort: "default",
+      backups_group_by: "game",
+      settings_active_tab: "general",
+      command_palette_recent: [],
+      show_support_nudge: true,
+      language: "en",
+    },
+    steam_api: { api_key: "", steam_id: "" },
+    steamgriddb: { api_key: "" },
+    window_state: { width: null, height: null, top: null, left: null, maximized: false },
+    blacklist: [],
+    ignored: [],
+    game_preferences: {},
+    advanced: {
+      dlss_debug_overlay: false,
+      verbose_logs: false,
+      allow_unsigned_dlls: false,
+      prefer_stable_channel: false,
+      apply_concurrency: 2,
+    },
+    network: { retry_attempts: 3, download_cache_ttl_secs: 300, connect_timeout_secs: 10, chunk_timeout_secs: 60 },
+    background: { ...DEFAULT_BACKGROUND_CONFIG },
+    ...over,
+  };
+}
+
+const saveSettingsSpy = vi.fn(async () => undefined);
+
+vi.mock("@/lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api")>();
+  const appPaths = {
+    root: "C:\\Users\\me\\DLSSync",
+    backups_dir: "",
+    cache_dir: "",
+    logs_dir: "",
+    settings_dir: "",
+    backups_db: "",
+    catalog_cache: "",
+    settings_file: "C:\\Users\\me\\DLSSync\\settings.json",
+  };
+  return {
+    ...actual,
+    getSettings: vi.fn(async () => fullSettings()),
+    saveSettings: (s: AppSettings) => saveSettingsSpy(s),
+    getAppPaths: vi.fn(async () => appPaths),
+    getDlssDebugOverlay: vi.fn(async () => false),
+    checkDriverUpdates: vi.fn(async () => []),
+  };
+});
+
+import Settings from "@/views/Settings.svelte";
+import { settings } from "@/lib/stores";
+
+beforeEach(() => {
+  saveSettingsSpy.mockClear();
+});
+
+afterEach(() => {
+  cleanup();
+  settings.set(null);
+});
+
+async function settle(): Promise<void> {
+  await tick();
+  await Promise.resolve();
+  await Promise.resolve();
+  await tick();
+  await tick();
+}
+
+describe("Settings — Background updates section", () => {
+  it("renders the daemon section with all five toggles and the interval select", async () => {
+    const { getByText, container } = render(Settings, { props: { onToggleTheme: vi.fn(), currentTheme: "dark" } });
+    await settle();
+
+    expect(getByText("Background updates")).toBeTruthy();
+    expect(getByText("Enable background scanning")).toBeTruthy();
+    expect(getByText("Close to tray instead of quitting")).toBeTruthy();
+    expect(getByText("Start with Windows (minimized to tray)")).toBeTruthy();
+    expect(getByText("Windows notification when updates are ready")).toBeTruthy();
+    expect(getByText("Auto-apply updates")).toBeTruthy();
+    expect(container.querySelector("#bg-interval")).not.toBeNull();
+  });
+
+  it("offers interval presets clamped within 1..168 hours", async () => {
+    const { container } = render(Settings, { props: { onToggleTheme: vi.fn(), currentTheme: "dark" } });
+    await settle();
+    const select = container.querySelector("#bg-interval") as HTMLSelectElement;
+    const values = Array.from(select.options).map((o) => Number(o.value));
+    expect(values.length).toBeGreaterThan(0);
+    expect(Math.min(...values)).toBeGreaterThanOrEqual(1);
+    expect(Math.max(...values)).toBeLessThanOrEqual(168);
+    expect(values).toContain(24);
+  });
+
+  it("persists background.enabled when the master toggle is flipped on", async () => {
+    const { getByText } = render(Settings, { props: { onToggleTheme: vi.fn(), currentTheme: "dark" } });
+    await settle();
+
+    const row = getByText("Enable background scanning").closest(".row") as HTMLElement;
+    const checkbox = row.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    expect(checkbox.checked).toBe(false);
+
+    await fireEvent.change(checkbox, { target: { checked: true } });
+    await settle();
+
+    expect(saveSettingsSpy).toHaveBeenCalled();
+    const saved = saveSettingsSpy.mock.calls.at(-1)![0] as AppSettings;
+    expect(saved.background.enabled).toBe(true);
+  });
+
+  it("persists the chosen scan interval", async () => {
+    const { container } = render(Settings, { props: { onToggleTheme: vi.fn(), currentTheme: "dark" } });
+    await settle();
+    const select = container.querySelector("#bg-interval") as HTMLSelectElement;
+    await fireEvent.change(select, { target: { value: "48" } });
+    await settle();
+
+    expect(saveSettingsSpy).toHaveBeenCalled();
+    const saved = saveSettingsSpy.mock.calls.at(-1)![0] as AppSettings;
+    expect(saved.background.interval_hours).toBe(48);
+  });
+});

--- a/tests/e2e/full-app.e2e.mjs
+++ b/tests/e2e/full-app.e2e.mjs
@@ -2,6 +2,7 @@
 import fs from "node:fs";
 import path from "node:path";
 
+const VERSION = "1.6.5";
 const CDP = process.env.DLSS_CDP || "http://127.0.0.1:9333";
 const OUT = path.join(process.env.TEMP || ".", "dlss-shots-e2e");
 fs.mkdirSync(OUT, { recursive: true });
@@ -47,7 +48,7 @@ async function check(name, fn) {
   }
 }
 
-await check("shell:mounts + 6 nav items + v1.5.2", async () => {
+await check(`shell:mounts + 6 nav items + v${VERSION}`, async () => {
   const nav = await ev(`["Library","Catalog","Drivers","Backups","Settings","About"].filter(t=>document.querySelector('button[title="'+t+'"]')).length`);
   const shell = await ev(`!!document.querySelector('.app-shell,.drivers-view,.catalog-page') || document.body.children.length>0`);
   return { pass: nav === 6 && shell, detail: `navItems=${nav} shell=${shell}` };
@@ -166,21 +167,21 @@ await check("commandPalette:opens + searches + results", async () => {
   return { pass: open, detail: `open=${open} results=${results}` };
 });
 
-await check("settings:hero version + sections (tabbed) + tab switch + toggle", async () => {
+await check(`settings:hero version + sections (tabbed) + tab switch + toggle`, async () => {
   await goto("Settings"); await sleep(900);
   const hero = await count(".settings-hero");
-  const ver = await has("1.5.2");
+  const ver = await has(VERSION);
   const sections = await count(".section-title-h, .settings-hero ~ * .section-title");
   const toggles = await count("input[type=checkbox], .row input, button[role=switch], .seg-btn");
-  const tabs = await count('[role=tab], .tab-btn, .settings-tab');
-  if (tabs > 0) { await ev(`document.querySelectorAll('[role=tab],.tab-btn,.settings-tab')[1]?.click()`); await sleep(400); }
+  const tabs = await count('[role=tab], .tab-btn, .settings-tab, .side-tab');
+  if (tabs > 0) { await ev(`document.querySelectorAll('[role=tab],.tab-btn,.settings-tab,.side-tab')[1]?.click()`); await sleep(400); }
   await shot("09-settings.png");
   return { pass: hero >= 1 && ver && sections >= 2 && toggles > 0, detail: `hero=${hero} versionShown=${ver} sectionHeadingsInDom=${sections} toggles=${toggles} tabs=${tabs}` };
 });
 
-await check("about:version v1.5.2 + manifest sources + system info", async () => {
+await check(`about:version v${VERSION} + manifest sources + system info`, async () => {
   await goto("About"); await sleep(800);
-  const ver = await ev(`(document.body.innerText.match(/v?1\\.5\\.2/)||[null])[0]`);
+  const ver = await ev(`(document.body.innerText.match(/v?${VERSION.replace(/\./g, "\\.")}/)||[null])[0]`);
   const sources = await count(".source-card");
   const sys = await has("Your system");
   await shot("10-about.png");
@@ -195,6 +196,152 @@ await check("theme:toggle flips dark/light", async () => {
   await shot("11-theme.png");
   await ev(`document.querySelector('button[title="Toggle theme"]')?.click()`); await sleep(300);
   return { pass: before !== after, detail: `before=${before} after=${after}` };
+});
+
+await check("settings:daemon background-updates section + gate semantics", async () => {
+  await goto("Settings"); await sleep(900);
+  await ev(`(()=>{const t=[...document.querySelectorAll('.side-tab')].find(b=>/general/i.test(b.textContent));if(t)t.click()})()`);
+  await sleep(500);
+
+  const sectionVisible = await has("Background updates");
+
+  const rowDisabled = async (labelText) => {
+    return await ev(`(()=>{
+      const rows = [...document.querySelectorAll('.row')];
+      const row = rows.find(r => {
+        const lbl = r.querySelector('.row-label');
+        return lbl && lbl.textContent.includes(${JSON.stringify(labelText)});
+      });
+      if (!row) return null;
+      const ctrl = row.querySelector('input[type="checkbox"],select');
+      if (!ctrl) return null;
+      return ctrl.disabled;
+    })()`);
+  };
+
+  const masterDisabled = await rowDisabled("Enable background scanning");
+  const masterChecked = await ev(`(()=>{
+    const rows = [...document.querySelectorAll('.row')];
+    const row = rows.find(r => { const lbl = r.querySelector('.row-label'); return lbl && lbl.textContent.includes("Enable background scanning"); });
+    if (!row) return null;
+    const inp = row.querySelector('input[type="checkbox"]');
+    return inp ? inp.checked : null;
+  })()`);
+
+  if (masterChecked === true) {
+    await ev(`(()=>{
+      const rows = [...document.querySelectorAll('.row')];
+      const row = rows.find(r => { const lbl = r.querySelector('.row-label'); return lbl && lbl.textContent.includes("Enable background scanning"); });
+      if (!row) return;
+      const inp = row.querySelector('input[type="checkbox"]');
+      if (inp) inp.click();
+    })()`);
+    await sleep(400);
+  }
+
+  const intervalDisabled  = await rowDisabled("Scan every");
+  const notifyDisabled    = await rowDisabled("Windows notification");
+  const autoApplyDisabled = await ev(`(()=>{
+    const rows = [...document.querySelectorAll('.row')];
+    const row = rows.find(r => {
+      const lbl = r.querySelector('.row-label');
+      return lbl && lbl.textContent.includes("Auto-apply") && /background scan/i.test(r.textContent || "");
+    });
+    if (!row) return null;
+    const ctrl = row.querySelector('input[type="checkbox"],select');
+    return ctrl ? ctrl.disabled : null;
+  })()`);
+
+  const closeToTrayDisabled  = await rowDisabled("Close to tray");
+  const runAtStartupDisabled = await rowDisabled("Start with Windows");
+
+  if (masterChecked === true) {
+    await ev(`(()=>{
+      const rows = [...document.querySelectorAll('.row')];
+      const row = rows.find(r => { const lbl = r.querySelector('.row-label'); return lbl && lbl.textContent.includes("Enable background scanning"); });
+      if (!row) return;
+      const inp = row.querySelector('input[type="checkbox"]');
+      if (inp) inp.click();
+    })()`);
+    await sleep(300);
+  }
+
+  await shot("12-settings-daemon.png");
+
+  const gatedOk   = intervalDisabled === true && notifyDisabled === true && autoApplyDisabled === true;
+  const ungatedOk = closeToTrayDisabled === false && runAtStartupDisabled === false;
+  const pass = sectionVisible && gatedOk && ungatedOk;
+  return {
+    pass,
+    detail: [
+      `sectionVisible=${sectionVisible}`,
+      `masterChecked=${masterChecked}`,
+      `gated[interval=${intervalDisabled},notify=${notifyDisabled},autoApply=${autoApplyDisabled}]`,
+      `ungated[closeToTray=${closeToTrayDisabled},runAtStartup=${runAtStartupDisabled}]`,
+    ].join(" "),
+  };
+});
+
+await check("library:apply-all affordance present when pending updates exist", async () => {
+  await goto("Library"); await sleep(900);
+  const heroCount = await count(".updates-hero");
+  const applyAllBtn = await count(".btn-apply-all, .updates-hero-apply");
+  if (heroCount === 0) {
+    return { gated: true, pass: true, detail: "GATED: no outdated DLLs in library at test time; updates-hero absent, apply-all not expected" };
+  }
+  const pass = applyAllBtn > 0;
+  await shot("13-library-apply-all.png");
+  return { pass, detail: `updatesHero=${heroCount} applyAllBtn=${applyAllBtn}` };
+});
+
+await check("gameDetail:anti-cheat apply-risk affordance (gated on data)", async () => {
+  await goto("Library"); await sleep(700);
+  const cardCount = await count(".game-card");
+  if (cardCount === 0) {
+    return { gated: true, pass: true, detail: "GATED: no games in library" };
+  }
+
+  let foundAcGame = false;
+  let acRiskPresent = null;
+
+  const cards = await ev(`document.querySelectorAll('.game-card').length`);
+  const limit = Math.min(Number(cards) || 0, 5);
+
+  for (let i = 0; i < limit; i++) {
+    await ev(`document.querySelectorAll('.game-card')[${i}]?.click()`);
+    await sleep(1200);
+
+    const detailOpen = await count(".detail-view");
+    if (!detailOpen) {
+      await ev(`document.querySelector('.detail-back')?.click()`);
+      await sleep(500);
+      continue;
+    }
+
+    const acBanner = await ev(`!!document.querySelector('.drawer-body .warning-banner, .detail-view .warning-banner')`);
+
+    if (acBanner) {
+      foundAcGame = true;
+      acRiskPresent = await ev(`
+        !!document.querySelector('.ac-apply-risk, .ac-apply-confirm, [class*=ac-apply]')
+      `);
+      await shot("14-ac-apply-risk.png");
+    }
+
+    await ev(`document.querySelector('.detail-back')?.click()`);
+    await sleep(500);
+
+    if (foundAcGame) break;
+  }
+
+  if (!foundAcGame) {
+    return { gated: true, pass: true, detail: "GATED: no anti-cheat game found in first 5 library entries at test time" };
+  }
+
+  return {
+    pass: acRiskPresent === true,
+    detail: `foundAcGame=${foundAcGame} acRiskPresent=${acRiskPresent} (selectors: .ac-apply-risk, .ac-apply-confirm)`,
+  };
 });
 
 await check("console:0 errors + 0 exceptions across the run", async () => {

--- a/tests/unit/backgroundAutoApply.test.ts
+++ b/tests/unit/backgroundAutoApply.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { AntiCheatReport, DetectedGame } from "@/lib/api";
+import type { ApplyTarget } from "@/lib/applyController";
+import type { OutdatedDllItem } from "@/lib/stores";
+
+const detectAnticheat = vi.fn<(dir: string, appId: string | null, name: string) => Promise<AntiCheatReport>>();
+const dispatchApply = vi.fn(async () => null);
+
+vi.mock("@/lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api")>();
+  return { ...actual, detectAnticheat: (...a: Parameters<typeof detectAnticheat>) => detectAnticheat(...a) };
+});
+
+vi.mock("@/lib/applyController", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/applyController")>();
+  return {
+    ...actual,
+    dispatchApply: (...a: unknown[]) => (dispatchApply as unknown as (...x: unknown[]) => Promise<null>)(...a),
+  };
+});
+
+const cleanReport: AntiCheatReport = { detected: [], status: null, source_url: null };
+const flaggedReport: AntiCheatReport = {
+  detected: [{ anticheat: "EAC", kind: "anti_cheat", source: "dataset" }],
+  status: null,
+  source_url: null,
+};
+
+function game(id: string): DetectedGame {
+  return {
+    id,
+    name: id,
+    launcher: "steam",
+    install_dir: `C:\\Games\\${id}`,
+    app_id: null,
+    image_url: null,
+    size_bytes: null,
+  };
+}
+
+function item(gameId: string): OutdatedDllItem {
+  return {
+    game: game(gameId),
+    record: {
+      family: "dlss_sr",
+      path: `C:\\Games\\${gameId}\\nvngx_dlss.dll`,
+      current_version: "1.0.0.0",
+      file_description: null,
+      sha256: null,
+    },
+    target: "2.0.0.0",
+  };
+}
+
+let autoApplyExcludingAntiCheat: typeof import("@/lib/backgroundScan").autoApplyExcludingAntiCheat;
+
+beforeEach(async () => {
+  detectAnticheat.mockReset();
+  dispatchApply.mockClear();
+  ({ autoApplyExcludingAntiCheat } = await import("@/lib/backgroundScan"));
+});
+
+describe("autoApplyExcludingAntiCheat", () => {
+  it("no-ops on an empty set", async () => {
+    await autoApplyExcludingAntiCheat([]);
+    expect(dispatchApply).not.toHaveBeenCalled();
+  });
+
+  it("dispatches every item when no game is anti-cheat flagged", async () => {
+    detectAnticheat.mockResolvedValue(cleanReport);
+    await autoApplyExcludingAntiCheat([item("a"), item("b")]);
+    expect(dispatchApply).toHaveBeenCalledTimes(1);
+    const targets = dispatchApply.mock.calls[0][0] as ApplyTarget[];
+    expect(targets.map((t) => t.game_id).sort()).toEqual(["a", "b"]);
+  });
+
+  it("excludes anti-cheat-flagged games from the batch", async () => {
+    detectAnticheat.mockImplementation(async (_dir, _appId, name) =>
+      name === "blocked" ? flaggedReport : cleanReport,
+    );
+    await autoApplyExcludingAntiCheat([item("safe"), item("blocked")]);
+    expect(dispatchApply).toHaveBeenCalledTimes(1);
+    const targets = dispatchApply.mock.calls[0][0] as ApplyTarget[];
+    expect(targets.map((t) => t.game_id)).toEqual(["safe"]);
+  });
+
+  it("dispatches nothing when every pending game is anti-cheat flagged", async () => {
+    detectAnticheat.mockResolvedValue(flaggedReport);
+    await autoApplyExcludingAntiCheat([item("a"), item("b")]);
+    expect(dispatchApply).not.toHaveBeenCalled();
+  });
+
+  it("keeps a game in (relies on backend guards) when the anti-cheat probe throws", async () => {
+    detectAnticheat.mockRejectedValue(new Error("probe boom"));
+    await autoApplyExcludingAntiCheat([item("a")]);
+    expect(dispatchApply).toHaveBeenCalledTimes(1);
+    const targets = dispatchApply.mock.calls[0][0] as ApplyTarget[];
+    expect(targets.map((t) => t.game_id)).toEqual(["a"]);
+  });
+
+  it("probes each distinct game once, not once per DLL", async () => {
+    detectAnticheat.mockResolvedValue(cleanReport);
+    const a1 = item("a");
+    const a2 = item("a");
+    await autoApplyExcludingAntiCheat([a1, a2]);
+    expect(detectAnticheat).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/backgroundScan.test.ts
+++ b/tests/unit/backgroundScan.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  handleScanTick,
+  handleApplyAll,
+  type BackgroundDeps,
+} from "@/lib/backgroundScan";
+import type { OutdatedDllItem } from "@/lib/stores";
+import type { DetectedGame } from "@/lib/api";
+import { BACKGROUND_SCAN_TICK_EVENT, BACKGROUND_APPLY_ALL_EVENT } from "@/lib/api";
+
+function game(id: string, over: Partial<DetectedGame> = {}): DetectedGame {
+  return {
+    id,
+    name: id,
+    launcher: "steam",
+    install_dir: `C:\\Games\\${id}`,
+    app_id: null,
+    image_url: null,
+    size_bytes: null,
+    ...over,
+  };
+}
+
+function item(gameId: string): OutdatedDllItem {
+  return {
+    game: game(gameId),
+    record: {
+      family: "dlss_sr",
+      path: `C:\\Games\\${gameId}\\nvngx_dlss.dll`,
+      current_version: "1.0.0.0",
+      file_description: null,
+      sha256: null,
+    },
+    target: "2.0.0.0",
+  };
+}
+
+const CONFIG_DEFAULT = {
+  enabled: true,
+  interval_hours: 24,
+  close_to_tray: false,
+  run_at_startup: false,
+  notify_os_toast: true,
+  auto_apply: false,
+};
+
+function makeDeps(over: Partial<BackgroundDeps> = {}, cfg: Partial<typeof CONFIG_DEFAULT> = {}): BackgroundDeps {
+  return {
+    isScanning: () => false,
+    isApplyInflight: () => false,
+    scanGames: vi.fn(async () => undefined),
+    loadCatalog: vi.fn(async () => undefined),
+    emitDigest: vi.fn(),
+    pendingDigest: () => ({ total: 0, games: 0 }),
+    outdatedItems: () => [],
+    config: () => ({ ...CONFIG_DEFAULT, ...cfg }),
+    setTrayPending: vi.fn(async () => undefined),
+    notifyToast: vi.fn(async () => true),
+    autoApply: vi.fn(async () => undefined),
+    triggerApplyAll: vi.fn(),
+    ...over,
+  };
+}
+
+describe("handleScanTick — guards", () => {
+  it("no-ops entirely when the daemon is disabled", async () => {
+    const scanGames = vi.fn(async () => undefined);
+    const deps = makeDeps({ scanGames }, { enabled: false });
+    await handleScanTick(deps);
+    expect(scanGames).not.toHaveBeenCalled();
+    expect(deps.setTrayPending).not.toHaveBeenCalled();
+  });
+
+  it("skips when a scan is already in progress", async () => {
+    const scanGames = vi.fn(async () => undefined);
+    const deps = makeDeps({ isScanning: () => true, scanGames });
+    await handleScanTick(deps);
+    expect(scanGames).not.toHaveBeenCalled();
+  });
+
+  it("skips when an apply is inflight", async () => {
+    const scanGames = vi.fn(async () => undefined);
+    const deps = makeDeps({ isApplyInflight: () => true, scanGames });
+    await handleScanTick(deps);
+    expect(scanGames).not.toHaveBeenCalled();
+  });
+});
+
+describe("handleScanTick — scan + tray", () => {
+  it("runs scan then catalog refresh and reports the games count to the tray", async () => {
+    const order: string[] = [];
+    const scanGames = vi.fn(async () => { order.push("scan"); });
+    const loadCatalog = vi.fn(async () => { order.push("catalog"); });
+    const setTrayPending = vi.fn(async () => undefined);
+    const deps = makeDeps({
+      scanGames,
+      loadCatalog,
+      setTrayPending,
+      pendingDigest: () => ({ total: 5, games: 2 }),
+    });
+    await handleScanTick(deps);
+    expect(order).toEqual(["scan", "catalog"]);
+    expect(setTrayPending).toHaveBeenCalledWith(2);
+  });
+
+  it("reports zero to the tray and shows no toast when nothing is pending", async () => {
+    const notifyToast = vi.fn(async () => true);
+    const setTrayPending = vi.fn(async () => undefined);
+    const deps = makeDeps({
+      notifyToast,
+      setTrayPending,
+      pendingDigest: () => ({ total: 0, games: 0 }),
+    });
+    await handleScanTick(deps);
+    expect(setTrayPending).toHaveBeenCalledWith(0);
+    expect(notifyToast).not.toHaveBeenCalled();
+  });
+});
+
+describe("handleScanTick — toast", () => {
+  it("fires a native toast only when there are pending updates", async () => {
+    const notifyToast = vi.fn(async () => true);
+    const deps = makeDeps({ notifyToast, pendingDigest: () => ({ total: 3, games: 1 }) });
+    await handleScanTick(deps);
+    expect(notifyToast).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to the in-app digest when the OS toast is denied", async () => {
+    const emitDigest = vi.fn();
+    const notifyToast = vi.fn(async () => false);
+    const deps = makeDeps({ emitDigest, notifyToast, pendingDigest: () => ({ total: 3, games: 1 }) });
+    await handleScanTick(deps);
+    expect(notifyToast).toHaveBeenCalledTimes(1);
+    expect(emitDigest).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the in-app digest (no native toast) when notify_os_toast is off", async () => {
+    const emitDigest = vi.fn();
+    const notifyToast = vi.fn(async () => true);
+    const deps = makeDeps(
+      { emitDigest, notifyToast, pendingDigest: () => ({ total: 3, games: 1 }) },
+      { notify_os_toast: false },
+    );
+    await handleScanTick(deps);
+    expect(notifyToast).not.toHaveBeenCalled();
+    expect(emitDigest).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("handleScanTick — auto-apply", () => {
+  it("does not auto-apply when auto_apply is off", async () => {
+    const autoApply = vi.fn(async () => undefined);
+    const deps = makeDeps(
+      { autoApply, pendingDigest: () => ({ total: 2, games: 1 }) },
+      { auto_apply: false },
+    );
+    await handleScanTick(deps);
+    expect(autoApply).not.toHaveBeenCalled();
+  });
+
+  it("auto-applies the outdated set when auto_apply is on and updates exist", async () => {
+    const outItems = [item("a"), item("b")];
+    const autoApply = vi.fn(async () => undefined);
+    const deps = makeDeps(
+      {
+        autoApply,
+        outdatedItems: () => outItems,
+        pendingDigest: () => ({ total: 2, games: 2 }),
+      },
+      { auto_apply: true },
+    );
+    await handleScanTick(deps);
+    expect(autoApply).toHaveBeenCalledTimes(1);
+    expect(autoApply).toHaveBeenCalledWith(outItems);
+  });
+
+  it("never auto-applies when nothing is pending, even with auto_apply on", async () => {
+    const autoApply = vi.fn(async () => undefined);
+    const deps = makeDeps(
+      { autoApply, pendingDigest: () => ({ total: 0, games: 0 }) },
+      { auto_apply: true },
+    );
+    await handleScanTick(deps);
+    expect(autoApply).not.toHaveBeenCalled();
+  });
+});
+
+describe("handleApplyAll", () => {
+  it("delegates to the shared Apply-All trigger", () => {
+    const triggerApplyAll = vi.fn();
+    handleApplyAll(makeDeps({ triggerApplyAll }));
+    expect(triggerApplyAll).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("event-name contract", () => {
+  it("matches the backend tick + apply-all literals exactly", () => {
+    expect(BACKGROUND_SCAN_TICK_EVENT).toBe("background:scan-tick");
+    expect(BACKGROUND_APPLY_ALL_EVENT).toBe("background:apply-all");
+  });
+});

--- a/tests/unit/notificationVendor.test.ts
+++ b/tests/unit/notificationVendor.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { makeNotificationEntry, vendorKeyForNotification } from "@/lib/notifications";
+import type { NotificationKind } from "@/lib/notifications";
+
+const resolve = (
+  kind: NotificationKind,
+  title: string,
+  body: string | null = null,
+  vendor: string | null = null,
+): string | null => vendorKeyForNotification(makeNotificationEntry(kind, title, body, { vendor }));
+
+describe("vendorKeyForNotification — structured field is authoritative", () => {
+  it("returns the stamped vendor verbatim for any kind", () => {
+    expect(resolve("apply_success", "Updated Cyberpunk 2077", "DLSS FG 310.6", "nvidia")).toBe("nvidia");
+    expect(resolve("backup_restored", "Restored backup", null, "amd")).toBe("amd");
+    expect(resolve("catalog_update_available", "XeSS 2.0", null, "intel")).toBe("intel");
+  });
+
+  it("the stamped vendor wins over conflicting text", () => {
+    expect(resolve("apply_success", "Updated game", "NVIDIA DLSS applied", "amd")).toBe("amd");
+  });
+});
+
+describe("vendorKeyForNotification — the app's own name never reads as a vendor", () => {
+  it("does not match nvidia via the substring 'dlss' inside 'DLSSync'", () => {
+    expect(resolve("app_update_available", "DLSSync v1.6.4 available", "A visual overhaul")).toBeNull();
+  });
+
+  it("stays null even if 'DLSSync' lands in a vendor-bound kind", () => {
+    expect(resolve("catalog_update_available", "DLSSync update", "new build")).toBeNull();
+  });
+});
+
+describe("vendorKeyForNotification — app/scan/refresh kinds are never vendor-branded", () => {
+  it("returns null for app_update / scan_failed / catalog_refresh_failed despite vendor text", () => {
+    expect(resolve("app_update_available", "Update", "NVIDIA RTX news")).toBeNull();
+    expect(resolve("scan_failed", "Scan failed", "NVIDIA driver error")).toBeNull();
+    expect(resolve("catalog_refresh_failed", "Refresh failed", "RTX manifest unreachable")).toBeNull();
+  });
+});
+
+describe("vendorKeyForNotification — text fallback for un-stamped vendor-bound kinds", () => {
+  it("maps GPU feature tokens to their vendor (word-boundary safe)", () => {
+    expect(resolve("apply_success", "Updated game", "DLSS Frame Generation")).toBe("nvidia");
+    expect(resolve("catalog_update_available", "FSR 3.1 available")).toBe("amd");
+    expect(resolve("catalog_update_available", "XeSS 2.0 available")).toBe("intel");
+    expect(resolve("catalog_update_available", "DirectStorage 1.2")).toBe("microsoft");
+  });
+
+  it("maps vendor names and GPU brands via the shared brand resolver", () => {
+    expect(resolve("driver_update_available", "GPU driver 999 — NVIDIA GeForce RTX 4070")).toBe("nvidia");
+    expect(resolve("driver_update_available", "AMD Radeon RX 7900 driver")).toBe("amd");
+    expect(resolve("driver_update_available", "Intel Arc A770 driver")).toBe("intel");
+  });
+
+  it("returns null when no vendor signal is present", () => {
+    expect(resolve("dll_updates_available", "8 updates ready in 1 game", "Open the Library")).toBeNull();
+    expect(resolve("apply_success", "Updated game", "done")).toBeNull();
+  });
+});


### PR DESCRIPTION
## v1.6.5

**Background updates daemon (opt-in):** scheduled library scan even when hidden, system-tray pending-count + menu (Show / Check now / Apply all / Quit), close-to-tray, run-at-Windows-startup, native Windows toast, one-click **Apply all updates**, and anti-cheat-safe auto-apply.

**Anti-cheat ban-risk at the apply step:** risk chip next to Apply + an explicit confirm before replacing DLLs in EAC/BattlEye/VAC games.

**Notifications:** structured per-vendor logos (no more app-release-wearing-NVIDIA), DB-enforced dedup that prunes legacy duplicates on launch, apply notifications no longer swallowed after the first per game.

**Security:** manifest Ed25519 verification (fail-closed enforcement staged off until the signed manifest is propagated), env-override disabled in release builds, Authenticode whole-chain revocation, zip measured-size guard, download-cache + rollback-path fixes. Bumped vitest to 4.x — clears CVE-2026-47429 (both Dependabot alerts).

### Verification
- cargo fmt / clippy `-D warnings` / test --workspace: clean / 0 / 0 failed
- svelte-check 0/0 · vitest v4 441 passed
- real e2e (`tests/e2e/full-app.e2e.mjs`): **16 pass / 0 fail / 0 console errors** (2 gated: jsdelivr propagation + no-AC-game)

Full notes in [CHANGELOG.md](CHANGELOG.md).