### PR TITLE
feat(frontend): add mouse side-button navigation

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onMount } from "svelte";
+  import { get } from "svelte/store";
   import { invoke } from "@tauri-apps/api/core";
   import { fade, fly } from "svelte/transition";
   import Sidebar from "./components/Sidebar.svelte";
@@ -43,6 +44,11 @@
   } from "./lib/driverInstallEvents";
   import { isLocale, localeFromNavigator, setLocale, t } from "./lib/i18n/index";
   import { motionDuration } from "./lib/ux";
+  import {
+    createAppNavigationHistory,
+    navigationDirectionForMouseButton,
+    type AppNavigationState,
+  } from "./lib/appNavigation";
 
   let theme = $state(localStorage.getItem("dlssync-theme") || "dark");
 
@@ -60,6 +66,15 @@
 
   let collapsed = $derived($settings?.ui_prefs.sidebar_collapsed ?? false);
   let railGameId = $derived($currentView === "library" ? $drawerGameId : null);
+
+  const navHistory = createAppNavigationHistory({
+    view: get(currentView),
+    drawerGameId: get(drawerGameId),
+  });
+  $effect(() => {
+    const state: AppNavigationState = { view: $currentView, drawerGameId: $drawerGameId };
+    navHistory.record(state);
+  });
 
   let gameAccent = $state<string | null>(null);
   $effect(() => {
@@ -133,6 +148,21 @@
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
+  });
+
+  onMount(() => {
+    const onMouse = (e: MouseEvent): void => {
+      const direction = navigationDirectionForMouseButton(e.button);
+      if (!direction) return;
+      e.preventDefault();
+      if (!navHistory.canMove(direction)) return;
+      const target = navHistory.move(direction);
+      if (!target) return;
+      currentView.set(target.view);
+      drawerGameId.set(target.drawerGameId);
+    };
+    window.addEventListener("mouseup", onMouse);
+    return () => window.removeEventListener("mouseup", onMouse);
   });
 </script>
 

--- a/frontend/src/lib/appNavigation.ts
+++ b/frontend/src/lib/appNavigation.ts
@@ -1,0 +1,54 @@
+export const MOUSE_BACK_BUTTON = 3;
+export const MOUSE_FORWARD_BUTTON = 4;
+
+export interface AppNavigationState {
+  view: string;
+  drawerGameId: string | null;
+}
+
+export type AppNavigationDirection = "back" | "forward";
+
+export interface AppNavigationHistory {
+  readonly entries: readonly AppNavigationState[];
+  readonly index: number;
+  record(state: AppNavigationState): void;
+  move(direction: AppNavigationDirection): AppNavigationState | null;
+  canMove(direction: AppNavigationDirection): boolean;
+}
+
+function sameState(a: AppNavigationState, b: AppNavigationState): boolean {
+  return a.view === b.view && a.drawerGameId === b.drawerGameId;
+}
+
+export function createAppNavigationHistory(initial: AppNavigationState): AppNavigationHistory {
+  let entries: AppNavigationState[] = [initial];
+  let index = 0;
+  return {
+    get entries() {
+      return entries;
+    },
+    get index() {
+      return index;
+    },
+    record(state) {
+      if (sameState(entries[index], state)) return;
+      entries = [...entries.slice(0, index + 1), state];
+      index = entries.length - 1;
+    },
+    move(direction) {
+      const nextIndex = direction === "back" ? index - 1 : index + 1;
+      if (nextIndex < 0 || nextIndex >= entries.length) return null;
+      index = nextIndex;
+      return entries[index];
+    },
+    canMove(direction) {
+      return direction === "back" ? index > 0 : index < entries.length - 1;
+    },
+  };
+}
+
+export function navigationDirectionForMouseButton(button: number): AppNavigationDirection | null {
+  if (button === MOUSE_BACK_BUTTON) return "back";
+  if (button === MOUSE_FORWARD_BUTTON) return "forward";
+  return null;
+}

--- a/tests/components/appSideButtonNav.test.ts
+++ b/tests/components/appSideButtonNav.test.ts
@@ -1,0 +1,43 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, it, expect } from "vitest";
+
+const APP_SOURCE = resolve(__dirname, "../../frontend/src/App.svelte");
+const source = readFileSync(APP_SOURCE, "utf8");
+const flat = source.replace(/\s+/g, " ");
+
+describe("App side-button navigation wiring", () => {
+  it("uses the appNavigation contract instead of browser history", () => {
+    expect(source).toMatch(
+      /import\s*\{[^}]*createAppNavigationHistory[^}]*navigationDirectionForMouseButton[^}]*\}\s*from\s*"\.\/lib\/appNavigation"/s,
+    );
+    expect(flat).toContain("createAppNavigationHistory(");
+    expect(source).not.toContain("history.back");
+    expect(source).not.toContain("history.forward");
+  });
+
+  it("records view and drawer changes as navigable states", () => {
+    expect(flat).toMatch(/view:\s*\$currentView,\s*drawerGameId:\s*\$drawerGameId/);
+    expect(flat).toContain("navHistory.record(");
+  });
+
+  it("maps side mouse buttons through the contract on a window mouseup listener", () => {
+    expect(flat).toContain('window.addEventListener("mouseup"');
+    expect(flat).toMatch(/navigationDirectionForMouseButton\(\s*e\.button\s*\)/);
+  });
+
+  it("prevents default for handled back/forward side-button events", () => {
+    expect(flat).toMatch(/if\s*\(\s*!direction\s*\)\s*return;\s*e\.preventDefault\(\)/);
+  });
+
+  it("applies a history move only when it can move, then writes both stores", () => {
+    expect(flat).toMatch(/navHistory\.canMove\(\s*direction\s*\)/);
+    expect(flat).toContain("navHistory.move(");
+    expect(flat).toMatch(/currentView\.set\(\s*target\.view\s*\)/);
+    expect(flat).toMatch(/drawerGameId\.set\(\s*target\.drawerGameId\s*\)/);
+  });
+
+  it("removes the side-button listener on teardown", () => {
+    expect(flat).toContain('window.removeEventListener("mouseup"');
+  });
+});

