### PR TITLE
chore(release): preparar v1.6.8 navigation polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to DLSSync are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.8] - 2026-06-12
+
+The navigation-polish release. DLSSync now respects the back and forward side buttons on gaming mice, but keeps that movement inside the app instead of handing it to Chromium history. You can jump back to the previous menu, restore the next app state when one exists, and reopen or close the game-detail drawer through the same history stack.
+
+### Added
+
+- Mouse side-button navigation across DLSSync app state: button 3 goes back and button 4 goes forward through views and game-detail drawer open/close states.
+- A small app-navigation history contract with unit coverage for back/forward movement, duplicate-state suppression, forward-branch dropping after new navigation, and mouse-button mapping.
+
+### Changed
+
+- The app shell now intercepts recognized side-button `mouseup` events and writes the target state back into `currentView` and `drawerGameId`, so browser history is never used for internal navigation.
+- README and release-marketing docs now point at v1.6.8 as the current public release line.
+
+### Fixed
+
+- Mouse users no longer have to return to the sidebar or keyboard shortcuts just to move back to the previous DLSSync menu or detail-drawer state.
+
 ## [1.6.7] - 2026-06-10
 
 The vendor-parity, trust, and color release. AMD one-click driver install works now — it was quietly broken before. The catalog is cryptographically enforced: a tampered manifest is rejected, and an offline first run still loads a signed catalog instead of a blank screen. Two full security passes closed holes around the driver installer, backup restore, elevated restores, and downloads. FSR and XeSS now update as coherent multi-DLL sets in one atomic click — with a hardware gate so FSR 4 is never pushed onto a GPU that can't run it. And the whole interface learned to speak in color: vendor-brand tech badges, a status hero in the Library, traffic-light state everywhere, and game art that tints the app around it.
@@ -222,6 +240,7 @@ of the Arc desktop package, and install progress no longer breaks when you switc
 - AMD opens its official download page instead of a constructed installer URL. The direct `.exe` is gated behind a license prompt and its filename changes per release, so a fabricated link was unreliable; version and changelog detection are unchanged.
 - Vendor installer exit codes are reported with a readable message. Intel's "no compatible device" (exit code 8) now explains the GPU may be OEM-locked or need a different driver branch, pointing to the manufacturer or Windows Update.
 
+[1.6.8]: https://github.com/xt0n1-t3ch/DLSSync/releases/tag/v1.6.8
 [1.6.7]: https://github.com/xt0n1-t3ch/DLSSync/releases/tag/v1.6.7
 [1.6.6]: https://github.com/xt0n1-t3ch/DLSSync/releases/tag/v1.6.6
 [1.6.5]: https://github.com/xt0n1-t3ch/DLSSync/releases/tag/v1.6.5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "anticheat-detect"
