### PR TITLE
fix(polish): post-1.6.5 accuracy + tray plural

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ DLSSync can keep your DLLs current on its own now — a background daemon that s
 ### Added
 
 - Background updates. Turn it on and DLSSync rescans your library on a schedule (every 1 to 168 hours) even with the window closed, shows how many games have updates ready in the tray, and raises a Windows notification when something is waiting. It can close to the tray instead of quitting, start with Windows minimized, and apply everything in one click from the tray, the notification, or the Library header. Optional auto-apply always skips anti-cheat games and makes a backup first. Off by default.
-- A ban-risk warning at the moment you apply. Games protected by EAC, BattlEye, or VAC now show a risk chip next to Apply and ask for one explicit confirmation before any DLL is replaced — the warning lands at the apply step, not buried in a panel.
+- A ban-risk warning at the moment you apply. Games protected by Easy Anti-Cheat, BattlEye, or Riot Vanguard now show a risk chip next to Apply and ask for one explicit confirmation before any DLL is replaced — the warning lands at the apply step, not buried in a panel.
 - Manifest signature verification (Ed25519) against a key baked into the app. Verification ships now; fail-closed enforcement is staged for a later release, once the signed manifest is live across the CDN.
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 </p>
 
 <p align="center">
-  <sub><b>New in v1.6.3:</b> DLSSync now speaks English and Spanish — switch from the globe button in the sidebar, and translate it into any language by editing a plain JSON file (<a href="docs/translations.md">guide</a>). Under a detected DLSS Enabler it also updates the Streamline set within the same major version again, so you can give the Enabler the Streamline 2.11+ it needs without the cross-major swap that crashes games. See <a href="CHANGELOG.md#163---2026-06-01">CHANGELOG</a>.</sub>
+  <sub><b>New in v1.6.5:</b> DLSSync can now keep your DLLs current on its own — an opt-in background daemon scans on a schedule even when the window is closed, lives in the system tray, and applies everything in one click. It also warns you before you touch a game that can ban you for it: titles protected by Easy Anti-Cheat, BattlEye, or Riot Vanguard show a ban-risk chip and ask for confirmation right at the apply step. See <a href="CHANGELOG.md#165---2026-06-03">CHANGELOG</a>.</sub>
 </p>
 
 <p align="center">
@@ -294,6 +294,7 @@ cargo check --workspace
 - [x] v1.0: Windows portable, NSIS installer, auto-update banner, tray, EcoQoS Efficiency Mode, all 7 launchers, hash and Authenticode gates, Apache 2.0.
 - [x] v1.2: Apply pipeline hardening — shared per-URL download cache, streaming downloads with retry ladder, per-apply cancellation, failure-centric apply modal, tray inflight badge.
 - [x] v1.5: GPU driver updater for NVIDIA, AMD and Intel with per-card version history and signature-verified installs; DLSS preset and frame-generation overrides through the NVIDIA driver profile; per-game anti-cheat and anti-tamper detection; broader FSR and XeSS coverage; redesigned Library, Drivers tab and game drawer.
+- [x] v1.6: NVIDIA Streamline set updater with version-scheme awareness, a background-update daemon (scheduled scans, system tray, one-click Apply All, run-at-startup), apply-time anti-cheat ban-risk warnings, Ed25519-signed manifests, and English/Spanish localization.
 - [ ] Next: SignPath OSS Authenticode signing to remove the SmartScreen warning on first run.
 - [ ] Later: per-DLL changelog viewer with a diff against the installed build, and custom catalog sources for community-maintained DLL trees.
 

--- a/crates/dll-catalog/src/lib.rs
+++ b/crates/dll-catalog/src/lib.rs
@@ -218,8 +218,9 @@ const MANIFEST_SIGNATURE_SUFFIX: &str = ".sig";
 /// Production Ed25519 public verification key (32 bytes, hex) for the DLSSync
 /// manifest. The matching private key is provisioned out-of-band and never lives
 /// in the repo; the manifest pipeline signs `manifest.json` into
-/// `manifest.json.sig` with it. A release build verifies every manifest against
-/// this key and fails closed on a missing/invalid signature.
+/// `manifest.json.sig` with it. Verification runs and logs in every build;
+/// fail-closed enforcement is staged off (see `ENFORCE_MANIFEST_SIGNATURE`)
+/// until the signed manifest is confirmed propagated across the CDN.
 pub const MANIFEST_PUBKEY_HEX: &str =
     "e9dd0828f9ee5ecb72e0a811723a79c6e5373ca1c20bd5b255d68a2b3928fcd3";
 

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -21,10 +21,10 @@ pub const EVENT_BACKGROUND_APPLY_ALL: &str = "background:apply-all";
 pub const TRAY_TOOLTIP_IDLE: &str = "DLSSync";
 
 pub fn pending_tooltip(n: u32) -> String {
-    if n == 0 {
-        TRAY_TOOLTIP_IDLE.to_string()
-    } else {
-        format!("DLSSync — {n} games have updates")
+    match n {
+        0 => TRAY_TOOLTIP_IDLE.to_string(),
+        1 => "DLSSync — 1 game has an update".to_string(),
+        _ => format!("DLSSync — {n} games have updates"),
     }
 }
 
@@ -140,7 +140,7 @@ mod tests {
 
     #[test]
     fn pending_tooltip_reports_count() {
-        assert_eq!(pending_tooltip(1), "DLSSync — 1 games have updates");
+        assert_eq!(pending_tooltip(1), "DLSSync — 1 game has an update");
         assert_eq!(pending_tooltip(7), "DLSSync — 7 games have updates");
     }
 }


### PR DESCRIPTION
Post-1.6.5 accuracy/polish (rides the next release):
- Tray tooltip pluralized ("1 game has an update" vs "N games have updates") + test.
- CHANGELOG [1.6.5]: anti-cheat examples corrected — VAC is server-side (never detected on-disk); use Easy Anti-Cheat / BattlEye / Riot Vanguard (actual signature-detected systems).
- MANIFEST_PUBKEY_HEX doc-comment: reflect staged verify-and-log (enforcement off), not the inaccurate 'fails closed' claim.
- README: headline v1.6.3 → v1.6.5 + v1.6 added to the shipped roadmap.

No functional change beyond the tray string. Gate: cargo fmt/clippy clean, tray tests pass.