--- a/tests/unit/appNavigation.test.ts
+++ b/tests/unit/appNavigation.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import {
+  MOUSE_BACK_BUTTON,
+  MOUSE_FORWARD_BUTTON,
+  createAppNavigationHistory,
+  navigationDirectionForMouseButton,
+} from "@/lib/appNavigation";
+
+describe("app navigation history", () => {
+  it("moves backward and forward through view states", () => {
+    const history = createAppNavigationHistory({ view: "library", drawerGameId: null });
+
+    history.record({ view: "catalog", drawerGameId: null });
+    history.record({ view: "drivers", drawerGameId: null });
+
+    expect(history.canMove("back")).toBe(true);
+    expect(history.move("back")).toEqual({ view: "catalog", drawerGameId: null });
+    expect(history.move("back")).toEqual({ view: "library", drawerGameId: null });
+    expect(history.move("back")).toBeNull();
+    expect(history.canMove("forward")).toBe(true);
+    expect(history.move("forward")).toEqual({ view: "catalog", drawerGameId: null });
+  });
+
+  it("tracks detail rail open and close as navigable states", () => {
+    const history = createAppNavigationHistory({ view: "library", drawerGameId: null });
+
+    history.record({ view: "library", drawerGameId: "game-1" });
+    history.record({ view: "library", drawerGameId: null });
+
+    expect(history.move("back")).toEqual({ view: "library", drawerGameId: "game-1" });
+    expect(history.move("back")).toEqual({ view: "library", drawerGameId: null });
+  });
+
+  it("does not duplicate unchanged states", () => {
+    const history = createAppNavigationHistory({ view: "library", drawerGameId: null });
+
+    history.record({ view: "library", drawerGameId: null });
+
+    expect(history.entries).toHaveLength(1);
+  });
+
+  it("drops forward history after recording a new branch", () => {
+    const history = createAppNavigationHistory({ view: "library", drawerGameId: null });
+
+    history.record({ view: "catalog", drawerGameId: null });
+    history.record({ view: "drivers", drawerGameId: null });
+    expect(history.move("back")).toEqual({ view: "catalog", drawerGameId: null });
+
+    history.record({ view: "settings", drawerGameId: null });
+
+    expect(history.entries.map((entry) => entry.view)).toEqual(["library", "catalog", "settings"]);
+    expect(history.canMove("forward")).toBe(false);
+  });
+});
+
+describe("navigationDirectionForMouseButton", () => {
+  it("maps side mouse buttons to app history directions", () => {
+    expect(navigationDirectionForMouseButton(MOUSE_BACK_BUTTON)).toBe("back");
+    expect(navigationDirectionForMouseButton(MOUSE_FORWARD_BUTTON)).toBe("forward");
+  });
+
+  it("ignores primary, middle, and secondary mouse buttons", () => {
+    expect(navigationDirectionForMouseButton(0)).toBeNull();
+    expect(navigationDirectionForMouseButton(1)).toBeNull();
+    expect(navigationDirectionForMouseButton(2)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Resumen
- Agrega un contrato de historial interno para estados de vista/drawer de DLSSync.
- Conecta los botones laterales del mouse en `App.svelte`: botón 3 navega hacia atrás y botón 4 navega hacia adelante.
- Captura transiciones entre menús/vistas y abrir/cerrar el drawer de detalle de juego.
- Agrega cobertura unitaria para el contrato puro y la integración del App shell.

Closes #15

## Mapeo de aceptación
- [x] Back lateral vuelve al estado/menú anterior de DLSSync.
- [x] Forward lateral restaura el siguiente estado cuando existe.
- [x] El drawer de detalle de juego entra en el historial: abrir y cerrar son navegables.
- [x] La navegación no depende de `history.back()` / `history.forward()` del navegador.
- [x] Botones no laterales no se interceptan.

## Archivos cambiados
- `frontend/src/lib/appNavigation.ts` — contrato puro de historial + mapping de botones mouse.
- `frontend/src/App.svelte` — listener `mouseup`, escritura a stores y cleanup.
- `tests/unit/appNavigation.test.ts` — back/forward, dedupe, branch-drop y mapping de botones.
- `tests/components/appSideButtonNav.test.ts` — prueba de wiring del App shell.

## Evidencia
- `pnpm --filter dlssync-frontend test -- appSideButtonNav.test.ts appNavigation.test.ts` → 2 archivos / 12 tests passed.
- `pnpm --filter dlssync-frontend test` → 62 archivos / 519 passed / 1 skipped.
- `pnpm --filter dlssync-frontend check` → 0 errors / 0 warnings.
- `pnpm --filter dlssync-frontend build` → build de producción completado.
- `git diff --check` → limpio.
- GitHub CI → Frontend (typecheck + build), Rust (fmt + clippy + check), y E2E (Playwright over WebView2) pasaron.

## Impacto release/docs
- Cambio user-facing: pertenece a `v1.6.8`.
- Follow-up PR #17 alinea version metadata, changelog, README y docs/release-marketing.

## Riesgo y rollback
- Riesgo: bajo; el historial es app-local y sólo intercepta botones laterales reconocidos.
- Rollback: revertir este PR remueve el listener y el contrato de navegación lateral.
- Archivo local no relacionado `.github/assets/nexus/badge-strip-1300x220.png` no fue incluido.