-version = "1.6.7"
+version = "1.6.8"
 dependencies = [
  "jwalk",
  "memchr",
@@ -352,7 +352,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "backup-store"
-version = "1.6.7"
+version = "1.6.8"
 dependencies = [
  "chrono",
  "rusqlite",
@@ -1143,7 +1143,7 @@ dependencies = [
 
 [[package]]
 name = "dll-catalog"
-version = "1.6.7"
+version = "1.6.8"
 dependencies = [
  "bytes",
  "chrono",
@@ -1168,7 +1168,7 @@ dependencies = [
 
 [[package]]
 name = "dll-scanner"
-version = "1.6.7"
+version = "1.6.8"
 dependencies = [
  "jwalk",
  "once_cell",
@@ -1205,7 +1205,7 @@ dependencies = [
 
 [[package]]
 name = "dlssync"
-version = "1.6.7"
+version = "1.6.8"
 dependencies = [
  "anticheat-detect",
  "anyhow",
@@ -1288,7 +1288,7 @@ dependencies = [
 
 [[package]]
 name = "driver-catalog"
-version = "1.6.7"
+version = "1.6.8"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1304,7 +1304,7 @@ dependencies = [
 
 [[package]]
 name = "driver-install"
-version = "1.6.7"
+version = "1.6.8"
 dependencies = [
  "dll-catalog",
  "futures-util",
@@ -2640,7 +2640,7 @@ dependencies = [
 
 [[package]]
 name = "launcher-scan"
-version = "1.6.7"
+version = "1.6.8"
 dependencies = [
  "serde",
  "serde_json",
@@ -2777,7 +2777,7 @@ dependencies = [
 
 [[package]]
 name = "manifest-builder"
-version = "1.6.7"
+version = "1.6.8"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2963,7 +2963,7 @@ dependencies = [
 
 [[package]]
 name = "notifications-store"
-version = "1.6.7"
+version = "1.6.8"
 dependencies = [
  "chrono",
  "rusqlite",
@@ -3055,7 +3055,7 @@ dependencies = [
 
 [[package]]
 name = "nvapi-drs"
-version = "1.6.7"
+version = "1.6.8"
 dependencies = [
  "serde",
  "windows-sys 0.59.0",
@@ -3418,7 +3418,7 @@ checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "pe-version"
-version = "1.6.7"
+version = "1.6.8"
 dependencies = [
  "pelite",
  "serde",
@@ -4827,7 +4827,7 @@ dependencies = [
 
 [[package]]
 name = "system-drivers"
-version = "1.6.7"
+version = "1.6.8"
 dependencies = [
  "serde",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["src-tauri", "crates/*"]
 
 [workspace.package]
-version = "1.6.7"
+version = "1.6.8"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/xt0n1-t3ch/DLSSync"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 </p>
 
 <p align="center">
-  <sub><b>New in v1.6.7:</b> AMD one-click driver install, signed manifest enforcement, hardware-gated FSR/XeSS set updates, reverted-swap detection, catalog fallback, and a cleaner color-coded interface. See <a href="CHANGELOG.md#167---2026-06-10">CHANGELOG</a>.</sub>
+  <sub><b>New in v1.6.8:</b> mouse side buttons now move backward and forward through DLSSync menus and the game-detail drawer, with the v1.6.7 driver, manifest, catalog, and color-system work carried forward. See <a href="CHANGELOG.md#168---2026-06-12">CHANGELOG</a>.</sub>
 </p>
 
 <p align="center">
@@ -226,7 +226,7 @@ The DLL-sync path has no driver, no kernel-mode hook, no in-process injection â€
 
 <p align="center">
   <a href="https://github.com/xt0n1-t3ch/DLSSync/releases/latest">
-    <img src="./.github/assets/download-button.svg" alt="Download DLSSync v1.6.7 for Windows 10 / 11" width="520"/>
+    <img src="./.github/assets/download-button.svg" alt="Download DLSSync v1.6.8 for Windows 10 / 11" width="520"/>
   </a>
 </p>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@
 | [anticheat.md](anticheat.md) | Per-game anti-cheat detection (local binary scan + bundled dataset) and the false-positive ban warning shown before any DLL swap or DLSS override |
 | [cdp-validation.md](cdp-validation.md) | Visual validation via CDP: attach to the app's own WebView2 remote-debugging port (NOT Edge, NOT localhost), `Page.captureScreenshot` regardless of foreground, and why the other approaches fail |
 | [translations.md](translations.md) | Contributor + translator guide for the i18n catalogs: where every UI string lives (`locales/<locale>.json`), the `area.component.purpose` key scheme, `{placeholder}` and `_one`/`_other` plural rules, the `_meta.json` sidecar, how to translate or add a language without touching code, the two parity validators, and what a parity failure looks like |
-| [release-marketing.md](release-marketing.md) | GitHub/Nexus discovery strategy, current v1.6.7 value proposition, SEO-safe wording, Nexus description order, and the canonical public asset map |
+| [release-marketing.md](release-marketing.md) | GitHub/Nexus discovery strategy, current v1.6.8 value proposition, SEO-safe wording, Nexus description order, and the canonical public asset map |
 
 Project-level references live at the repo root: [README.md](../README.md),
 [CHANGELOG.md](../CHANGELOG.md), and the test-suite index at [tests/index.md](../tests/index.md).

--- a/docs/release-marketing.md
+++ b/docs/release-marketing.md
@@ -9,7 +9,7 @@ DLSSync should be discoverable without looking like keyword spam. The public pro
 - Lead with the minimalist banner: `.github/assets/nexus/banner-2560x720.png`.
 - Keep the first paragraph under 90 words and include the real search phrases users type: DLSS updater, FSR updater, XeSS updater, GPU driver updater, DLSS swapper alternative.
 - Keep the visible "Also useful if you searched for" line. Do not hide a keyword block in HTML comments.
-- Keep the release chip current with the exact app version and changelog anchor.
+- Keep the release chip current with the exact app version and changelog anchor. For v1.6.8, the public hook is mouse side-button back/forward navigation through DLSSync menus and the game-detail drawer, plus the v1.6.7 trust/driver foundation.
 - Keep security claims tied to the implementation: signed manifest, SHA-256 catalog hashes, Authenticode publisher gate, official vendor domains, local backup snapshots, one-click rollback, zero telemetry.
 
 ## Nexus Mods

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dlssync-frontend",
   "private": true,
-  "version": "1.6.7",
+  "version": "1.6.8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dlssync",
-  "version": "1.6.7",
+  "version": "1.6.8",
   "private": true,
   "scripts": {
     "dev": "tauri dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "DLSSync",
-  "version": "1.6.7",
+  "version": "1.6.8",
   "identifier": "io.github.xt0n1-t3ch.dlssync",
   "build": {
     "beforeBuildCommand": "pnpm -w run prebuild:kill && pnpm --filter dlssync-frontend build",


### PR DESCRIPTION
## Resumen
- Prepara DLSSync `v1.6.8` para el cambio ya mergeado de navegación con botones laterales del mouse.
- Alinea metadata de versión en npm, Cargo workspace, Cargo.lock y Tauri.
- Actualiza README, CHANGELOG y docs de release marketing para que el cambio sea visible como release de producto.
- Corrige el hueco del PR #16: el feature era user-facing y necesitaba release/docs/changelog en el mismo tren.

Refs #15
Refs #16

## Mapeo de aceptación
- [x] La versión activa queda en `1.6.8` en `package.json`, `frontend/package.json`, `Cargo.toml`, `Cargo.lock` y `src-tauri/tauri.conf.json`.
- [x] `CHANGELOG.md` incluye sección `1.6.8` con `Added`, `Changed` y `Fixed`.
- [x] `README.md` apunta a `v1.6.8` y al anchor correcto del changelog.
- [x] `docs/index.md` y `docs/release-marketing.md` reflejan la línea pública actual.
- [x] No se incluye el asset local no relacionado `.github/assets/nexus/badge-strip-1300x220.png`.

## Evidencia
- `git diff --check` → limpio.
- `pnpm --filter dlssync-frontend test` → 62 archivos / 519 tests passed / 1 skipped.
- `pnpm --filter dlssync-frontend check` → 0 errors / 0 warnings.
- `pnpm --filter dlssync-frontend build` → build de producción completado en v1.6.8.
- `cargo fmt --all -- --check` → limpio.
- `cargo check --workspace` → workspace compila/checkea en v1.6.8.
- `cargo clippy --workspace --all-targets -- -D warnings` → limpio.

## Impacto release/docs
- SemVer: `1.6.7` → `1.6.8` como release patch de navegación/polish.
- Release notes: sección nueva en changelog, no dump de commits.
- Docs: README + release marketing alineados al release actual.
- GitHub Project: debe quedarse visible en `DLSSync Roadmap`, público y linkeado al repo.

## Riesgo y rollback
- Riesgo bajo: sólo metadata/docs/changelog; no cambia lógica runtime adicional.
- Rollback: revertir este commit restaura `1.6.7` en metadata y docs si se decide no shippear `v1.6.8` todavía.