### PR TITLE
release: v1.6.6 - apply minimize-to-dock, Backups month timeline, sidebar revamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to DLSSync are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.6] - 2026-06-07
+
+Quality-of-life on the X button, the apply modal, and Backups. The X minimizes to the system tray for new installs while your saved choice still wins. The Apply Progress wall is gone: close the modal mid-apply, navigate to Catalog or About, then pick it back up from the activity dock. And the date-grouped Backups view divides itself into month headers, so months of history read at a glance instead of a flat scroll.
+
+### Added
+
+- A token-driven `<CounterPill>` component shared by every sidebar counter so the badges line up the same way everywhere.
+- Three intent-named sidebar groups (Library, Catalog & Drivers, History) plus the existing General. Same icons, same view names, clearer headers.
+- A bundle-size contract test that fails the build if the main JS chunk exceeds 250 KB gzip or the CSS exceeds 75 KB gzip.
+- A rotating chevron on the language switcher tied to `aria-expanded` so the menu state reads correctly to screen readers and to the eye.
+- A month header divides the Backups date-grouped view at every month boundary, so multi-month histories read at a glance instead of a long flat list.
+- An axe-core accessibility contract over the core components (CounterPill, BrandMark, Checkbox, Toast) that fails the build on any critical or serious WCAG violation.
+
+### Changed
+
+- Close-to-tray is on by default for new installs. An explicit `false` from a prior config is preserved — never silently re-enabled.
+- The Apply Progress modal can be closed while applies are still running. Click the X, hit Escape, or click outside, and it minimizes to the activity dock. The apply keeps going, the rest of the app is yours. A one-time hint shows you where the dock is the first time.
+- The apply pipeline's pure decisions (error classification, signature-error hinting, version-major parsing, the Streamline cross-major ban check, the failure-outcome shape) moved into their own module with a focused 14-test cargo suite. The 400-line apply hot path stays the orchestrator; the decisions get their own contract.
+- Driver history and Catalog versions flyouts share a `<FlyoutShell>` primitive now. Backdrop, dialog frame, vendor-accent routing, and the Escape-close behavior live in one place instead of repeated in each consumer.
+
+### Fixed
+
+- Two concurrent driver checks used to collect WMI/DXGI system info twice in parallel under a stale read-lock pattern. A coordinator now serializes the collection so it runs exactly once, and the cached value is reused.
+- Large DLL copies during apply no longer block the tokio runtime — every `std::fs::copy` is wrapped in `spawn_blocking` so download-progress emits, cancellation signals, and tray pings stay responsive even while the file copy runs.
+
 ## [1.6.5] - 2026-06-03
 
 DLSSync can keep your DLLs current on its own now — a background daemon that scans on a schedule, sits in the tray, and warns you before you touch a game that can ban you for it.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "anticheat-detect"
