### PR TITLE
fix(nexus): remove every in-app GitHub/source link from the Nexus build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- In the Nexus build, the in-app "check for updates" and changelog actions open the Nexus Mods page instead of GitHub Releases, so the distributed package never routes users to an auto-updating download.
+- In the Nexus build, every in-app link that pointed at the DLSSync GitHub repository — the source/sponsor/report buttons, the author profile and star links, the support nudge, the apply-failure issue report, and the live star-count request — is hidden, and the "check for updates" and changelog actions open the Nexus Mods page. The distributed package surfaces no link to an auto-updating download or to the source repository, and makes no GitHub network request.
 
 ## [1.6.9] - 2026-06-12
 

--- a/docs/nexus-build.md
+++ b/docs/nexus-build.md
@@ -63,4 +63,15 @@ Use this wording when explaining the release:
 
 > This is a Nexus Mods compliant build. DLSSync's core DLL synchronization remains intact, but application self-update is disabled because Nexus Mods does not allow auto-updating hosted utilities. Users install future DLSSync application versions manually from the Nexus Mods page.
 
-In the Nexus build the in-app "check for updates" and changelog actions open the Nexus Mods page, not GitHub Releases, so the distributed package never points users at an auto-updating download.
+## In-app source links
+
+The Nexus build hides every in-app link to the DLSSync GitHub repository so the package surfaces no path to an auto-updating download or to the source repo. The `showSourceLinks` flag (`frontend/src/lib/distribution.ts`, `false` for the nexus build) gates:
+
+- the About header GitHub, Sponsor, and Report buttons;
+- the About footer GitHub profile link and the "Star on GitHub" support action;
+- the support nudge "Star" action;
+- the apply-failure "Report issue" button (the clipboard "Copy report" stays);
+- the live GitHub star-count request (no network call to the GitHub API);
+- the share action, which targets the Nexus mod page instead of the repo.
+
+The "check for updates" and changelog actions open the Nexus Mods page. Upstream vendor SDK links (NVIDIA, Intel, AMD, Microsoft) and non-GitHub links (Ko-fi, Discord, the project website, the Nexus page) are unaffected. The signed DLL catalog (manifest) repository is still referenced for transparency — it is the audited DLL source Nexus asked to verify, not an application build.

--- a/frontend/src/components/ApplyProgressModal.svelte
+++ b/frontend/src/components/ApplyProgressModal.svelte
@@ -22,6 +22,7 @@
     type ApplyErrorClass,
     type DllRecord,
   } from "../lib/api";
