### PR TITLE
fix(security): verify on-disk catalog cache signature on startup load

### DIFF
--- a/crates/dll-catalog/src/lib.rs
+++ b/crates/dll-catalog/src/lib.rs
@@ -603,14 +603,23 @@ fn write_catalog_cache(cache_path: &Path, raw: &[u8], sig: Option<&str>) {
     }
 }
 
+/// Load + parse an on-disk cache after requiring its detached signature to verify.
+pub fn load_verified_cache(cache_path: &Path) -> Option<Catalog> {
+    load_cached_catalog_with(cache_path, true)
+}
+
 /// Load + parse the on-disk cache. When enforcement is on, the cached raw bytes
 /// are re-verified against the sidecar `.sig`; a missing or invalid signature
 /// rejects the cache (the caller then falls back to the embedded manifest). A
 /// legacy re-serialized cache from before sidecar caching has no `.sig`, so it is
 /// correctly rejected under enforcement and accepted only when enforcement is off.
 fn load_cached_catalog(cache_path: &Path) -> Option<Catalog> {
+    load_cached_catalog_with(cache_path, signature_enforced())
+}
+
+fn load_cached_catalog_with(cache_path: &Path, require_signature: bool) -> Option<Catalog> {
     let raw = std::fs::read(cache_path).ok()?;
-    if signature_enforced() {
+    if require_signature {
         let sig = std::fs::read_to_string(cache_sig_path(cache_path)).ok()?;
         verify_manifest_signature(&raw, &sig).ok()?;
     }
@@ -806,6 +815,22 @@ mod tests {
 
     fn test_signing_key() -> ed25519_dalek::SigningKey {
         ed25519_dalek::SigningKey::from_bytes(&[7u8; 32])
+    }
+
+    #[test]
+    fn verified_cache_rejects_sidecar_from_wrong_key() {
+        use ed25519_dalek::Signer;
+        let dir = tempfile::tempdir().unwrap();
+        let cache_path = dir.path().join("manifest.json");
+        let catalog = catalog_with(
+            "dlss",
+            vec![release_with("nvngx_dlss.dll", "1.0.0", 1, "a")],
+        );
+        let raw = serde_json::to_vec(&catalog).unwrap();
+        let sig_hex = hex::encode(test_signing_key().sign(&raw).to_bytes());
+        std::fs::write(&cache_path, raw).unwrap();
+        std::fs::write(cache_sig_path(&cache_path), sig_hex).unwrap();
+        assert!(load_verified_cache(&cache_path).is_none());
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -375,25 +375,32 @@ pub fn run() {
 
             *state.catalog_cache_path.write() = Some(app_paths.catalog_cache.clone());
             if app_paths.catalog_cache.exists() {
-                match std::fs::read(&app_paths.catalog_cache)
-                    .map_err(|e| e.to_string())
-                    .and_then(|bytes| {
-                        serde_json::from_slice::<dll_catalog::Catalog>(&bytes)
-                            .map_err(|e| e.to_string())
-                    }) {
-                    Ok(cat) => {
+                match dll_catalog::load_verified_cache(&app_paths.catalog_cache) {
+                    Some(cat) => {
                         *state.catalog.write() = Some(cat);
                         tracing::info!(
                             path = %app_paths.catalog_cache.display(),
                             "catalog loaded from cache",
                         );
                     }
-                    Err(e) => {
+                    None => {
                         tracing::warn!(
                             path = %app_paths.catalog_cache.display(),
-                            error = %e,
+                            error = "cache missing, invalid, or signature verification failed",
                             "catalog cache unreadable",
                         );
+                        match dll_catalog::embedded_fallback_catalog() {
+                            Ok(cat) => {
+                                *state.catalog.write() = Some(cat);
+                                tracing::info!("catalog loaded from embedded fallback");
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    error = %e,
+                                    "embedded fallback catalog unreadable",
+                                );
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary

Closes #20. At startup the app read the cached catalog directly into `state.catalog` without verifying its Ed25519 signature, so a locally modified `Cache/catalog.json` could influence DLL download destinations before a verified refresh. This routes the startup load through a signature-required loader and falls back to the signed embedded manifest when the cache cannot be verified.

## Changes

- `crates/dll-catalog/src/lib.rs`: add `pub fn load_verified_cache()` that always requires the `.sig` sidecar to verify; `load_cached_catalog` keeps its enforcement-gated behavior for the fetch-with-cache path via a shared helper. New test: a cache whose sidecar is signed with the wrong key is rejected.
- `src-tauri/src/lib.rs`: startup loads through `load_verified_cache()`; on missing/invalid/unsigned cache, falls back to `embedded_fallback_catalog()` instead of trusting unverified bytes.

## Proof

- `cargo test -p dll-catalog` -> 55 passed (incl. `verified_cache_rejects_sidecar_from_wrong_key`)
- `cargo check -p dlssync` and `cargo check -p dlssync --features nexus` -> Finished
- `cargo clippy -p dll-catalog -- -D warnings` -> clean
- `cargo fmt --all -- --check` -> clean

Closes #20