-version = "1.6.5"
+version = "1.6.6"
 dependencies = [
  "jwalk",
  "memchr",
@@ -352,7 +352,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "backup-store"
-version = "1.6.5"
+version = "1.6.6"
 dependencies = [
  "chrono",
  "rusqlite",
@@ -1143,7 +1143,7 @@ dependencies = [
 
 [[package]]
 name = "dll-catalog"
-version = "1.6.5"
+version = "1.6.6"
 dependencies = [
  "bytes",
  "chrono",
@@ -1168,7 +1168,7 @@ dependencies = [
 
 [[package]]
 name = "dll-scanner"
-version = "1.6.5"
+version = "1.6.6"
 dependencies = [
  "jwalk",
  "once_cell",
@@ -1205,7 +1205,7 @@ dependencies = [
 
 [[package]]
 name = "dlssync"
-version = "1.6.5"
+version = "1.6.6"
 dependencies = [
  "anticheat-detect",
  "anyhow",
@@ -1287,7 +1287,7 @@ dependencies = [
 
 [[package]]
 name = "driver-catalog"
-version = "1.6.5"
+version = "1.6.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1303,7 +1303,7 @@ dependencies = [
 
 [[package]]
 name = "driver-install"
-version = "1.6.5"
+version = "1.6.6"
 dependencies = [
  "dll-catalog",
  "futures-util",
@@ -2639,7 +2639,7 @@ dependencies = [
 
 [[package]]
 name = "launcher-scan"
-version = "1.6.5"
+version = "1.6.6"
 dependencies = [
  "serde",
  "serde_json",
@@ -2776,7 +2776,7 @@ dependencies = [
 
 [[package]]
 name = "manifest-builder"
-version = "1.6.5"
+version = "1.6.6"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2962,7 +2962,7 @@ dependencies = [
 
 [[package]]
 name = "notifications-store"
-version = "1.6.5"
+version = "1.6.6"
 dependencies = [
  "chrono",
  "rusqlite",
@@ -3054,7 +3054,7 @@ dependencies = [
 
 [[package]]
 name = "nvapi-drs"
-version = "1.6.5"
+version = "1.6.6"
 dependencies = [
  "serde",
  "windows-sys 0.59.0",
@@ -3417,7 +3417,7 @@ checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "pe-version"
-version = "1.6.5"
+version = "1.6.6"
 dependencies = [
  "pelite",
  "serde",
@@ -4826,7 +4826,7 @@ dependencies = [
 
 [[package]]
 name = "system-drivers"
-version = "1.6.5"
+version = "1.6.6"
 dependencies = [
  "serde",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["src-tauri", "crates/*"]
 
 [workspace.package]
-version = "1.6.5"
+version = "1.6.6"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/xt0n1-t3ch/DLSSync"

--- a/crates/driver-install/src/state.rs
+++ b/crates/driver-install/src/state.rs
@@ -74,6 +74,10 @@ impl InstallPhase {
     }
 }
 
+pub fn reboot_required(code: i32) -> bool {
+    code == EXIT_REBOOT_REQUIRED
+}
+
 pub fn classify_exit(code: i32) -> InstallStage {
     match code {
         EXIT_OK | EXIT_REBOOT_REQUIRED => InstallStage::Completed,
@@ -158,6 +162,14 @@ mod tests {
             assert!(terminal.is_terminal());
             assert!(!terminal.can_advance_to(InstallStage::Installing));
         }
+    }
+
+    #[test]
+    fn reboot_required_true_only_for_3010() {
+        assert!(reboot_required(3010));
+        assert!(!reboot_required(0));
+        assert!(!reboot_required(1602));
+        assert!(!reboot_required(1));
     }
 
     #[test]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dlssync-frontend",
   "private": true,
-  "version": "1.6.5",
+  "version": "1.6.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/ApplyProgressModal.svelte
+++ b/frontend/src/components/ApplyProgressModal.svelte
@@ -313,6 +313,26 @@
     onClose();
   }
 
+  // v1.7: close the modal WITHOUT clearing in-flight applies. The ActivityDock
+  // keeps tracking the same `activeApplies` store and the user can click its
+  // expand chevron at any time to re-open the modal. We never lose progress.
+  async function pin(): Promise<void> {
+    onClose();
+    if (!anyRunning) return;
+    try {
+      if (!localStorage.getItem("dlssync.applyPinHintSeen")) {
+        localStorage.setItem("dlssync.applyPinHintSeen", "1");
+        showToast(
+          "info",
+          translate(get(locale), "component.applyModal.toast.movedToDock"),
+        );
+      }
+    } catch {
+      // localStorage may be blocked (private window, exotic config). Silent
+      // skip is safe — at worst the hint shows once next session.
+    }
+  }
+
   async function handleRetryGroup(g: ApplyGroup): Promise<void> {
     if (busy) return;
     busy = true;
@@ -540,9 +560,12 @@
   class="backdrop"
   transition:fade={{ duration: 150 }}
   role="presentation"
-  onclick={() => allDone && dismiss()}
+  onclick={() => (allDone ? void dismiss() : void pin())}
   onkeydown={(e) => {
-    if (e.key === "Escape" && allDone) void dismiss();
+    if (e.key === "Escape") {
+      if (allDone) void dismiss();
+      else void pin();
+    }
   }}
   tabindex="-1"
 ></div>
@@ -586,10 +609,13 @@
     </div>
     <button
       class="dialog-close"
-      onclick={() => allDone && dismiss()}
-      disabled={!allDone}
-      title={allDone ? $t("common.close") : $t("component.applyModal.closeBlockedTitle")}
-      aria-label={$t("common.close")}
+      onclick={() => (allDone ? void dismiss() : void pin())}
+      title={allDone
+        ? $t("common.close")
+        : $t("component.applyModal.action.minimize")}
+      aria-label={allDone
+        ? $t("common.close")
+        : $t("component.applyModal.action.minimize")}
     >
       <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
     </button>

--- a/frontend/src/components/CatalogVersionsFlyout.svelte
+++ b/frontend/src/components/CatalogVersionsFlyout.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { onMount } from "svelte";
   import { get } from "svelte/store";
-  import { fly } from "svelte/transition";
   import { t, locale, translate } from "../lib/i18n/index";
   import { listReleases, type Release } from "../lib/api";
   import {
@@ -17,6 +16,7 @@
   import { mergeFamilyReleases } from "../lib/catalogReleases";
   import FeatureIcon from "./FeatureIcon.svelte";
   import Checkbox from "./Checkbox.svelte";
+  import FlyoutShell from "./FlyoutShell.svelte";
 
   let {
     vendor,
@@ -203,14 +203,12 @@
     }
   }
 
-  function handleKey(e: KeyboardEvent): void {
-    if (e.key === "Escape") {
-      e.stopPropagation();
-      if (mode === "versions" && catalogKey === "advanced") {
-        backToModules();
-      } else {
-        onClose();
-      }
+  function onEscape(e: KeyboardEvent): void {
+    e.stopPropagation();
+    if (mode === "versions" && catalogKey === "advanced") {
+      backToModules();
+    } else {
+      onClose();
     }
   }
 
@@ -222,8 +220,14 @@
   }
 </script>
 
-<div class="flyout-backdrop" role="presentation" onclick={onClose} onkeydown={handleKey} tabindex="-1"></div>
-<div class="flyout glass-dialog" transition:fly={{ y: -8, duration: 160 }} style:--edge-color={accent} role="dialog" aria-label={headerTitle} tabindex="-1" onkeydown={handleKey}>
+<FlyoutShell
+  {onClose}
+  {accent}
+  {onEscape}
+  ariaLabel={headerTitle}
+  backdropOpacity={0.45}
+  backdropBlur={3}
+>
   <header class="flyout-head">
     {#if mode === "versions" && catalogKey === "advanced"}
       <button class="flyout-back" onclick={backToModules} aria-label={$t("component.flyout.backToModules")}>
@@ -362,27 +366,9 @@
       <span class="foot-count">{$t("component.flyout.versionCount", { shown: filtered.length, count: releases.length })}</span>
     </footer>
   {/if}
-</div>
+</FlyoutShell>
 
 <style>
-  .flyout-backdrop {
-    position: fixed;
-    inset: 0;
-    background: rgba(0, 0, 0, 0.45);
-    backdrop-filter: blur(3px);
-    z-index: 220;
-  }
-  .flyout {
-    position: fixed;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    width: min(720px, 94vw);
-    max-height: 84vh;
-    display: flex;
-    flex-direction: column;
-    z-index: 221;
-  }
   .flyout-head {
     padding: 18px 52px 14px 20px;
     border-bottom: 1px solid var(--border);

--- a/frontend/src/components/CounterPill.svelte
+++ b/frontend/src/components/CounterPill.svelte
@@ -1,0 +1,66 @@
+<script lang="ts">
+  type Tone = "default" | "update" | "success" | "warning" | "danger";
+
+  let {
+    count,
+    tone = "default",
+    collapsed = false,
+    overlay = false,
+    ariaLabel,
+  }: {
+    count: number;
+    tone?: Tone;
+    collapsed?: boolean;
+    overlay?: boolean;
+    ariaLabel?: string;
+  } = $props();
+
+  let display = $derived(count > 99 ? "99+" : String(count));
+</script>
+
+{#if count > 0}
+  <span
+    class="counter-pill tone-{tone}"
+    class:is-collapsed={collapsed}
+    class:is-overlay={overlay}
+    aria-label={ariaLabel}
+  >
+    {display}
+  </span>
+{/if}
+
+<style>
+  .counter-pill {
+    font-family: var(--font-mono);
+    font-size: var(--fs-2xs);
+    font-weight: 700;
+    padding: 1px 7px;
+    border-radius: var(--radius-full);
+    background: var(--bg-elevated);
+    color: var(--text-muted);
+    font-variant-numeric: tabular-nums;
+    min-width: 18px;
+    text-align: center;
+    line-height: var(--lh-tight);
+    display: inline-block;
+  }
+  .counter-pill.tone-update { background: var(--update-dim); color: var(--update); }
+  .counter-pill.tone-success { background: var(--success-dim); color: var(--success); }
+  .counter-pill.tone-warning { background: var(--warning-dim); color: var(--warning); }
+  .counter-pill.tone-danger { background: var(--danger-dim); color: var(--danger); }
+
+  .counter-pill.is-collapsed {
+    position: absolute;
+    top: 2px;
+    right: 2px;
+    padding: 0 4px;
+    min-width: 14px;
+  }
+
+  .counter-pill.is-overlay {
+    position: absolute;
+    top: -4px;
+    right: -4px;
+    box-shadow: 0 0 0 2px var(--bg-base);
+  }
+</style>

--- a/frontend/src/components/DriverHistoryFlyout.svelte
+++ b/frontend/src/components/DriverHistoryFlyout.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
   import { onMount } from "svelte";
   import { get } from "svelte/store";
-  import { fly } from "svelte/transition";
   import { t, locale, translate } from "../lib/i18n/index";
   import Checkbox from "./Checkbox.svelte";
+  import FlyoutShell from "./FlyoutShell.svelte";
   import {
     driverHistory,
     driverHistoryLoading,
@@ -106,27 +106,14 @@
       installingVersion = null;
     }
   }
-
-  function handleKey(e: KeyboardEvent): void {
-    if (e.key === "Escape") onClose();
-  }
 </script>
 
-<div
-  class="flyout-backdrop"
-  role="presentation"
-  onclick={onClose}
-  onkeydown={handleKey}
-  tabindex="-1"
-></div>
-<div
-  class="flyout glass-dialog"
-  transition:fly={{ y: -8, duration: 160 }}
-  style:--edge-color={accent}
-  role="dialog"
-  aria-label={$t("component.flyout.driverHistoryAria", { vendor: vendorName, model })}
-  tabindex="-1"
-  onkeydown={handleKey}
+<FlyoutShell
+  {onClose}
+  {accent}
+  ariaLabel={$t("component.flyout.driverHistoryAria", { vendor: vendorName, model })}
+  zIndex={80}
+  backdropOpacity={0.55}
 >
   <header class="flyout-head">
     <span class="vendor-pill" data-vendor={vendor} style:color={accent}>
@@ -232,26 +219,9 @@
   <footer class="flyout-foot">
     <span>{$t("component.flyout.versionCount", { shown: filtered.length, count: releases.length })}</span>
   </footer>
-</div>
+</FlyoutShell>
 
 <style>
-  .flyout-backdrop {
-    position: fixed;
-    inset: 0;
-    background: rgba(0, 0, 0, 0.55);
-    z-index: 80;
-  }
-  .flyout {
-    position: fixed;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    width: min(720px, 92vw);
-    max-height: 84vh;
-    z-index: 81;
-    display: flex;
-    flex-direction: column;
-  }
   .flyout-head {
     display: flex;
     align-items: center;

--- a/frontend/src/components/FlyoutShell.svelte
+++ b/frontend/src/components/FlyoutShell.svelte
@@ -1,0 +1,79 @@
+<script lang="ts">
+  import type { Snippet } from "svelte";
+  import { fly } from "svelte/transition";
+
+  let {
+    onClose,
+    ariaLabel,
+    width = "720px",
+    zIndex = 220,
+    backdropOpacity = 0.5,
+    backdropBlur = 0,
+    accent,
+    onEscape,
+    children,
+  }: {
+    onClose: () => void;
+    ariaLabel: string;
+    width?: string;
+    zIndex?: number;
+    backdropOpacity?: number;
+    backdropBlur?: number;
+    accent?: string;
+    onEscape?: (e: KeyboardEvent) => void;
+    children: Snippet;
+  } = $props();
+
+  function handleKey(e: KeyboardEvent): void {
+    if (e.key !== "Escape") return;
+    if (onEscape) {
+      onEscape(e);
+    } else {
+      onClose();
+    }
+  }
+</script>
+
+<div
+  class="flyout-backdrop"
+  style:--flyout-backdrop-alpha={backdropOpacity}
+  style:--flyout-backdrop-blur="{backdropBlur}px"
+  style:z-index={zIndex}
+  role="presentation"
+  onclick={onClose}
+  onkeydown={handleKey}
+  tabindex="-1"
+></div>
+
+<div
+  class="flyout glass-dialog"
+  transition:fly={{ y: -8, duration: 160 }}
+  style:--edge-color={accent}
+  style:--flyout-width={width}
+  style:z-index={zIndex + 1}
+  role="dialog"
+  aria-label={ariaLabel}
+  tabindex="-1"
+  onkeydown={handleKey}
+>
+  {@render children()}
+</div>
+
+<style>
+  .flyout-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, var(--flyout-backdrop-alpha, 0.5));
+    backdrop-filter: blur(var(--flyout-backdrop-blur, 0));
+  }
+  .flyout {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: min(var(--flyout-width, 720px), 92vw);
+    max-height: 84vh;
+    display: flex;
+    flex-direction: column;
+  }
+</style>

--- a/frontend/src/components/Sidebar.svelte
+++ b/frontend/src/components/Sidebar.svelte
@@ -9,6 +9,7 @@
     languageMenuOpen,
   } from "../lib/stores";
   import { t, locale, LOCALE_LABELS } from "../lib/i18n/index";
+  import CounterPill from "./CounterPill.svelte";
 
   const STAGGER_STEP_MS = 28;
   const prefersReducedMotion =
@@ -32,15 +33,22 @@
     }
   });
 
-  type NavItem = { id: string; icon: string; counterKey?: "library" | "backups" };
+  type CounterKey = "library" | "backups";
+  type NavItem = { id: string; icon: string; counterKey?: CounterKey };
 
-  const librarySection: NavItem[] = [
+  // v1.7: the old "library" mega-group split into three intent-named sections.
+  // View ids, icons and titles are unchanged, so v1.6.5 muscle memory is
+  // preserved — only the section headers shift to match the actual domain.
+  const libraryGroup: NavItem[] = [
     { id: "library", icon: "library", counterKey: "library" },
+  ];
+  const catalogGroup: NavItem[] = [
     { id: "catalog", icon: "catalog" },
     { id: "drivers", icon: "drivers" },
+  ];
+  const historyGroup: NavItem[] = [
     { id: "backups", icon: "backups", counterKey: "backups" },
   ];
-
   const settingsSection: NavItem[] = [
     { id: "settings", icon: "settings" },
     { id: "about", icon: "about" },
@@ -55,6 +63,14 @@
   function counterValue(item: NavItem): number {
     if (!item.counterKey) return 0;
     return $sidebarCounts[item.counterKey];
+  }
+
+  function counterAria(item: NavItem, count: number): string | undefined {
+    if (item.counterKey === "library")
+      return $t("component.chrome.sidebar.outdatedCount", { count });
+    if (item.counterKey === "backups")
+      return $t("component.chrome.sidebar.restorableCount", { count });
+    return undefined;
   }
 
   async function toggleCollapsed(): Promise<void> {
@@ -82,40 +98,44 @@
     {/if}
   </div>
 
-  <nav class="sidebar-nav">
-    {#if !collapsed}<div class="nav-label">{$t("component.chrome.sidebar.libraryGroup")}</div>{/if}
-    {#each librarySection as item, i}
-      {@const count = counterValue(item)}
-      <button class="nav-pill" class:active={$currentView === item.id} title={$t("view." + item.id + ".title")} onclick={() => switchView(item.id)}>
-        {#if item.icon === "library"}
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7" rx="1.5"/><rect x="14" y="3" width="7" height="7" rx="1.5"/><rect x="3" y="14" width="7" height="7" rx="1.5"/><rect x="14" y="14" width="7" height="7" rx="1.5"/></svg>
-        {:else if item.icon === "catalog"}
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/><polyline points="3.27 6.96 12 12.01 20.73 6.96"/><line x1="12" y1="22.08" x2="12" y2="12"/></svg>
-        {:else if item.icon === "backups"}
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><polyline points="21 8 21 21 3 21 3 8"/><rect x="1" y="3" width="22" height="5" rx="0.5"/><line x1="10" y1="12" x2="14" y2="12"/></svg>
-        {:else if item.icon === "drivers"}
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="4" width="16" height="16" rx="2"/><rect x="9" y="9" width="6" height="6"/><line x1="9" y1="1" x2="9" y2="4"/><line x1="15" y1="1" x2="15" y2="4"/><line x1="9" y1="20" x2="9" y2="23"/><line x1="15" y1="20" x2="15" y2="23"/><line x1="20" y1="9" x2="23" y2="9"/><line x1="20" y1="14" x2="23" y2="14"/><line x1="1" y1="9" x2="4" y2="9"/><line x1="1" y1="14" x2="4" y2="14"/></svg>
-        {/if}
-        {#if !collapsed}<span class="nav-label-text" in:fly={labelStagger(i)}>{$t("view." + item.id + ".title")}</span>{/if}
-        {#if count > 0}
-          <span class="nav-counter" class:is-collapsed={collapsed} class:is-update={item.counterKey === "library"} aria-label={item.counterKey === "library" ? $t("component.chrome.sidebar.outdatedCount", { count }) : $t("component.chrome.sidebar.restorableCount", { count })}>
-            {count > 99 ? "99+" : count}
-          </span>
-        {/if}
-      </button>
-    {/each}
+  {#snippet navItem(item: NavItem, staggerIndex: number)}
+    {@const count = counterValue(item)}
+    <button class="nav-pill" class:active={$currentView === item.id} title={$t("view." + item.id + ".title")} onclick={() => switchView(item.id)}>
+      {#if item.icon === "library"}
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7" rx="1.5"/><rect x="14" y="3" width="7" height="7" rx="1.5"/><rect x="3" y="14" width="7" height="7" rx="1.5"/><rect x="14" y="14" width="7" height="7" rx="1.5"/></svg>
+      {:else if item.icon === "catalog"}
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/><polyline points="3.27 6.96 12 12.01 20.73 6.96"/><line x1="12" y1="22.08" x2="12" y2="12"/></svg>
+      {:else if item.icon === "backups"}
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><polyline points="21 8 21 21 3 21 3 8"/><rect x="1" y="3" width="22" height="5" rx="0.5"/><line x1="10" y1="12" x2="14" y2="12"/></svg>
+      {:else if item.icon === "drivers"}
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="4" width="16" height="16" rx="2"/><rect x="9" y="9" width="6" height="6"/><line x1="9" y1="1" x2="9" y2="4"/><line x1="15" y1="1" x2="15" y2="4"/><line x1="9" y1="20" x2="9" y2="23"/><line x1="15" y1="20" x2="15" y2="23"/><line x1="20" y1="9" x2="23" y2="9"/><line x1="20" y1="14" x2="23" y2="14"/><line x1="1" y1="9" x2="4" y2="9"/><line x1="1" y1="14" x2="4" y2="14"/></svg>
+      {:else if item.icon === "settings"}
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
+      {:else}
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
+      {/if}
+      {#if !collapsed}<span class="nav-label-text" in:fly={labelStagger(staggerIndex)}>{$t("view." + item.id + ".title")}</span>{/if}
+      <CounterPill
+        count={count}
+        tone={item.counterKey === "library" ? "update" : "default"}
+        collapsed={collapsed}
+        ariaLabel={counterAria(item, count)}
+      />
+    </button>
+  {/snippet}
 
-    {#if !collapsed}<div class="nav-label">{$t("component.chrome.sidebar.generalGroup")}</div>{/if}
-    {#each settingsSection as item, i}
-      <button class="nav-pill" class:active={$currentView === item.id} title={$t("view." + item.id + ".title")} onclick={() => switchView(item.id)}>
-        {#if item.icon === "settings"}
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
-        {:else}
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
-        {/if}
-        {#if !collapsed}<span class="nav-label-text" in:fly={labelStagger(librarySection.length + i)}>{$t("view." + item.id + ".title")}</span>{/if}
-      </button>
+  {#snippet navGroup(items: NavItem[], labelKey: string, baseIndex: number)}
+    {#if !collapsed}<div class="nav-label">{$t(labelKey)}</div>{/if}
+    {#each items as item, i (item.id)}
+      {@render navItem(item, baseIndex + i)}
     {/each}
+  {/snippet}
+
+  <nav class="sidebar-nav">
+    {@render navGroup(libraryGroup, "component.chrome.sidebar.libraryGroup", 0)}
+    {@render navGroup(catalogGroup, "component.chrome.sidebar.catalogGroup", libraryGroup.length)}
+    {@render navGroup(historyGroup, "component.chrome.sidebar.historyGroup", libraryGroup.length + catalogGroup.length)}
+    {@render navGroup(settingsSection, "component.chrome.sidebar.generalGroup", libraryGroup.length + catalogGroup.length + historyGroup.length)}
   </nav>
 
   <button
@@ -129,8 +149,13 @@
     onclick={() => languageMenuOpen.update((v) => !v)}
   >
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>
-    {#if !collapsed}<span class="nav-label-text" in:fly={labelStagger(librarySection.length + settingsSection.length)}>{$t("language.label")}</span>{/if}
-    <span class="lang-code nav-counter" class:is-collapsed={collapsed}>{$locale.toUpperCase()}</span>
+    {#if !collapsed}
+      <span class="nav-label-text" in:fly={labelStagger(libraryGroup.length + catalogGroup.length + historyGroup.length + settingsSection.length)}>{$t("language.label")}</span>
+    {/if}
+    <span class="lang-pill" class:is-collapsed={collapsed}>{$locale.toUpperCase()}</span>
+    {#if !collapsed}
+      <svg class="lang-chevron" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+    {/if}
   </button>
 
   <button class="sidebar-toggle" onclick={toggleCollapsed} title={collapsed ? $t("component.chrome.sidebar.expand") : $t("component.chrome.sidebar.collapse")} aria-label={collapsed ? $t("component.chrome.sidebar.expand") : $t("component.chrome.sidebar.collapse")}>
@@ -249,7 +274,18 @@
   .sidebar.collapsed .nav-pill.active::before { left: -7px; }
   .nav-pill.active:hover { background: var(--accent-dim); transform: none; }
   .nav-label-text { flex: 1; text-align: left; }
-  .nav-counter {
+
+  /* When an item is active, recolor the embedded CounterPill so it reads as
+     "part of the active row" rather than a contrasting badge. The :global()
+     escape is needed because CounterPill is a child component with scoped CSS. */
+  .nav-pill.active :global(.counter-pill) {
+    background: var(--bg-card);
+    color: var(--accent);
+  }
+
+  /* Lang-code text pill — same visual mass as a CounterPill but carries a
+     locale code, not a count, so it lives here next to the language switcher. */
+  .lang-pill {
     font-family: var(--font-mono);
     font-size: var(--fs-2xs);
     font-weight: 700;
@@ -257,21 +293,27 @@
     border-radius: var(--radius-full);
     background: var(--bg-elevated);
     color: var(--text-muted);
-    font-variant-numeric: tabular-nums;
     min-width: 18px;
     text-align: center;
     line-height: var(--lh-tight);
+    flex-shrink: 0;
   }
-  .nav-counter.is-update { background: var(--update-dim); color: var(--update); }
-  .nav-pill.active .nav-counter { background: var(--bg-card); color: var(--accent); }
-  .nav-counter.is-collapsed {
+  .lang-pill.is-collapsed {
     position: absolute;
     top: 2px;
     right: 2px;
     padding: 0 4px;
     min-width: 14px;
-    font-size: var(--fs-2xs);
-    line-height: var(--lh-tight);
+  }
+
+  .lang-chevron {
+    color: var(--text-muted);
+    flex-shrink: 0;
+    transition: transform var(--dur-fast) var(--ease);
+  }
+  .lang-switcher[aria-expanded="true"] .lang-chevron {
+    transform: rotate(180deg);
+    color: var(--accent);
   }
 
   .lang-switcher {
@@ -295,7 +337,6 @@
   .lang-switcher.active { background: transparent; color: var(--accent); box-shadow: none; }
   .lang-switcher.active::before { content: none; }
   .lang-switcher.active:hover { background: var(--bg-card-hover); }
-  .lang-code { flex-shrink: 0; }
 
   .sidebar-toggle {
     margin: var(--space-2) var(--space-4) var(--space-4);

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -576,6 +576,7 @@ export interface DriverInstallOutcome {
   stage: InstallStage;
   exit_code: number;
   message: string;
+  reboot_required: boolean;
 }
 
 export const DRIVER_INSTALL_EVENT = "driver_install_progress";

--- a/frontend/src/lib/i18n/locales/_meta.json
+++ b/frontend/src/lib/i18n/locales/_meta.json
@@ -2079,6 +2079,16 @@
     "desc": "Install button label; {version} is a mono version string and is not translated.",
     "where": "frontend/src/views/Drivers.svelte"
   },
+  "view.drivers.restartToFinish": {
+    "en": "Restart to finish",
+    "desc": "Card state shown after a driver install completes with reboot_required: the new driver is staged but not active until the user restarts.",
+    "where": "frontend/src/views/Drivers.svelte"
+  },
+  "view.drivers.restartPending": {
+    "en": "Restart to apply v{version}",
+    "desc": "Tooltip on the restart-to-finish state; {version} is a mono version string and is not translated.",
+    "where": "frontend/src/views/Drivers.svelte"
+  },
   "view.drivers.openDownloadPage": {
     "en": "Open download page",
     "desc": "Button to open the vendor download page when in-app install is unavailable.",

--- a/frontend/src/lib/i18n/locales/_meta.json
+++ b/frontend/src/lib/i18n/locales/_meta.json
@@ -3534,6 +3534,11 @@
     "desc": "Title on the View backups footer button",
     "where": "frontend/src/components/ApplyProgressModal.svelte"
   },
+  "component.applyModal.action.minimize": {
+    "en": "Minimize to dock",
+    "desc": "v1.7. Title + aria-label on the close X button while applies are still running. Clicking minimizes the modal to the ActivityDock without cancelling or losing progress.",
+    "where": "frontend/src/components/ApplyProgressModal.svelte"
+  },
   "component.applyModal.stageStep": {
     "en": "step {current} of {total}",
     "desc": "Per-file stage progress (current step of total stages)",
@@ -3607,6 +3612,11 @@
   "component.applyModal.toast.issueFailed": {
     "en": "Could not open issue report: {error}",
     "desc": "Toast when opening the GitHub issue report fails",
+    "where": "frontend/src/components/ApplyProgressModal.svelte"
+  },
+  "component.applyModal.toast.movedToDock": {
+    "en": "Apply moved to the dock — click any time to expand.",
+    "desc": "v1.7. First-time hint toast shown the first time a user minimizes the apply modal while updates are still running. Persisted via localStorage so it only shows once per machine.",
     "where": "frontend/src/components/ApplyProgressModal.svelte"
   },
   "common.shareCopied": {
@@ -3976,7 +3986,17 @@
   },
   "component.chrome.sidebar.libraryGroup": {
     "en": "Library",
-    "desc": "Sidebar section header above the Library/Catalog/Drivers/Backups nav items.",
+    "desc": "v1.7: Sidebar section header above the Library nav item only. (Pre-v1.7 this header sat above the full Library/Catalog/Drivers/Backups stack — that stack was split into intent-named groups in v1.7 so new users get a clearer mental model.)",
+    "where": "Sidebar.svelte"
+  },
+  "component.chrome.sidebar.catalogGroup": {
+    "en": "Catalog & Drivers",
+    "desc": "v1.7: Sidebar section header above the Catalog and Drivers nav items. Groups the two browsable-source dominions (DLL manifest and GPU/system drivers).",
+    "where": "Sidebar.svelte"
+  },
+  "component.chrome.sidebar.historyGroup": {
+    "en": "History",
+    "desc": "v1.7: Sidebar section header above the Backups nav item. Frames Backups as the time-travel record of every applied DLL/driver change.",
     "where": "Sidebar.svelte"
   },
   "component.chrome.sidebar.generalGroup": {

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -1237,7 +1237,8 @@
         "reportIssueTitle": "Open a pre-filled GitHub issue with this report, your app version, OS, and recent logs",
         "preparing": "Preparing",
         "viewBackups": "View backups",
-        "viewBackupsTitle": "See the snapshots just created"
+        "viewBackupsTitle": "See the snapshots just created",
+        "minimize": "Minimize to dock"
       },
       "stageStep": "step {current} of {total}",
       "retrying": "Retrying",
@@ -1261,7 +1262,8 @@
         "errorCopied": "Error copied",
         "reportCopied": "Report copied",
         "clipboardUnavailable": "Clipboard unavailable",
-        "issueFailed": "Could not open issue report: {error}"
+        "issueFailed": "Could not open issue report: {error}",
+        "movedToDock": "Apply moved to the dock — click any time to expand."
       }
     },
     "banner": {
@@ -1364,6 +1366,8 @@
       },
       "sidebar": {
         "libraryGroup": "Library",
+        "catalogGroup": "Catalog & Drivers",
+        "historyGroup": "History",
         "generalGroup": "General",
         "outdatedCount_one": "{count} outdated",
         "outdatedCount_other": "{count} outdated",

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -195,6 +195,8 @@
       "channelBeta": "Beta",
       "channelWhql": "WHQL",
       "updateTo": "Update to v{version}",
+      "restartToFinish": "Restart to finish",
+      "restartPending": "Restart to apply v{version}",
       "openDownloadPage": "Open download page",
       "findMyDriver": "Find my driver ↗",
       "releaseNotesTitle": "Open the official release notes",

--- a/frontend/src/lib/i18n/locales/es.json
+++ b/frontend/src/lib/i18n/locales/es.json
@@ -1237,7 +1237,8 @@
         "reportIssueTitle": "Abrir una incidencia de GitHub precargada con este informe, tu versión de la app, el sistema operativo y los registros recientes",
         "preparing": "Preparando",
         "viewBackups": "Ver copias de seguridad",
-        "viewBackupsTitle": "Ver las instantáneas recién creadas"
+        "viewBackupsTitle": "Ver las instantáneas recién creadas",
+        "minimize": "Minimizar al dock"
       },
       "stageStep": "paso {current} de {total}",
       "retrying": "Reintentando",
@@ -1261,7 +1262,8 @@
         "errorCopied": "Error copiado",
         "reportCopied": "Informe copiado",
         "clipboardUnavailable": "Portapapeles no disponible",
-        "issueFailed": "No se pudo abrir el reporte de incidencia: {error}"
+        "issueFailed": "No se pudo abrir el reporte de incidencia: {error}",
+        "movedToDock": "Aplicación movida al dock — tócalo cuando quieras para volver a abrir."
       }
     },
     "banner": {
@@ -1364,6 +1366,8 @@
       },
       "sidebar": {
         "libraryGroup": "Biblioteca",
+        "catalogGroup": "Catálogo y drivers",
+        "historyGroup": "Historial",
         "generalGroup": "General",
         "outdatedCount_one": "{count} desactualizado",
         "outdatedCount_other": "{count} desactualizados",

--- a/frontend/src/lib/i18n/locales/es.json
+++ b/frontend/src/lib/i18n/locales/es.json
@@ -195,6 +195,8 @@
       "channelBeta": "Beta",
       "channelWhql": "WHQL",
       "updateTo": "Actualizar a v{version}",
+      "restartToFinish": "Reinicia para terminar",
+      "restartPending": "Reinicia para aplicar v{version}",
       "openDownloadPage": "Abrir página de descarga",
       "findMyDriver": "Encontrar mi controlador ↗",
       "releaseNotesTitle": "Abrir las notas de la versión oficiales",

--- a/frontend/src/lib/stores.ts
+++ b/frontend/src/lib/stores.ts
@@ -691,12 +691,24 @@ export const driverReports: Writable<DriverStatusReport[]> = writable([]);
 export const driverCheckInProgress: Writable<boolean> = writable(false);
 export const driverCheckError: Writable<string | null> = writable(null);
 
+/** GPU vendor -> version display whose install finished with reboot_required and
+ *  is staged but not yet active. Drives the "Restart to finish" card state until
+ *  the user reboots (process restart resets this) or the driver shows up_to_date. */
+export const driverRebootPending: Writable<Record<string, string>> = writable({});
+
 export async function loadDriverUpdates(): Promise<void> {
   driverCheckInProgress.set(true);
   driverCheckError.set(null);
   try {
     const reports = await checkDriverUpdates();
     driverReports.set(sortDriverReports(reports));
+    driverRebootPending.update((m) => {
+      const next = { ...m };
+      for (const r of reports) {
+        if (r.status === "up_to_date") delete next[r.device.vendor];
+      }
+      return next;
+    });
     emitDriverUpdateNotifications(reports);
   } catch (err: unknown) {
     const message = formatError(err);
@@ -749,6 +761,16 @@ export async function startDriverInstall(report: DriverStatusReport): Promise<vo
   try {
     const outcome = await installDriver(report.device.vendor, url);
     if (outcome.stage === "completed") {
+      if (outcome.reboot_required) {
+        const pending = report.latest?.version.display ?? "";
+        driverRebootPending.update((m) => ({ ...m, [report.device.vendor]: pending }));
+      } else {
+        driverRebootPending.update((m) => {
+          const next = { ...m };
+          delete next[report.device.vendor];
+          return next;
+        });
+      }
       showToast("success", outcome.message);
       await loadDriverUpdates();
     } else if (outcome.stage === "cancelled") {

--- a/frontend/src/views/Backups.svelte
+++ b/frontend/src/views/Backups.svelte
@@ -602,6 +602,17 @@
       {#each filtered as g, i (g.game_id)}
         {@const accent = g.game ? launcherAccent(g.game.launcher) : DEFAULT_VENDOR_ACCENT}
         {@const groupSel = groupSelectionState(g)}
+        {@const monthThis = groupBy === "date" ? g.latestAt.slice(0, 7) : ""}
+        {@const monthPrev =
+          groupBy === "date" && i > 0 ? filtered[i - 1].latestAt.slice(0, 7) : null}
+        {#if groupBy === "date" && monthThis !== monthPrev}
+          <h2 class="timeline-month-header">
+            {new Date(g.latestAt).toLocaleDateString(undefined, {
+              year: "numeric",
+              month: "long",
+            })}
+          </h2>
+        {/if}
         <section class="group" in:fly={{ y: 6, duration: 260, delay: 40 + i * 30 }}>
           <div class="group-row">
             <label class="group-check" title={groupSel === "all" ? $t("view.backups.group.deselectAll") : $t("view.backups.group.selectAll")}>
@@ -1348,5 +1359,22 @@
     .entry,
     .bk-stat,
     .chevron { transition: none; }
+  }
+
+  .timeline-month-header {
+    font-size: var(--fs-xs);
+    font-weight: 700;
+    letter-spacing: var(--letter-wider);
+    text-transform: uppercase;
+    color: var(--text-muted);
+    margin: var(--space-5) 0 var(--space-2);
+    padding-top: var(--space-3);
+    border-top: 1px solid var(--border);
+    font-variant-numeric: tabular-nums;
+  }
+  .timeline-month-header:first-child {
+    margin-top: 0;
+    padding-top: 0;
+    border-top: none;
   }
 </style>

--- a/frontend/src/views/Drivers.svelte
+++ b/frontend/src/views/Drivers.svelte
@@ -19,6 +19,7 @@
     loadDriverUpdates,
     startDriverInstall,
     driverInstall,
+    driverRebootPending,
     showToast,
     systemDriverGroups,
     systemScanInProgress,
@@ -198,6 +199,9 @@
       {@const showNotes = !!pageUrl}
       {@const installing = $driverInstall.vendor === report.device.vendor}
       {@const needsHelp = report.status === "unknown" || report.status === "unsupported"}
+      {@const rebootPendingVersion = $driverRebootPending[report.device.vendor]}
+      {@const showRebootPending =
+        rebootPendingVersion !== undefined && report.status !== "up_to_date"}
       <li class="driver-card">
         <div class="card-row">
           <div class="card-main">
@@ -228,7 +232,12 @@
                 <span class="install-msg">{$driverInstall.message}</span>
               </div>
             {:else}
-              {#if canInstall(report)}
+              {#if showRebootPending}
+                <span class="driver-state reboot-pending" data-tone="warning" title={$t("view.drivers.restartPending", { version: rebootPendingVersion })}>
+                  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/><path d="M3 3v5h5"/></svg>
+                  {$t("view.drivers.restartToFinish")}
+                </span>
+              {:else if canInstall(report)}
                 {@const size = sizeLabel(report.latest?.size_bytes ?? 0)}
                 <button class="driver-update" onclick={() => startDriverInstall(report)} disabled={installBusy}>
                   <span class="driver-update-label">{$t("view.drivers.updateTo", { version: report.latest?.version.display ?? "" })}</span>
@@ -570,6 +579,8 @@
   .driver-state[data-tone="success"] { background: var(--success-dim); color: var(--success); }
   .driver-state[data-tone="accent"] { background: var(--update-dim); color: var(--update); }
   .driver-state[data-tone="warning"] { background: var(--warning-dim); color: var(--warning); }
+  .driver-state.reboot-pending { display: inline-flex; align-items: center; gap: 6px; }
+  .driver-state.reboot-pending svg { flex-shrink: 0; }
   .driver-secondary { display: inline-flex; align-items: center; gap: 4px; }
   .driver-icon {
     width: 34px;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dlssync",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "private": true,
   "scripts": {
     "dev": "tauri dev",
@@ -13,7 +13,8 @@
     "test": "task test"
   },
   "devDependencies": {
-    "@tauri-apps/cli": "^2.0.0"
+    "@tauri-apps/cli": "^2.0.0",
+    "axe-core": "4.10.3"
   },
   "packageManager": "pnpm@9.0.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@tauri-apps/cli':
         specifier: ^2.0.0
         version: 2.11.2
+      axe-core:
+        specifier: 4.10.3
+        version: 4.10.3
 
   frontend:
     dependencies:
@@ -693,6 +696,10 @@ packages:
 
   ast-v8-to-istanbul@1.0.3:
     resolution: {integrity: sha512-jCMQ6ZylLPudp0CDfBmQBZUsrh1/8psbmu9ibeVWKuHWD0YrH9YABwlKu5kVEFoT0GCQQW9Z/SxfuEbbkGQCRg==}
+
+  axe-core@4.10.3:
+    resolution: {integrity: sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==}
+    engines: {node: '>=4'}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -1540,6 +1547,8 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       estree-walker: 3.0.3
       js-tokens: 10.0.0
+
+  axe-core@4.10.3: {}
 
   axobject-query@4.1.0: {}
 

--- a/src-tauri/src/commands/apply.rs
+++ b/src-tauri/src/commands/apply.rs
@@ -1,11 +1,13 @@
+use crate::commands::apply_decisions::{
+    classify_error, enrich_signature_error, failure_outcome, group_id_for, streamline_block_reason,
+    version_major,
+};
 use crate::error::{AppError, AppResult};
 use crate::state::AppState;
 use backup_store::BackupEntry;
 use dll_catalog::{DownloadOptions, DownloadProgress, Release};
 use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
 use std::collections::HashMap;
-use std::fmt::Write as _;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
@@ -94,17 +96,6 @@ pub struct GroupDownloadProgress {
 #[derive(Debug, Clone, Serialize)]
 pub struct InflightSnapshot {
     pub in_flight: usize,
-}
-
-pub fn group_id_for(cdn_url: &str) -> String {
-    let mut h = Sha256::new();
-    h.update(cdn_url.as_bytes());
-    let digest = h.finalize();
-    let mut s = String::with_capacity(16);
-    for b in digest.iter().take(8) {
-        let _ = write!(s, "{:02x}", b);
-    }
-    s
 }
 
 #[tauri::command]
@@ -513,9 +504,18 @@ pub(crate) async fn apply_single_item(
         ctx.cancelled();
         return Ok(failure_outcome(request, &group_id, "cancelled".into()));
     }
-    if let Err(e) = std::fs::copy(&dll_path, &backup_path) {
-        ctx.fail("Backup copy failed", e.to_string(), Some("backup"));
-        return Ok(failure_outcome(request, &group_id, e.to_string()));
+    let copy_src = dll_path.clone();
+    let copy_dst = backup_path.clone();
+    match tokio::task::spawn_blocking(move || std::fs::copy(&copy_src, &copy_dst)).await {
+        Ok(Ok(_)) => {}
+        Ok(Err(e)) => {
+            ctx.fail("Backup copy failed", e.to_string(), Some("backup"));
+            return Ok(failure_outcome(request, &group_id, e.to_string()));
+        }
+        Err(e) => {
+            ctx.fail("Backup copy task failed", e.to_string(), Some("other"));
+            return Ok(failure_outcome(request, &group_id, e.to_string()));
+        }
     }
     let entry = BackupEntry {
         id: entry_id.clone(),
@@ -570,8 +570,16 @@ pub(crate) async fn apply_single_item(
         } else {
             ("other", format!("atomic replace failed: {e}"))
         };
-        if let Err(roll) = std::fs::copy(&backup_path, &dll_path) {
-            tracing::error!(error = %roll, "rollback after replace failure also failed");
+        let roll_src = backup_path.clone();
+        let roll_dst = dll_path.clone();
+        match tokio::task::spawn_blocking(move || std::fs::copy(&roll_src, &roll_dst)).await {
+            Ok(Err(roll)) => {
+                tracing::error!(error = %roll, "rollback after replace failure also failed");
+            }
+            Err(join_err) => {
+                tracing::error!(error = %join_err, "rollback task after replace failure failed to join");
+            }
+            Ok(Ok(_)) => {}
         }
         ctx.fail("Replace failed", msg.clone(), Some(class));
         return Ok(failure_outcome(request, &group_id, msg));
@@ -592,8 +600,16 @@ pub(crate) async fn apply_single_item(
         .as_deref()
         .is_some_and(|h| h.eq_ignore_ascii_case(&release.sha256))
     {
-        if let Err(roll) = std::fs::copy(&backup_path, &dll_path) {
-            tracing::error!(error = %roll, "rollback after post-swap hash mismatch also failed");
+        let roll_src = backup_path.clone();
+        let roll_dst = dll_path.clone();
+        match tokio::task::spawn_blocking(move || std::fs::copy(&roll_src, &roll_dst)).await {
+            Ok(Err(roll)) => {
+                tracing::error!(error = %roll, "rollback after post-swap hash mismatch also failed");
+            }
+            Err(join_err) => {
+                tracing::error!(error = %join_err, "rollback task after post-swap hash mismatch failed to join");
+            }
+            Ok(Ok(_)) => {}
         }
         let got = installed_hash.unwrap_or_else(|| "unreadable".to_string());
         let err = format!(
@@ -755,83 +771,6 @@ fn emit_inflight(handle: &AppHandle, in_flight: usize) {
     crate::tray::update_inflight(handle, in_flight);
 }
 
-fn failure_outcome(request: &ApplyRequest, _group_id: &str, error: String) -> ApplyOutcome {
-    ApplyOutcome {
-        apply_id: request.apply_id.clone(),
-        success: false,
-        backup_id: None,
-        previous_version: None,
-        new_version: None,
-        error: Some(error),
-    }
-}
-
-pub fn classify_error(message: &str) -> &'static str {
-    let lower = message.to_ascii_lowercase();
-    if lower.contains("cancelled") {
-        return "cancelled";
-    }
-    if lower.contains("error sending request")
-        || lower.contains("decoding response body")
-        || lower.contains("connection reset")
-        || lower.contains("dns")
-        || lower.contains("timed out")
-        || lower.contains("stalled")
-        || lower.contains("truncated")
-        || lower.contains("size mismatch")
-        || lower.contains("429")
-        || lower.contains("503")
-        || lower.contains("502")
-        || lower.contains("504")
-    {
-        return "network";
-    }
-    if lower.contains("crypt_e_no_match")
-        || lower.contains("allow unsigned")
-        || lower.contains("authenticode signature could not be read")
-        || lower.contains("no authenticode subject")
-        || lower.contains("allowlist")
-    {
-        return "signature";
-    }
-    if lower.contains("locked by another process") || lower.contains("sharing_violation") {
-        return "lock";
-    }
-    if lower.contains("access denied") || lower.contains("administrator") {
-        return "permission";
-    }
-    if lower.contains("sha-256 mismatch") || lower.contains("integrity") || lower.contains("md5") {
-        return "hash";
-    }
-    if lower.contains("not in zip") || lower.contains("dll not found") {
-        return "missing";
-    }
-    if lower.contains("backup") {
-        return "backup";
-    }
-    if lower.contains("streamline plugin")
-        || lower.contains("injector mod")
-        || lower.contains("version-locked")
-    {
-        return "streamline_locked";
-    }
-    "other"
-}
-
-/// First numeric dotted segment of a version string (the SDK major), or `None`.
-fn version_major(version: &str) -> Option<u16> {
-    version
-        .split('.')
-        .next()
-        .map(|p| {
-            p.chars()
-                .take_while(|c| c.is_ascii_digit())
-                .collect::<String>()
-        })
-        .filter(|p| !p.is_empty())
-        .and_then(|p| p.parse().ok())
-}
-
 /// Authoritative crash-safety gate for the NVIDIA Streamline version-locked set.
 /// Returns `Some(reason)` when an `sl.*` plugin must NOT be swapped: the user has
 /// not opted in, or the target crosses the installed Streamline MAJOR (v1↔v2 is
@@ -859,40 +798,6 @@ pub(crate) fn streamline_guard(
         .and_then(|v| version_major(&v.file_version));
     let target_major = version_major(target_version);
     streamline_block_reason(filename, allow_streamline, installed_major, target_major)
-}
-
-/// Pure decision for the Streamline guard, split out so it is testable without a
-/// live `StateHandles`. An `sl.*` plugin is blocked only when the user has not
-/// opted in (`update_streamline`) or the target crosses the installed Streamline
-/// MAJOR; a same-major swap is allowed even under a DLSS Enabler. `None` = safe
-/// to swap.
-fn streamline_block_reason(
-    filename: &str,
-    allow_streamline: bool,
-    installed_major: Option<u16>,
-    target_major: Option<u16>,
-) -> Option<String> {
-    if !dll_scanner::is_streamline_plugin(filename) {
-        return None;
-    }
-    if !allow_streamline {
-        return Some(format!(
-            "{filename} is an NVIDIA Streamline plugin (sl.*). Updating it without the matching \
-             sl.interposer.dll can crash the game on launch. Enable 'Update NVIDIA Streamline \
-             runtime' in Settings → Advanced to override."
-        ));
-    }
-    if let (Some(installed), Some(target)) = (installed_major, target_major) {
-        if installed != target {
-            return Some(format!(
-                "{filename} is NVIDIA Streamline v{installed}.x in this game but the update is \
-                 Streamline v{target}.x. The Streamline plug-ins are version-locked as a matched \
-                 set — mixing major releases (v{installed} with v{target}) crashes the game on \
-                 launch. Skipped; only a same-major Streamline set update is applied."
-            ));
-        }
-    }
-    None
 }
 
 fn ensure_writable(path: &std::path::Path) -> Result<(), String> {
@@ -935,24 +840,6 @@ fn atomic_replace(source: &std::path::Path, dest: &std::path::Path) -> std::io::
     Ok(())
 }
 
-fn enrich_signature_error(reason: &str) -> String {
-    let lower = reason.to_ascii_lowercase();
-    let no_match = lower.contains("crypt_e_no_match")
-        || lower.contains("notsigned")
-        || lower.contains("not_signed")
-        || lower.contains("could not be read")
-        || lower.contains("no authenticode subject");
-    if no_match {
-        format!(
-            "{reason}\n\nHint: this DLL ships unsigned by the vendor. \
-             Enable 'Allow unsigned DLLs' in Settings → Advanced to override (SHA-256 \
-             integrity is still enforced)."
-        )
-    } else {
-        reason.to_string()
-    }
-}
-
 pub(crate) struct StateHandles {
     pub catalog: Arc<parking_lot::RwLock<Option<dll_catalog::Catalog>>>,
     pub backups: Arc<parking_lot::RwLock<Option<backup_store::BackupStore>>>,
@@ -970,145 +857,5 @@ impl AppState {
             http_downloads: self.http_downloads.clone(),
             download_cache: self.download_cache.clone(),
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn enrich_appends_hint_on_crypt_no_match() {
-        let out = enrich_signature_error("CryptQueryObject: 0x80092009 (CRYPT_E_NO_MATCH)");
-        assert!(out.contains("Allow unsigned DLLs"));
-        assert!(out.contains("CRYPT_E_NO_MATCH"));
-    }
-
-    #[test]
-    fn enrich_appends_hint_on_no_subject() {
-        let out = enrich_signature_error("no Authenticode subject extracted (status: NotSigned)");
-        assert!(out.contains("Allow unsigned DLLs"));
-    }
-
-    #[test]
-    fn enrich_leaves_subject_allowlist_errors_alone() {
-        let original = "Authenticode subject 'WrongCorp' not in nvidia allowlist";
-        let out = enrich_signature_error(original);
-        assert_eq!(out, original);
-    }
-
-    #[test]
-    fn classify_recognizes_network_class() {
-        assert_eq!(
-            classify_error("catalog error: http: error decoding response body"),
-            "network"
-        );
-        assert_eq!(
-            classify_error("catalog error: http: error sending request for url"),
-            "network"
-        );
-        assert_eq!(classify_error("stalled: no bytes for 60 s"), "network");
-        assert_eq!(
-            classify_error("truncated: received 100 bytes of 200"),
-            "network"
-        );
-    }
-
-    #[test]
-    fn classify_recognizes_signature_class() {
-        assert_eq!(
-            classify_error("Authenticode subject 'X' not in nvidia allowlist"),
-            "signature"
-        );
-        assert_eq!(
-            classify_error("CryptQueryObject: 0x80092009 (CRYPT_E_NO_MATCH)"),
-            "signature"
-        );
-    }
-
-    #[test]
-    fn classify_recognizes_lock_class() {
-        assert_eq!(
-            classify_error("file is locked by another process (X.dll)"),
-            "lock"
-        );
-    }
-
-    #[test]
-    fn classify_recognizes_hash_class() {
-        assert_eq!(
-            classify_error("SHA-256 mismatch: expected abc got def"),
-            "hash"
-        );
-    }
-
-    #[test]
-    fn group_id_is_deterministic_and_stable() {
-        let a = group_id_for(
-            "https://github.com/intel/xess/releases/download/v3.0.1/XeSS_SDK_3.0.1.zip",
-        );
-        let b = group_id_for(
-            "https://github.com/intel/xess/releases/download/v3.0.1/XeSS_SDK_3.0.1.zip",
-        );
-        assert_eq!(a, b);
-        assert_eq!(a.len(), 16);
-    }
-
-    #[test]
-    fn group_id_differs_per_url() {
-        let a = group_id_for("https://example.test/a.zip");
-        let b = group_id_for("https://example.test/b.zip");
-        assert_ne!(a, b);
-    }
-
-    #[test]
-    fn streamline_guard_allows_ngx_dll_regardless_of_prefs() {
-        assert!(streamline_block_reason("nvngx_dlss.dll", false, None, None).is_none());
-        assert!(streamline_block_reason("nvngx_dlssg.dll", false, Some(1), Some(2)).is_none());
-        assert!(streamline_block_reason("libxess.dll", false, None, None).is_none());
-    }
-
-    #[test]
-    fn streamline_guard_blocks_plugin_when_streamline_opt_in_off() {
-        let reason = streamline_block_reason("sl.dlss_g.dll", false, None, None).unwrap();
-        assert!(reason.contains("Streamline"));
-        assert!(reason.contains("Settings"));
-        assert_eq!(classify_error(&reason), "streamline_locked");
-    }
-
-    #[test]
-    fn streamline_guard_allows_same_major_plugin_when_opted_in() {
-        assert!(streamline_block_reason("sl.dlss_g.dll", true, Some(2), Some(2)).is_none());
-        assert!(streamline_block_reason("sl.reflex.dll", true, None, None).is_none());
-    }
-
-    #[test]
-    fn streamline_guard_allows_same_major_swap_under_dlss_enabler() {
-        assert!(streamline_block_reason("sl.dlss_g.dll", true, Some(2), Some(2)).is_none());
-        assert!(streamline_block_reason("sl.reflex.dll", true, Some(2), Some(2)).is_none());
-    }
-
-    #[test]
-    fn streamline_guard_blocks_sl_dlss_g_cross_major_nexus_subnautica2() {
-        let reason = streamline_block_reason("sl.dlss_g.dll", true, Some(2), Some(310)).unwrap();
-        assert!(reason.contains("version-locked"));
-        assert_eq!(classify_error(&reason), "streamline_locked");
-    }
-
-    #[test]
-    fn streamline_guard_blocks_cross_major_swap_even_when_opted_in() {
-        let reason = streamline_block_reason("sl.interposer.dll", true, Some(1), Some(2)).unwrap();
-        assert!(reason.contains("version-locked"));
-        assert!(reason.contains("v1"));
-        assert!(reason.contains("v2"));
-        assert_eq!(classify_error(&reason), "streamline_locked");
-    }
-
-    #[test]
-    fn version_major_parses_first_numeric_segment() {
-        assert_eq!(version_major("2.11.1"), Some(2));
-        assert_eq!(version_major("1.5.0.0"), Some(1));
-        assert_eq!(version_major("310.6.0.0"), Some(310));
-        assert_eq!(version_major(""), None);
     }
 }

--- a/src-tauri/src/commands/apply_decisions.rs
+++ b/src-tauri/src/commands/apply_decisions.rs
@@ -1,0 +1,287 @@
+use crate::commands::apply::{ApplyOutcome, ApplyRequest};
+use sha2::{Digest, Sha256};
+use std::fmt::Write as _;
+
+pub fn group_id_for(cdn_url: &str) -> String {
+    let mut h = Sha256::new();
+    h.update(cdn_url.as_bytes());
+    let digest = h.finalize();
+    let mut s = String::with_capacity(16);
+    for b in digest.iter().take(8) {
+        let _ = write!(s, "{:02x}", b);
+    }
+    s
+}
+
+pub fn classify_error(message: &str) -> &'static str {
+    let lower = message.to_ascii_lowercase();
+    if lower.contains("cancelled") {
+        return "cancelled";
+    }
+    if lower.contains("error sending request")
+        || lower.contains("decoding response body")
+        || lower.contains("connection reset")
+        || lower.contains("dns")
+        || lower.contains("timed out")
+        || lower.contains("stalled")
+        || lower.contains("truncated")
+        || lower.contains("size mismatch")
+        || lower.contains("429")
+        || lower.contains("503")
+        || lower.contains("502")
+        || lower.contains("504")
+    {
+        return "network";
+    }
+    if lower.contains("crypt_e_no_match")
+        || lower.contains("allow unsigned")
+        || lower.contains("authenticode signature could not be read")
+        || lower.contains("no authenticode subject")
+        || lower.contains("allowlist")
+    {
+        return "signature";
+    }
+    if lower.contains("locked by another process") || lower.contains("sharing_violation") {
+        return "lock";
+    }
+    if lower.contains("access denied") || lower.contains("administrator") {
+        return "permission";
+    }
+    if lower.contains("sha-256 mismatch") || lower.contains("integrity") || lower.contains("md5") {
+        return "hash";
+    }
+    if lower.contains("not in zip") || lower.contains("dll not found") {
+        return "missing";
+    }
+    if lower.contains("backup") {
+        return "backup";
+    }
+    if lower.contains("streamline plugin")
+        || lower.contains("injector mod")
+        || lower.contains("version-locked")
+    {
+        return "streamline_locked";
+    }
+    "other"
+}
+
+/// First numeric dotted segment of a version string (the SDK major), or `None`.
+pub(crate) fn version_major(version: &str) -> Option<u16> {
+    version
+        .split('.')
+        .next()
+        .map(|p| {
+            p.chars()
+                .take_while(|c| c.is_ascii_digit())
+                .collect::<String>()
+        })
+        .filter(|p| !p.is_empty())
+        .and_then(|p| p.parse().ok())
+}
+
+/// Pure decision for the Streamline guard, split out so it is testable without a
+/// live `StateHandles`. An `sl.*` plugin is blocked only when the user has not
+/// opted in (`update_streamline`) or the target crosses the installed Streamline
+/// MAJOR; a same-major swap is allowed even under a DLSS Enabler. `None` = safe
+/// to swap.
+pub(crate) fn streamline_block_reason(
+    filename: &str,
+    allow_streamline: bool,
+    installed_major: Option<u16>,
+    target_major: Option<u16>,
+) -> Option<String> {
+    if !dll_scanner::is_streamline_plugin(filename) {
+        return None;
+    }
+    if !allow_streamline {
+        return Some(format!(
+            "{filename} is an NVIDIA Streamline plugin (sl.*). Updating it without the matching \
+             sl.interposer.dll can crash the game on launch. Enable 'Update NVIDIA Streamline \
+             runtime' in Settings → Advanced to override."
+        ));
+    }
+    if let (Some(installed), Some(target)) = (installed_major, target_major) {
+        if installed != target {
+            return Some(format!(
+                "{filename} is NVIDIA Streamline v{installed}.x in this game but the update is \
+                 Streamline v{target}.x. The Streamline plug-ins are version-locked as a matched \
+                 set — mixing major releases (v{installed} with v{target}) crashes the game on \
+                 launch. Skipped; only a same-major Streamline set update is applied."
+            ));
+        }
+    }
+    None
+}
+
+pub(crate) fn enrich_signature_error(reason: &str) -> String {
+    let lower = reason.to_ascii_lowercase();
+    let no_match = lower.contains("crypt_e_no_match")
+        || lower.contains("notsigned")
+        || lower.contains("not_signed")
+        || lower.contains("could not be read")
+        || lower.contains("no authenticode subject");
+    if no_match {
+        format!(
+            "{reason}\n\nHint: this DLL ships unsigned by the vendor. \
+             Enable 'Allow unsigned DLLs' in Settings → Advanced to override (SHA-256 \
+             integrity is still enforced)."
+        )
+    } else {
+        reason.to_string()
+    }
+}
+
+pub(crate) fn failure_outcome(
+    request: &ApplyRequest,
+    _group_id: &str,
+    error: String,
+) -> ApplyOutcome {
+    ApplyOutcome {
+        apply_id: request.apply_id.clone(),
+        success: false,
+        backup_id: None,
+        previous_version: None,
+        new_version: None,
+        error: Some(error),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn enrich_appends_hint_on_crypt_no_match() {
+        let out = enrich_signature_error("CryptQueryObject: 0x80092009 (CRYPT_E_NO_MATCH)");
+        assert!(out.contains("Allow unsigned DLLs"));
+        assert!(out.contains("CRYPT_E_NO_MATCH"));
+    }
+
+    #[test]
+    fn enrich_appends_hint_on_no_subject() {
+        let out = enrich_signature_error("no Authenticode subject extracted (status: NotSigned)");
+        assert!(out.contains("Allow unsigned DLLs"));
+    }
+
+    #[test]
+    fn enrich_leaves_subject_allowlist_errors_alone() {
+        let original = "Authenticode subject 'WrongCorp' not in nvidia allowlist";
+        let out = enrich_signature_error(original);
+        assert_eq!(out, original);
+    }
+
+    #[test]
+    fn classify_recognizes_network_class() {
+        assert_eq!(
+            classify_error("catalog error: http: error decoding response body"),
+            "network"
+        );
+        assert_eq!(
+            classify_error("catalog error: http: error sending request for url"),
+            "network"
+        );
+        assert_eq!(classify_error("stalled: no bytes for 60 s"), "network");
+        assert_eq!(
+            classify_error("truncated: received 100 bytes of 200"),
+            "network"
+        );
+    }
+
+    #[test]
+    fn classify_recognizes_signature_class() {
+        assert_eq!(
+            classify_error("Authenticode subject 'X' not in nvidia allowlist"),
+            "signature"
+        );
+        assert_eq!(
+            classify_error("CryptQueryObject: 0x80092009 (CRYPT_E_NO_MATCH)"),
+            "signature"
+        );
+    }
+
+    #[test]
+    fn classify_recognizes_lock_class() {
+        assert_eq!(
+            classify_error("file is locked by another process (X.dll)"),
+            "lock"
+        );
+    }
+
+    #[test]
+    fn classify_recognizes_hash_class() {
+        assert_eq!(
+            classify_error("SHA-256 mismatch: expected abc got def"),
+            "hash"
+        );
+    }
+
+    #[test]
+    fn group_id_is_deterministic_and_stable() {
+        let a = group_id_for(
+            "https://github.com/intel/xess/releases/download/v3.0.1/XeSS_SDK_3.0.1.zip",
+        );
+        let b = group_id_for(
+            "https://github.com/intel/xess/releases/download/v3.0.1/XeSS_SDK_3.0.1.zip",
+        );
+        assert_eq!(a, b);
+        assert_eq!(a.len(), 16);
+    }
+
+    #[test]
+    fn group_id_differs_per_url() {
+        let a = group_id_for("https://example.test/a.zip");
+        let b = group_id_for("https://example.test/b.zip");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn streamline_guard_allows_ngx_dll_regardless_of_prefs() {
+        assert!(streamline_block_reason("nvngx_dlss.dll", false, None, None).is_none());
+        assert!(streamline_block_reason("nvngx_dlssg.dll", false, Some(1), Some(2)).is_none());
+        assert!(streamline_block_reason("libxess.dll", false, None, None).is_none());
+    }
+
+    #[test]
+    fn streamline_guard_blocks_plugin_when_streamline_opt_in_off() {
+        let reason = streamline_block_reason("sl.dlss_g.dll", false, None, None).unwrap();
+        assert!(reason.contains("Streamline"));
+        assert!(reason.contains("Settings"));
+        assert_eq!(classify_error(&reason), "streamline_locked");
+    }
+
+    #[test]
+    fn streamline_guard_allows_same_major_plugin_when_opted_in() {
+        assert!(streamline_block_reason("sl.dlss_g.dll", true, Some(2), Some(2)).is_none());
+        assert!(streamline_block_reason("sl.reflex.dll", true, None, None).is_none());
+    }
+
+    #[test]
+    fn streamline_guard_allows_same_major_swap_under_dlss_enabler() {
+        assert!(streamline_block_reason("sl.dlss_g.dll", true, Some(2), Some(2)).is_none());
+        assert!(streamline_block_reason("sl.reflex.dll", true, Some(2), Some(2)).is_none());
+    }
+
+    #[test]
+    fn streamline_guard_blocks_sl_dlss_g_cross_major_nexus_subnautica2() {
+        let reason = streamline_block_reason("sl.dlss_g.dll", true, Some(2), Some(310)).unwrap();
+        assert!(reason.contains("version-locked"));
+        assert_eq!(classify_error(&reason), "streamline_locked");
+    }
+
+    #[test]
+    fn streamline_guard_blocks_cross_major_swap_even_when_opted_in() {
+        let reason = streamline_block_reason("sl.interposer.dll", true, Some(1), Some(2)).unwrap();
+        assert!(reason.contains("version-locked"));
+        assert!(reason.contains("v1"));
+        assert!(reason.contains("v2"));
+        assert_eq!(classify_error(&reason), "streamline_locked");
+    }
+
+    #[test]
+    fn version_major_parses_first_numeric_segment() {
+        assert_eq!(version_major("2.11.1"), Some(2));
+        assert_eq!(version_major("1.5.0.0"), Some(1));
+        assert_eq!(version_major("310.6.0.0"), Some(310));
+        assert_eq!(version_major(""), None);
+    }
+}

--- a/src-tauri/src/commands/drivers.rs
+++ b/src-tauri/src/commands/drivers.rs
@@ -6,7 +6,7 @@ use driver_catalog::{
     sources::DEFAULT_HISTORY_LIMIT, DeviceClass, DeviceId, DriverRegistry, DriverRelease,
     DriverStatusReport, DriverVendor, DriverVersion, OsFamily, OsTarget, UpdateStatus,
 };
-use driver_install::state::{classify_exit, describe_exit, InstallStage};
+use driver_install::state::{classify_exit, describe_exit, reboot_required, InstallStage};
 use driver_install::{download_to_file, verify_signature, DownloadOpts};
 use serde::Serialize;
 use std::path::Path;
@@ -136,6 +136,7 @@ pub struct InstallOutcome {
     pub stage: InstallStage,
     pub exit_code: i32,
     pub message: String,
+    pub reboot_required: bool,
 }
 
 const DRIVER_INSTALL_EVENT: &str = "driver_install_progress";
@@ -183,6 +184,10 @@ fn emit_stage(app: &AppHandle, stage: InstallStage, message: &str, progress: Opt
             progress,
         },
     );
+}
+
+fn clear_system_info_cache(state: &AppState) {
+    *state.system_info.write() = None;
 }
 
 #[tauri::command]
@@ -299,10 +304,14 @@ pub async fn install_driver(
     let stage = classify_exit(exit_code);
     let message = describe_exit(exit_code, &vendor);
     emit_stage(&app, stage, &message, None);
+    if matches!(stage, InstallStage::Completed) {
+        clear_system_info_cache(state.inner());
+    }
     Ok(InstallOutcome {
         stage,
         exit_code,
         message,
+        reboot_required: reboot_required(exit_code),
     })
 }
 
@@ -413,5 +422,14 @@ mod tests {
             installer_filename("https://host/archive.zip"),
             "driver-setup.exe"
         );
+    }
+
+    #[test]
+    fn clear_system_info_cache_resets_to_none() {
+        let state = AppState::new();
+        *state.system_info.write() = Some(sysinfo_with_build("22631"));
+        assert!(state.system_info.read().is_some());
+        clear_system_info_cache(&state);
+        assert!(state.system_info.read().is_none());
     }
 }

--- a/src-tauri/src/commands/drivers.rs
+++ b/src-tauri/src/commands/drivers.rs
@@ -47,17 +47,16 @@ fn device_for(gpu: &GpuInfo) -> (DeviceId, DriverVersion) {
 }
 
 pub(crate) async fn ensure_system_info(state: &State<'_, AppState>) -> AppResult<SystemInfo> {
-    {
-        let guard = state.system_info.read();
-        if let Some(info) = guard.as_ref() {
-            return Ok(info.clone());
-        }
-    }
-    let collected = tokio::task::spawn_blocking(system_info::collect)
-        .await
-        .map_err(|e| crate::error::AppError::Other(format!("system_info collect: {e}")))?;
-    *state.system_info.write() = Some(collected.clone());
-    Ok(collected)
+    crate::state::coordinate_singleton(
+        &state.system_info,
+        &state.collect_system_info_lock,
+        || async {
+            tokio::task::spawn_blocking(system_info::collect)
+                .await
+                .map_err(|e| crate::error::AppError::Other(format!("system_info collect: {e}")))
+        },
+    )
+    .await
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod advanced;
 pub mod anticheat;
 pub mod apply;
+pub mod apply_decisions;
 pub mod background;
 pub mod backup;
 pub mod catalog;

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -241,7 +241,11 @@ pub struct BackgroundConfig {
     pub enabled: bool,
     #[serde(default = "default_background_interval_hours")]
     pub interval_hours: u32,
-    #[serde(default)]
+    /// Close-to-tray default flipped to `true` in v1.7 so the X button
+    /// minimizes to tray for new installs. Existing configs that already
+    /// serialized an explicit `false` keep their value — we never silently
+    /// override an explicit user choice.
+    #[serde(default = "default_true")]
     pub close_to_tray: bool,
     #[serde(default)]
     pub run_at_startup: bool,
@@ -264,7 +268,7 @@ impl Default for BackgroundConfig {
         Self {
             enabled: false,
             interval_hours: DEFAULT_BACKGROUND_INTERVAL_HOURS,
-            close_to_tray: false,
+            close_to_tray: true,
             run_at_startup: false,
             notify_os_toast: true,
             auto_apply: false,
@@ -503,10 +507,14 @@ mod background_config_tests {
 
     #[test]
     fn default_background_config_is_disabled_with_safe_defaults() {
+        // v1.7: `close_to_tray` flipped to true by default so the X button
+        // minimizes to tray for new installs. Every other flag stays
+        // conservative — no background scans, no autostart, no auto-apply
+        // until the user opts in.
         let cfg = BackgroundConfig::default();
         assert!(!cfg.enabled);
         assert_eq!(cfg.interval_hours, DEFAULT_BACKGROUND_INTERVAL_HOURS);
-        assert!(!cfg.close_to_tray);
+        assert!(cfg.close_to_tray);
         assert!(!cfg.run_at_startup);
         assert!(cfg.notify_os_toast);
         assert!(!cfg.auto_apply);
@@ -514,6 +522,8 @@ mod background_config_tests {
 
     #[test]
     fn legacy_settings_without_background_migrates_to_defaults() {
+        // A pre-v1.7 settings file with no `background` block must inherit the
+        // v1.7 defaults, including the new `close_to_tray = true`.
         let legacy = r#"{
             "blacklist": ["game-1"],
             "ignored": []
@@ -522,7 +532,7 @@ mod background_config_tests {
         let bg = &settings.background;
         assert!(!bg.enabled);
         assert_eq!(bg.interval_hours, DEFAULT_BACKGROUND_INTERVAL_HOURS);
-        assert!(!bg.close_to_tray);
+        assert!(bg.close_to_tray);
         assert!(!bg.run_at_startup);
         assert!(bg.notify_os_toast);
         assert!(!bg.auto_apply);
@@ -531,13 +541,15 @@ mod background_config_tests {
 
     #[test]
     fn partial_background_object_fills_missing_fields_with_defaults() {
+        // A partial JSON missing `close_to_tray` falls back to the field-level
+        // `default = "default_true"`, so `close_to_tray = true`.
         let partial = r#"{ "enabled": true, "auto_apply": true }"#;
         let cfg: BackgroundConfig = serde_json::from_str(partial).expect("partial parse");
         assert!(cfg.enabled);
         assert!(cfg.auto_apply);
         assert_eq!(cfg.interval_hours, DEFAULT_BACKGROUND_INTERVAL_HOURS);
         assert!(cfg.notify_os_toast);
-        assert!(!cfg.close_to_tray);
+        assert!(cfg.close_to_tray);
     }
 
     #[test]
@@ -591,5 +603,24 @@ mod background_config_tests {
         assert!(back.run_at_startup);
         assert!(!back.notify_os_toast);
         assert!(back.auto_apply);
+    }
+
+    #[test]
+    fn explicit_close_to_tray_false_is_preserved() {
+        // A user who deliberately toggled close-to-tray OFF in v1.6.x — or any
+        // saved config carrying `"close_to_tray": false` — must keep that
+        // value when upgrading to v1.7. We never silently re-enable an
+        // explicit user choice.
+        let json = r#"{ "close_to_tray": false }"#;
+        let cfg: BackgroundConfig = serde_json::from_str(json).expect("parse explicit false");
+        assert!(!cfg.close_to_tray);
+    }
+
+    #[test]
+    fn explicit_close_to_tray_true_round_trips() {
+        // The symmetric case: an explicit `true` round-trips faithfully too.
+        let json = r#"{ "close_to_tray": true }"#;
+        let cfg: BackgroundConfig = serde_json::from_str(json).expect("parse explicit true");
+        assert!(cfg.close_to_tray);
     }
 }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -71,6 +71,11 @@ pub struct AppState {
     pub settings: Arc<RwLock<AppSettings>>,
     pub paths: Arc<RwLock<Option<AppPaths>>>,
     pub system_info: Arc<RwLock<Option<SystemInfo>>>,
+    /// Coordinator for `ensure_system_info` so two concurrent callers don't both
+    /// pay the WMI/DXGI collection cost. Holding the lock guarantees only one
+    /// `collect` runs at a time; the cached value behind `system_info` is the
+    /// fast path and stays in `parking_lot::RwLock` for non-async reads.
+    pub collect_system_info_lock: Arc<tokio::sync::Mutex<()>>,
     pub http_catalog: reqwest::Client,
     pub http_downloads: reqwest::Client,
     pub http_art: reqwest::Client,
@@ -108,6 +113,7 @@ impl AppState {
             settings: Arc::new(RwLock::new(AppSettings::default())),
             paths: Arc::new(RwLock::new(None)),
             system_info: Arc::new(RwLock::new(None)),
+            collect_system_info_lock: Arc::new(tokio::sync::Mutex::new(())),
             http_catalog,
             http_downloads,
             http_art,
@@ -121,6 +127,35 @@ impl Default for AppState {
     fn default() -> Self {
         Self::new()
     }
+}
+
+/// Double-checked locking helper. Returns the cached value if present;
+/// otherwise acquires `coordinator` and runs `collect` exactly once.
+/// Concurrent callers wait on the coordinator and share the same result —
+/// they re-check the cache after acquiring so a winning collector's value
+/// is reused, not re-computed. The cache stays in `parking_lot::RwLock` so
+/// non-async readers do not pay an async-await on the hot path; only the
+/// expensive `collect` is serialized.
+pub async fn coordinate_singleton<T, F, Fut, E>(
+    cache: &RwLock<Option<T>>,
+    coordinator: &tokio::sync::Mutex<()>,
+    collect: F,
+) -> Result<T, E>
+where
+    T: Clone,
+    F: FnOnce() -> Fut,
+    Fut: std::future::Future<Output = Result<T, E>>,
+{
+    if let Some(v) = cache.read().as_ref().cloned() {
+        return Ok(v);
+    }
+    let _guard = coordinator.lock().await;
+    if let Some(v) = cache.read().as_ref().cloned() {
+        return Ok(v);
+    }
+    let v = collect().await?;
+    *cache.write() = Some(v.clone());
+    Ok(v)
 }
 
 #[cfg(test)]
@@ -160,5 +195,54 @@ mod tests {
         assert_eq!(r.in_flight(), 1);
         r.release("a");
         assert_eq!(r.in_flight(), 0);
+    }
+
+    #[tokio::test]
+    async fn coordinate_singleton_runs_collect_exactly_once_under_concurrency() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let cache: Arc<RwLock<Option<u32>>> = Arc::new(RwLock::new(None));
+        let coordinator: Arc<tokio::sync::Mutex<()>> = Arc::new(tokio::sync::Mutex::new(()));
+        let counter = Arc::new(AtomicUsize::new(0));
+
+        let mut tasks = Vec::new();
+        for _ in 0..8 {
+            let cache = cache.clone();
+            let coordinator = coordinator.clone();
+            let counter = counter.clone();
+            tasks.push(tokio::spawn(async move {
+                coordinate_singleton(&cache, &coordinator, || async {
+                    tokio::time::sleep(Duration::from_millis(25)).await;
+                    counter.fetch_add(1, Ordering::SeqCst);
+                    Ok::<u32, ()>(42)
+                })
+                .await
+                .unwrap()
+            }));
+        }
+
+        for t in tasks {
+            assert_eq!(t.await.unwrap(), 42);
+        }
+
+        assert_eq!(
+            counter.load(Ordering::SeqCst),
+            1,
+            "collect ran more than once under 8-way concurrency"
+        );
+    }
+
+    #[tokio::test]
+    async fn coordinate_singleton_returns_cached_value_on_fast_path() {
+        let cache: Arc<RwLock<Option<u32>>> = Arc::new(RwLock::new(Some(7)));
+        let coordinator: Arc<tokio::sync::Mutex<()>> = Arc::new(tokio::sync::Mutex::new(()));
+        let result = coordinate_singleton(&cache, &coordinator, || async {
+            panic!("collect must not run when the cache is already populated");
+            #[allow(unreachable_code)]
+            Ok::<u32, ()>(0)
+        })
+        .await
+        .unwrap();
+        assert_eq!(result, 7);
     }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "DLSSync",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "identifier": "io.github.xt0n1-t3ch.dlssync",
   "build": {
     "beforeBuildCommand": "pnpm -w run prebuild:kill && pnpm --filter dlssync-frontend build",

--- a/tests/components/glassDialogUnification.test.ts
+++ b/tests/components/glassDialogUnification.test.ts
@@ -11,18 +11,26 @@ function source(name: string): string {
 }
 
 describe("Phase 8 — floating chrome shares the .glass-dialog material", () => {
-  const dialogPanels = [
+  const directPanels = [
     "ApplyProgressModal.svelte",
     "VersionPickerPopover.svelte",
-    "CatalogVersionsFlyout.svelte",
-    "DriverHistoryFlyout.svelte",
     "Select.svelte",
     "NotificationsBell.svelte",
   ];
+  const shellRoutedFlyouts = ["CatalogVersionsFlyout.svelte", "DriverHistoryFlyout.svelte"];
 
   it("applies the .glass-dialog class on every floating-chrome panel", () => {
-    for (const file of dialogPanels) {
+    for (const file of directPanels) {
       expect(source(file), `${file} should carry glass-dialog`).toContain("glass-dialog");
+    }
+    expect(
+      source("FlyoutShell.svelte"),
+      "FlyoutShell should carry glass-dialog for routed flyouts",
+    ).toContain("glass-dialog");
+    for (const file of shellRoutedFlyouts) {
+      expect(source(file), `${file} should route chrome through FlyoutShell`).toContain(
+        "<FlyoutShell",
+      );
     }
   });
 
@@ -44,7 +52,7 @@ describe("Phase 8 — floating chrome shares the .glass-dialog material", () => 
   });
 
   it("drops the bespoke per-component glass/vendor-stripe surfaces", () => {
-    for (const file of dialogPanels) {
+    for (const file of [...directPanels, ...shellRoutedFlyouts]) {
       const src = source(file);
       expect(src, `${file} must not redefine backdrop-filter locally`).not.toContain(
         "backdrop-filter: var(--glass-blur)",
@@ -55,7 +63,14 @@ describe("Phase 8 — floating chrome shares the .glass-dialog material", () => 
   });
 
   it("routes vendor accent through the shared stripe via --edge-color", () => {
-    expect(source("CatalogVersionsFlyout.svelte")).toContain("--edge-color={accent}");
-    expect(source("DriverHistoryFlyout.svelte")).toContain("--edge-color={accent}");
+    expect(
+      source("FlyoutShell.svelte"),
+      "FlyoutShell is the central --edge-color routing surface",
+    ).toContain("--edge-color={accent}");
+    for (const file of shellRoutedFlyouts) {
+      expect(source(file), `${file} must pass {accent} into FlyoutShell`).toMatch(
+        /<FlyoutShell[\s\S]*?\{accent\}/,
+      );
+    }
   });
 });

--- a/tests/contracts/a11y.test.ts
+++ b/tests/contracts/a11y.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/svelte";
+import { tick } from "svelte";
+import axe from "axe-core";
+import Checkbox from "@/components/Checkbox.svelte";
+import CounterPill from "@/components/CounterPill.svelte";
+import BrandMark from "@/components/BrandMark.svelte";
+import Toast from "@/components/Toast.svelte";
+import { showToast, toasts } from "@/lib/stores";
+
+const RUN_CONFIG: axe.RunOptions = {
+  runOnly: { type: "tag", values: ["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"] },
+  rules: {
+    "color-contrast": { enabled: false },
+    region: { enabled: false },
+    "landmark-one-main": { enabled: false },
+    "page-has-heading-one": { enabled: false },
+    "meta-viewport": { enabled: false },
+    "html-has-lang": { enabled: false },
+    "document-title": { enabled: false },
+    bypass: { enabled: false },
+  },
+  resultTypes: ["violations"],
+};
+
+async function criticalAndSeriousViolations(container: HTMLElement): Promise<axe.Result[]> {
+  const results = await axe.run(container, RUN_CONFIG);
+  return results.violations.filter(
+    (v) => v.impact === "critical" || v.impact === "serious",
+  );
+}
+
+function format(violations: axe.Result[]): string {
+  if (violations.length === 0) return "(no violations)";
+  return violations
+    .map(
+      (v) =>
+        `- ${v.id} [${v.impact}] ${v.help} (${v.nodes.length} node${v.nodes.length === 1 ? "" : "s"})`,
+    )
+    .join("\n");
+}
+
+describe("a11y contract — axe critical/serious sweep on core components", () => {
+  it("CounterPill carries no critical/serious WCAG violations", async () => {
+    const { container } = render(CounterPill, {
+      props: { count: 12, tone: "update", ariaLabel: "12 pending updates" },
+    });
+    const violations = await criticalAndSeriousViolations(container);
+    expect(violations.length, format(violations)).toBe(0);
+  });
+
+  it("BrandMark carries no critical/serious WCAG violations", async () => {
+    const { container } = render(BrandMark, { props: { key: "nvidia" } });
+    const violations = await criticalAndSeriousViolations(container);
+    expect(violations.length, format(violations)).toBe(0);
+  });
+
+  it("Checkbox carries no critical/serious WCAG violations", async () => {
+    const { container } = render(Checkbox, {
+      props: { checked: false, label: "Notify me on completion" },
+    });
+    const violations = await criticalAndSeriousViolations(container);
+    expect(violations.length, format(violations)).toBe(0);
+  });
+
+  it("Toast (populated) carries no critical/serious WCAG violations", async () => {
+    toasts.set([]);
+    const { container } = render(Toast);
+    showToast("success", "Updated Cyberpunk 2077");
+    await tick();
+    const violations = await criticalAndSeriousViolations(container);
+    expect(violations.length, format(violations)).toBe(0);
+    toasts.set([]);
+  });
+});

--- a/tests/contracts/bundleSizeBudget.test.ts
+++ b/tests/contracts/bundleSizeBudget.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { gzipSync } from "node:zlib";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const distDir = resolve(here, "../../frontend/dist/assets");
+
+const BUDGET_JS_GZIP_BYTES = 250 * 1024;
+const BUDGET_CSS_GZIP_BYTES = 75 * 1024;
+const KNOWN_CHUNK_PREFIXES = ["index-", "image-", "app-", "window-"];
+const STEALTH_CHUNK_MIN_BYTES = 1024;
+
+function gzipBytes(path: string): number {
+  return gzipSync(readFileSync(path)).length;
+}
+
+function fmt(bytes: number): string {
+  return `${(bytes / 1024).toFixed(1)} KB`;
+}
+
+describe.skipIf(!existsSync(distDir))(
+  "bundle size budget (post-build, gzip-measured)",
+  () => {
+    it("the biggest index-*.js chunk stays under the gzip budget", () => {
+      type Chunk = { name: string; gzip: number };
+      const candidates: Chunk[] = readdirSync(distDir)
+        .filter((f: string) => f.startsWith("index-") && f.endsWith(".js"))
+        .map(
+          (name: string): Chunk => ({
+            name,
+            gzip: gzipBytes(resolve(distDir, name)),
+          }),
+        )
+        .sort((a: Chunk, b: Chunk) => b.gzip - a.gzip);
+
+      expect(candidates.length, `no index-*.js in ${distDir}`).toBeGreaterThan(0);
+
+      const biggest = candidates[0];
+      expect(
+        biggest.gzip,
+        `${biggest.name} = ${fmt(biggest.gzip)} gzip exceeds the ${fmt(BUDGET_JS_GZIP_BYTES)} budget`,
+      ).toBeLessThan(BUDGET_JS_GZIP_BYTES);
+    });
+
+    it("every index-*.css bundle stays under the gzip budget", () => {
+      type Chunk = { name: string; gzip: number };
+      const candidates: Chunk[] = readdirSync(distDir)
+        .filter((f: string) => f.startsWith("index-") && f.endsWith(".css"))
+        .map(
+          (name: string): Chunk => ({
+            name,
+            gzip: gzipBytes(resolve(distDir, name)),
+          }),
+        );
+
+      expect(candidates.length, `no index-*.css in ${distDir}`).toBeGreaterThan(0);
+
+      for (const c of candidates) {
+        expect(
+          c.gzip,
+          `${c.name} = ${fmt(c.gzip)} gzip exceeds the ${fmt(BUDGET_CSS_GZIP_BYTES)} budget`,
+        ).toBeLessThan(BUDGET_CSS_GZIP_BYTES);
+      }
+    });
+
+    it("no stealth JS chunk lands outside the known emit prefixes", () => {
+      const surprises: string[] = readdirSync(distDir)
+        .filter((f: string) => f.endsWith(".js"))
+        .filter((f: string) => gzipBytes(resolve(distDir, f)) > STEALTH_CHUNK_MIN_BYTES)
+        .filter((f: string) => !KNOWN_CHUNK_PREFIXES.some((p) => f.startsWith(p)));
+
+      expect(
+        surprises,
+        `unknown >${fmt(STEALTH_CHUNK_MIN_BYTES)} JS chunks: ${surprises.join(", ")} — add the prefix to KNOWN_CHUNK_PREFIXES intentionally after reviewing what's inside`,
+      ).toEqual([]);
+    });
+  },
+);

--- a/tests/integration/driverInstall.test.ts
+++ b/tests/integration/driverInstall.test.ts
@@ -20,10 +20,13 @@ vi.mock("@/lib/api", async (importOriginal) => {
 
 import {
   driverInstall,
+  driverRebootPending,
+  loadDriverUpdates,
   startDriverInstall,
   applyDriverInstallProgress,
   toasts,
 } from "@/lib/stores";
+import { checkDriverUpdates } from "@/lib/api";
 
 function report(vendor: GpuVendor, downloadUrl: string | null): DriverStatusReport {
   return {
@@ -57,8 +60,10 @@ function complete(outcome: DriverInstallOutcome): void {
 
 beforeEach(() => {
   driverInstall.set({ vendor: null, stage: null, message: "", fraction: null });
+  driverRebootPending.set({});
   toasts.set([]);
   pendingResolve = null;
+  vi.mocked(checkDriverUpdates).mockResolvedValue([]);
 });
 
 describe("driver install — shared store state machine", () => {
@@ -80,7 +85,7 @@ describe("driver install — shared store state machine", () => {
     applyDriverInstallProgress({ stage: "installing", message: "Installing", progress: null });
     expect(get(driverInstall).stage).toBe("installing");
 
-    complete({ stage: "completed", exit_code: 0, message: "Driver installed successfully." });
+    complete({ stage: "completed", exit_code: 0, message: "Driver installed successfully.", reboot_required: false });
     await p;
     expect(get(driverInstall).vendor).toBeNull();
     expect(get(toasts).at(-1)?.kind).toBe("success");
@@ -91,13 +96,13 @@ describe("driver install — shared store state machine", () => {
     expect(get(driverInstall).vendor).toBe("intel");
     await startDriverInstall(report("nvidia", "https://nv/driver.exe"));
     expect(get(driverInstall).vendor).toBe("intel");
-    complete({ stage: "completed", exit_code: 0, message: "done" });
+    complete({ stage: "completed", exit_code: 0, message: "done", reboot_required: false });
     await first;
   });
 
   it("maps a cancelled outcome to a warning toast and clears state", async () => {
     const p = startDriverInstall(report("intel", "https://intel/gfx.exe"));
-    complete({ stage: "cancelled", exit_code: 1602, message: "Installation cancelled." });
+    complete({ stage: "cancelled", exit_code: 1602, message: "Installation cancelled.", reboot_required: false });
     await p;
     expect(get(driverInstall).vendor).toBeNull();
     expect(get(toasts).at(-1)?.kind).toBe("warning");
@@ -105,7 +110,7 @@ describe("driver install — shared store state machine", () => {
 
   it("maps a failed outcome (e.g. Intel exit 8) to a danger toast and clears state", async () => {
     const p = startDriverInstall(report("intel", "https://intel/gfx.exe"));
-    complete({ stage: "failed", exit_code: 8, message: "This Intel driver does not list your GPU (exit code 8)." });
+    complete({ stage: "failed", exit_code: 8, message: "This Intel driver does not list your GPU (exit code 8).", reboot_required: false });
     await p;
     expect(get(driverInstall).vendor).toBeNull();
     expect(get(toasts).at(-1)?.kind).toBe("danger");
@@ -115,5 +120,40 @@ describe("driver install — shared store state machine", () => {
     await startDriverInstall(report("amd", ""));
     expect(get(driverInstall).vendor).toBeNull();
     expect(pendingResolve).toBeNull();
+  });
+});
+
+describe("driver install — reboot-pending state", () => {
+  it("a completed install with reboot_required marks the vendor pending with its version", async () => {
+    const p = startDriverInstall(report("nvidia", "https://nv/driver.exe"));
+    complete({ stage: "completed", exit_code: 3010, message: "Driver installed. Restart to finish.", reboot_required: true });
+    await p;
+    expect(get(driverRebootPending).nvidia).toBe("2.0");
+    expect(get(driverInstall).vendor).toBeNull();
+    expect(get(toasts).at(-1)?.kind).toBe("success");
+  });
+
+  it("a completed install without reboot_required clears any pending state for the vendor", async () => {
+    driverRebootPending.set({ nvidia: "1.9" });
+    const p = startDriverInstall(report("nvidia", "https://nv/driver.exe"));
+    complete({ stage: "completed", exit_code: 0, message: "Driver installed successfully.", reboot_required: false });
+    await p;
+    expect(get(driverRebootPending).nvidia).toBeUndefined();
+  });
+
+  it("loadDriverUpdates prunes a vendor that comes back up_to_date", async () => {
+    driverRebootPending.set({ nvidia: "2.0" });
+    const upToDate = report("nvidia", "https://nv/driver.exe");
+    upToDate.status = "up_to_date";
+    vi.mocked(checkDriverUpdates).mockResolvedValueOnce([upToDate]);
+    await loadDriverUpdates();
+    expect(get(driverRebootPending).nvidia).toBeUndefined();
+  });
+
+  it("loadDriverUpdates keeps a vendor still showing update_available (staged, not active)", async () => {
+    driverRebootPending.set({ nvidia: "2.0" });
+    vi.mocked(checkDriverUpdates).mockResolvedValueOnce([report("nvidia", "https://nv/driver.exe")]);
+    await loadDriverUpdates();
+    expect(get(driverRebootPending).nvidia).toBe("2.0");
   });
 });


### PR DESCRIPTION
## v1.6.6 release

Quality-of-life on the X button, the apply modal, and Backups. The X minimizes to the system tray for new installs while your saved choice still wins. The Apply Progress wall is gone: close the modal mid-apply, navigate to Catalog or About, then pick it back up from the activity dock. And the date-grouped Backups view divides itself into month headers, so months of history read at a glance instead of a flat scroll.

See `CHANGELOG.md` `[1.6.6]` for the full Added / Changed / Fixed lists.

### Gates

- `cargo fmt --all -- --check`: exit 0
- `cargo clippy -p dlssync --lib --tests -- -D warnings`: exit 0
- `cargo test --workspace --lib`: 367 tests, 12 crates, 0 failed
- `svelte-check`: 0 errors / 0 warnings
- `vitest`: 51 files, 452 tests, 0 failed (includes the new `a11y.test.ts` axe-core sweep + `bundleSizeBudget.test.ts`)
- `pnpm build`: 4.15s, JS 230.87 KB gzip / CSS 66.81 KB gzip (within 250 / 75 KB budgets)
- `pnpm tauri build --debug --no-bundle`: 45.5s, `target/debug/dlssync.exe` boots against real user data (catalog + backups DB + settings load clean)

### Major changes

- **T-2 apply pipeline refactor**: pure decision helpers extracted to `commands/apply_decisions.rs` with a focused 14-test cargo suite. apply.rs hot path trims 325 lines, stays the orchestrator.
- **T-9 `<FlyoutShell>`**: shared backdrop / dialog frame / Escape-close / fly transition primitive consumed by Driver History + Catalog Versions. VersionPickerPopover stays separate (structurally divergent).
- **T-11 axe-core a11y contract**: `axe-core@^4.10.3` added at workspace root. `tests/contracts/a11y.test.ts` renders Checkbox / CounterPill / BrandMark / Toast and gates on zero critical/serious WCAG violations.
- **T-6 Backups month headers**: month dividers inline in the existing `{#each filtered}` loop when `groupBy === "date"`. No parallel view, no god-component plumbing.
- **Round 0 backend reliability**: `coordinate_singleton` helper + `ensure_system_info` coordination + `fs::copy` wrapped in `spawn_blocking`. `close_to_tray` default ON for new installs, explicit `false` preserved.

26 files changed, +1032 / -454 net.