### PR TITLE
fix(ci): put pnpm overrides in package.json for pnpm 9

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,5 +19,10 @@
     "@tauri-apps/cli": "^2.0.0",
     "axe-core": "4.10.3"
   },
+  "pnpm": {
+    "overrides": {
+      "esbuild": "0.28.1"
+    }
+  },
   "packageManager": "pnpm@9.0.0"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,2 @@
 packages:
   - frontend
-
-overrides:
-  esbuild: 0.28.1


### PR DESCRIPTION
## Summary
Second CI fix for the 1.7.0 release: the Frontend job still failed at `pnpm install --frozen-lockfile`.

## Root cause and fix
The esbuild override lived in `pnpm-workspace.yaml`, a location only pnpm 10+ reads. The repo pins `pnpm@9.0.0` and CI runs it; pnpm 9 reads overrides from `package.json` `pnpm.overrides`. pnpm 9 therefore saw no current override while the lockfile recorded `esbuild: 0.28.1`, tripping `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`. Moving the override to `package.json` aligns the config pnpm 9 reads with the lockfile.

## Proof
Reproduced and fixed with `CI=true` on pnpm 9.0.0: `install --frozen-lockfile`, check, lint, build and test all pass. The Rust job's check-bindings already passes on main after the `.gitattributes` LF fix (#28). Lockfile unchanged.