+  import { showSourceLinks } from "../lib/distribution";
   import {
     featureTitle,
     featureFromFamily,
@@ -915,7 +916,7 @@
           {$t("component.applyModal.action.copyReport")}
         </button>
       {/if}
-      {#if failedGroups > 0 && !anyRunning}
+      {#if showSourceLinks && failedGroups > 0 && !anyRunning}
         <button class="aura-pill aura-pill-ghost" onclick={reportIssue} disabled={reportingIssue} title={$t("component.applyModal.action.reportIssueTitle")}>
           {#if reportingIssue}
             <span class="spinner-tiny"></span>

--- a/frontend/src/components/SupportNudge.svelte
+++ b/frontend/src/components/SupportNudge.svelte
@@ -9,6 +9,7 @@
   import X from "@lucide/svelte/icons/x";
   import { get } from "svelte/store";
   import { supportNudgeVisible, dismissNudge, dontShowAgain, shareDlssync } from "../lib/community";
+  import { showSourceLinks } from "../lib/distribution";
   import { EXTERNAL_URLS } from "../lib/ux";
   import { showToast, updateBannerActive } from "../lib/stores";
   import { t, locale, translate } from "../lib/i18n/index";
@@ -73,9 +74,11 @@
       </div>
     </div>
     <div class="actions">
+      {#if showSourceLinks}
       <button class="act is-star" onclick={star} title={$t("component.support.starTitle")}>
         <Star size={15} fill="currentColor" strokeWidth={2} /> {$t("component.support.star")}
       </button>
+      {/if}
       <button class="act is-endorse" onclick={endorse} title={$t("component.support.endorseTitle")}>
         <NexusLogo size={15} /> {$t("component.support.endorse")}
       </button>

--- a/frontend/src/lib/community.ts
+++ b/frontend/src/lib/community.ts
@@ -1,6 +1,7 @@
 import { get, writable } from "svelte/store";
 import { EXTERNAL_URLS } from "./ux";
 import { settings, persistSettings } from "./stores";
+import { isNexusBuild } from "./distribution";
 
 const STAR_CACHE_KEY = "dlssync.starCount.v1";
 const STAR_TTL_MS = 6 * 60 * 60 * 1000;
@@ -54,7 +55,8 @@ export function resetNudgeSession(): void {
 export type ShareResult = "shared" | "copied" | "failed";
 
 export async function shareDlssync(): Promise<ShareResult> {
-  const url = EXTERNAL_URLS.homepage;
+  // The Nexus build shares the Nexus mod page, never the GitHub repo.
+  const url = isNexusBuild ? EXTERNAL_URLS.nexusMod : EXTERNAL_URLS.homepage;
   const message = `${SHARE_TEXT} ${url}`;
   const nav = navigator as Navigator & {
     share?: (data: { title: string; text: string; url: string }) => Promise<void>;
@@ -83,6 +85,8 @@ interface StarCache {
 /** Live GitHub star count for social proof. Cached in localStorage for STAR_TTL_MS
  * (GitHub allows 60 unauthenticated req/h per IP). Returns null on any failure. */
 export async function fetchStarCount(now: number = Date.now()): Promise<number | null> {
+  // The Nexus build never calls the GitHub API.
+  if (isNexusBuild) return null;
   try {
     const raw = localStorage.getItem(STAR_CACHE_KEY);
     if (raw) {

--- a/frontend/src/lib/distribution.ts
+++ b/frontend/src/lib/distribution.ts
@@ -3,3 +3,11 @@ const DISTRIBUTION = import.meta.env.VITE_DLSSYNC_DISTRIBUTION ?? "standard";
 export const isNexusBuild = DISTRIBUTION === "nexus";
 export const appUpdaterEnabled = !isNexusBuild;
 export const distributionLabel = isNexusBuild ? "Nexus Mods" : "Standard";
+
+// In the Nexus build, hide every link that points at the DLSSync GitHub
+// repository (releases, issues, sponsors, the author profile, the star CTA).
+// Nexus Mods does not allow linking to source/auto-updating builds from a
+// hosted mod, so the Nexus package surfaces none of them. Upstream vendor SDK
+// links (NVIDIA/Intel/AMD/Microsoft) and non-GitHub links (Ko-fi, Discord,
+// website, the Nexus page itself) are unaffected.
+export const showSourceLinks = !isNexusBuild;

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -570,7 +570,9 @@
       "updates": {
         "autoUpdate": {
           "title": "Auto-update",
-          "help": "DLSSync polls GitHub Releases every 6 hours. Trigger a manual check below."
+          "help": "DLSSync polls GitHub Releases every 6 hours. Trigger a manual check below.",
+          "titleManual": "App updates",
+          "helpManual": "This {distribution} build does not auto-update. Install future versions manually from the Nexus Mods page."
         },
         "currentVersion": {
           "label": "Current version"
@@ -588,7 +590,7 @@
           "checkFailed": "Update check failed: {error}"
         },
         "manualOnly": "{distribution} build: manual app updates only",
-        "openReleases": "Open releases"
+        "openReleases": "Open Nexus Mods page"
       },
       "toast": {
         "overlayEnabled": "DLSS Debug Overlay enabled",
@@ -727,7 +729,7 @@
         "preparing": "Preparing",
         "checkUpdates": "Check for updates",
         "checking": "Checking",
-        "openReleases": "Open releases"
+        "openReleases": "Open Nexus Mods page"
       },
       "tagline": "SYNC · VERIFY · APPLY",
       "pillar": {
@@ -823,7 +825,7 @@
       "nexus": {
         "kicker": "{distribution} compliant build",
         "title": "Manual app updates for Nexus Mods",
-        "body": "Nexus Mods does not allow applications to auto-update themselves from a hosted mod page. This build keeps DLSSync's DLSS/FSR/XeSS sync core intact, but disables the app self-updater. Install future DLSSync versions manually from Nexus Mods or GitHub Releases."
+        "body": "Nexus Mods does not allow applications to auto-update themselves from a hosted mod page. This build keeps DLSSync's DLSS/FSR/XeSS sync core intact, but disables the app self-updater. Install future DLSSync versions manually from the Nexus Mods page."
       }
     }
   },

--- a/frontend/src/lib/i18n/locales/es.json
+++ b/frontend/src/lib/i18n/locales/es.json
@@ -570,7 +570,9 @@
       "updates": {
         "autoUpdate": {
           "title": "Actualización automática",
-          "help": "DLSSync consulta las versiones de GitHub cada 6 horas. Inicia una comprobación manual abajo."
+          "help": "DLSSync consulta las versiones de GitHub cada 6 horas. Inicia una comprobación manual abajo.",
+          "titleManual": "Actualizaciones de la app",
+          "helpManual": "Este build {distribution} no se auto-actualiza. Instala futuras versiones manualmente desde la página de Nexus Mods."
         },
         "currentVersion": {
           "label": "Versión actual"
@@ -588,7 +590,7 @@
           "checkFailed": "Error al buscar actualizaciones: {error}"
         },
         "manualOnly": "Build {distribution}: actualizaciones manuales de la app",
-        "openReleases": "Abrir releases"
+        "openReleases": "Abrir página de Nexus Mods"
       },
       "toast": {
         "overlayEnabled": "Superposición de depuración DLSS activada",
@@ -727,7 +729,7 @@
         "preparing": "Preparando",
         "checkUpdates": "Buscar actualizaciones",
         "checking": "Buscando",
-        "openReleases": "Abrir releases"
+        "openReleases": "Abrir página de Nexus Mods"
       },
       "tagline": "SINCRONIZAR · VERIFICAR · APLICAR",
       "pillar": {
@@ -823,7 +825,7 @@
       "nexus": {
         "kicker": "Build compatible con {distribution}",
         "title": "Actualizaciones manuales de la app para Nexus Mods",
-        "body": "Nexus Mods no permite que una aplicación se auto-actualice desde una página de mod. Este build mantiene intacto el core de sincronización DLSS/FSR/XeSS de DLSSync, pero desactiva el auto-updater de la app. Instala futuras versiones de DLSSync manualmente desde Nexus Mods o GitHub Releases."
+        "body": "Nexus Mods no permite que una aplicación se auto-actualice desde una página de mod. Este build mantiene intacto el core de sincronización DLSS/FSR/XeSS de DLSSync, pero desactiva el auto-updater de la app. Instala futuras versiones de DLSSync manualmente desde la página de Nexus Mods."
       }
     }
   },

--- a/frontend/src/views/About.svelte
+++ b/frontend/src/views/About.svelte
@@ -24,7 +24,7 @@
   } from "../lib/api";
   import { vendorLabel, vendorAccent } from "../lib/labels";
   import { EXTERNAL_URLS } from "../lib/ux";
-  import { appUpdaterEnabled, distributionLabel } from "../lib/distribution";
+  import { appUpdaterEnabled, distributionLabel, showSourceLinks } from "../lib/distribution";
   import { fetchStarCount, shareDlssync } from "../lib/community";
   import changelogRaw from "../../../CHANGELOG.md?raw";
   import RefreshCw from "@lucide/svelte/icons/refresh-cw";
@@ -132,10 +132,12 @@
       systemInfo = null;
       systemInfoFailed = true;
     }
-    try {
-      starCount = await fetchStarCount();
-    } catch {
-      starCount = null;
+    if (showSourceLinks) {
+      try {
+        starCount = await fetchStarCount();
+      } catch {
+        starCount = null;
+      }
     }
   });
 
@@ -274,6 +276,7 @@
     <p class="view-subtitle">{$t("view.about.subtitle")}</p>
   </div>
   <div class="header-actions">
+    {#if showSourceLinks}
     <button class="btn btn-ghost" onclick={() => openExternal(REPO_URL)}>
       <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .3a12 12 0 0 0-3.79 23.4c.6.11.82-.26.82-.58v-2c-3.34.73-4.04-1.61-4.04-1.61-.55-1.4-1.34-1.77-1.34-1.77-1.1-.75.08-.73.08-.73 1.2.09 1.84 1.24 1.84 1.24 1.07 1.84 2.81 1.31 3.5 1 .1-.78.42-1.31.76-1.61-2.66-.3-5.46-1.33-5.46-5.93 0-1.31.47-2.38 1.24-3.22-.13-.3-.54-1.52.12-3.17 0 0 1-.32 3.3 1.23a11.5 11.5 0 0 1 6 0c2.29-1.55 3.3-1.23 3.3-1.23.66 1.65.25 2.87.12 3.17.77.84 1.24 1.91 1.24 3.22 0 4.61-2.8 5.62-5.47 5.92.43.37.81 1.1.81 2.22v3.29c0 .32.22.7.83.58A12 12 0 0 0 12 .3Z"/></svg>
       GitHub
@@ -282,6 +285,7 @@
       <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.27 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.77-3.4 6.86-8.55 11.53L12 21.35z"/></svg>
       Sponsor
     </button>
+    {/if}
     <button class="btn btn-ghost kofi-btn" onclick={() => openExternal(EXTERNAL_URLS.kofi)} title={$t("view.about.action.kofiTitle")}>
       <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M17 8h1a4 4 0 0 1 0 8h-1"/><path d="M3 8h14v9a4 4 0 0 1-4 4H7a4 4 0 0 1-4-4Z"/><line x1="6" y1="2" x2="6" y2="4"/><line x1="10" y1="2" x2="10" y2="4"/><line x1="14" y1="2" x2="14" y2="4"/></svg>
       Ko-fi
@@ -290,6 +294,7 @@
       <NexusLogo size={15} />
       Nexus
     </button>
+    {#if showSourceLinks}
     <button class="btn btn-ghost" onclick={reportBug} disabled={reporting} title={$t("view.about.action.reportTitle")}>
       {#if reporting}
         <span class="spin"></span>
@@ -299,6 +304,7 @@
         {$t("view.about.action.report")}
       {/if}
     </button>
+    {/if}
     <button class="btn btn-primary" onclick={checkForUpdates} disabled={appUpdaterEnabled && updateChecking}>
       {#if appUpdaterEnabled && updateChecking}
         <span class="spin"></span>
@@ -355,7 +361,7 @@
   </section>
 {/if}
 
-{#if releaseHighlights && (releaseHighlights.summary || releaseHighlights.bullets.length > 0)}
+{#if showSourceLinks && releaseHighlights && (releaseHighlights.summary || releaseHighlights.bullets.length > 0)}
   <section class="whats-new" in:fly={{ y: 6, duration: 240, delay: 40 }}>
     <header class="wn-head">
       <span class="wn-tag">
@@ -589,10 +595,12 @@
       </div>
     </div>
     <div class="author-links">
+      {#if showSourceLinks}
       <button class="author-link" onclick={() => openExternal("https://github.com/xt0n1-t3ch")} title="GitHub @xt0n1-t3ch">
         <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .3a12 12 0 0 0-3.79 23.4c.6.11.82-.26.82-.58v-2c-3.34.73-4.04-1.61-4.04-1.61-.55-1.4-1.34-1.77-1.34-1.77-1.1-.75.08-.73.08-.73 1.2.09 1.84 1.24 1.84 1.24 1.07 1.84 2.81 1.31 3.5 1 .1-.78.42-1.31.76-1.61-2.66-.3-5.46-1.33-5.46-5.93 0-1.31.47-2.38 1.24-3.22-.13-.3-.54-1.52.12-3.17 0 0 1-.32 3.3 1.23a11.5 11.5 0 0 1 6 0c2.29-1.55 3.3-1.23 3.3-1.23.66 1.65.25 2.87.12 3.17.77.84 1.24 1.91 1.24 3.22 0 4.61-2.8 5.62-5.47 5.92.43.37.81 1.1.81 2.22v3.29c0 .32.22.7.83.58A12 12 0 0 0 12 .3Z"/></svg>
         <span class="author-link-text">github.com/xt0n1-t3ch</span>
       </button>
+      {/if}
       <button class="author-link" onclick={() => openExternal("https://discord.com/users/211189703641268224")} title="Discord">
         <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M20.317 4.369A19.79 19.79 0 0 0 16.558 3.2a.074.074 0 0 0-.079.038c-.342.61-.72 1.405-.987 2.027a18.27 18.27 0 0 0-5.484 0 12.65 12.65 0 0 0-1.001-2.027.077.077 0 0 0-.078-.038A19.736 19.736 0 0 0 5.171 4.369a.07.07 0 0 0-.032.027C1.533 9.79.583 14.95 1.05 20.04a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.029.077.077 0 0 0 .084-.027 14.24 14.24 0 0 0 1.226-1.994.075.075 0 0 0-.041-.104 13.1 13.1 0 0 1-1.872-.892.077.077 0 0 1-.008-.128c.126-.094.252-.192.372-.291a.074.074 0 0 1 .078-.011c3.927 1.793 8.18 1.793 12.061 0a.074.074 0 0 1 .079.01c.12.1.246.198.373.292a.077.077 0 0 1-.006.128c-.598.349-1.22.645-1.873.892a.077.077 0 0 0-.041.105c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.84 19.84 0 0 0 6.002-3.03.077.077 0 0 0 .031-.055c.5-5.876-.838-10.998-3.548-15.644a.06.06 0 0 0-.031-.028zM8.02 16.937c-1.182 0-2.157-1.085-2.157-2.418 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.419 0 1.333-.956 2.418-2.157 2.418zm7.974 0c-1.182 0-2.157-1.085-2.157-2.418 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.419 0 1.333-.946 2.418-2.157 2.418z"/></svg>
         <span class="author-link-text">Discord</span>
@@ -611,11 +619,13 @@
     <p class="section-sub">{$t("view.about.support.sub")}</p>
   </header>
   <div class="support-grid">
+    {#if showSourceLinks}
     <button class="support-cta is-star" onclick={() => openExternal(EXTERNAL_URLS.homepage)} title={$t("view.about.support.starTitle")}>
       <Star size={16} fill="currentColor" />
       <span class="support-cta-label">{$t("view.about.support.star")}</span>
       {#if starCount !== null}<span class="support-cta-count mono">{starCount.toLocaleString()}</span>{/if}
     </button>
+    {/if}
     <button class="support-cta is-endorse" onclick={() => openExternal(EXTERNAL_URLS.nexusMod)} title={$t("view.about.support.endorseTitle")}>
       <NexusLogo size={18} />
       <span class="support-cta-label">{$t("view.about.support.endorse")}</span>

--- a/frontend/src/views/Settings.svelte
+++ b/frontend/src/views/Settings.svelte
@@ -702,8 +702,8 @@
     {:else if activeTab === "updates"}
       <section in:fly={{ y: 4, duration: 200 }}>
         <header class="section-head">
-          <h2 class="section-title-h">{$t("view.settings.updates.autoUpdate.title")}</h2>
-          <p class="section-help">{$t("view.settings.updates.autoUpdate.help")}</p>
+          <h2 class="section-title-h">{appUpdaterEnabled ? $t("view.settings.updates.autoUpdate.title") : $t("view.settings.updates.autoUpdate.titleManual")}</h2>
+          <p class="section-help">{appUpdaterEnabled ? $t("view.settings.updates.autoUpdate.help") : $t("view.settings.updates.autoUpdate.helpManual", { distribution: distributionLabel })}</p>
         </header>
         <div class="card">
           <div class="row">


### PR DESCRIPTION
## Summary

Follow-up to #21. Makes the Nexus build surface zero links to the DLSSync GitHub repository and removes the last "GitHub Releases" update wording, so the package fully meets the Nexus Mods "no source/auto-updating-build links" requirement.

## Changes

Centralized behind `showSourceLinks` (`frontend/src/lib/distribution.ts`, `false` for the nexus build). In nexus mode:

- About header GitHub / Sponsor / Report buttons hidden; footer GitHub profile link and "Star on GitHub" support action hidden; What's New section hidden (it renders changelog text that references past releases)
- Support nudge "Star" action hidden; apply-failure "Report issue" button hidden (clipboard "Copy report" kept)
- Live GitHub star-count request skipped (no `api.github.com` call)
- Share targets the Nexus mod page; check-for-updates/changelog open the Nexus mod page; CTA relabeled
- nexus notice + Settings update copy no longer mention "GitHub Releases"

Unchanged: vendor SDK links (NVIDIA/Intel/AMD/Microsoft), Ko-fi, Discord, website, the Nexus page, the signed manifest (DLL source) reference. Standard build unaffected.

## Proof

- `pnpm --filter dlssync-frontend check` -> 350 files, 0 errors, 0 warnings
- fresh `build:nexus` + `rg` over `frontend/dist` -> 0 matches for `plugin-updater|downloadAndInstall|tauri_plugin_updater|plugin:updater|plugin-process`
- Browser render of the nexus build's About page: header shows only Ko-fi / Nexus / "Open Nexus Mods page"; the compliant-build notice reads "manually from the Nexus Mods page"; What's New hidden; Made-by shows only Discord + website; support row shows only Endorse on Nexus + Share. No GitHub/Sponsor/Report/Star/profile links.

Closes #23
Part of #19
