### PR TITLE
fix(ci): reconcile frozen lockfile config and force LF on text files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,8 @@
+# Normalize all text to LF in the repo and on checkout so cross-platform builds
+# (Windows CI included) stay byte-identical. cargo xtask check-bindings compares
+# generated files byte-for-byte, so a CRLF checkout would otherwise read as stale.
+* text=auto eol=lf
+
 .gitattributes text eol=lf
 CHANGELOG.md text eol=lf
 crates/dll-catalog/fallback/manifest.json text eol=lf

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,5 +3,3 @@ packages:
 
 overrides:
   esbuild: 0.28.1
-allowBuilds:
-  esbuild: set this to true or false


### PR DESCRIPTION
## Summary
Fixes the two CI failures that surfaced when the 1.7.0 release commit first ran through Actions on main.

## Root cause and fix
- `pnpm install --frozen-lockfile` failed with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`. `pnpm-workspace.yaml` carried a stray `allowBuilds: esbuild: set this to true or false` placeholder that pushed the resolved pnpm config out of sync with the lockfile. Removing it reconciles the two; the lockfile content itself is unchanged.
- `cargo xtask check-bindings` reported the generated TypeScript bindings as stale on the Windows runner. It byte-compares `frontend/src/generated/bindings.ts` before and after regeneration, and with no `.gitattributes` rule the file was checked out CRLF while the generator writes LF. `* text=auto eol=lf` forces LF on checkout everywhere so the byte compare matches.

## Proof
- Local: `pnpm install --frozen-lockfile` and `cargo xtask check-bindings` both pass.
- CI re-runs on merge to main.
